### PR TITLE
Potential fix for code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -215,8 +215,6 @@ async function _refreshCognitoTokens() {
 function _storeCognitoTokens(result) {
   _idToken = result.IdToken;
   if (result.RefreshToken) _refreshToken = result.RefreshToken;
-  localStorage.setItem('ra_id_token', _idToken);
-  if (_refreshToken) localStorage.setItem('ra_refresh_token', _refreshToken);
   try {
     const payload = JSON.parse(atob(_idToken.split('.')[1]));
     _userEmail = payload.email || payload['cognito:username'] || '';


### PR DESCRIPTION
Potential fix for [https://github.com/hoyla/RA-SummerExhibition-ListOfWorks/security/code-scanning/1](https://github.com/hoyla/RA-SummerExhibition-ListOfWorks/security/code-scanning/1)

General fix: avoid storing sensitive authentication tokens in cleartext persistent storage on the client. Prefer in‑memory storage for tokens, or, if the wider system allows, move to secure, HttpOnly, same-site cookies set by the server. Within this snippet, we can remove the `localStorage` writes so that tokens are never written to persistent storage by this code. This reduces exposure to token theft via XSS or local disk compromise, while keeping the rest of the login flow unchanged.

Best concrete fix here: update `_storeCognitoTokens` (lines 215–225) so that it no longer stores `_idToken` and `_refreshToken` into `localStorage`. The function already assigns them to in‑memory variables (`_idToken`, `_refreshToken`, `_userEmail`, `_tokenExpiry`), which are used by `_ensureFreshToken` and other logic; keeping that behavior is enough for runtime use. We simply remove the `localStorage.setItem` calls. Because we are not told about any other code, we must not add new storage mechanisms or imports; eliminating the cleartext write is the safest change that does not alter the authentication semantics during a single-page session (tokens still exist and are used in memory).

Concretely:
- In `frontend/app.js`, modify `_storeCognitoTokens`:
  - Delete line 218: `localStorage.setItem('ra_id_token', _idToken);`
  - Delete line 219: `if (_refreshToken) localStorage.setItem('ra_refresh_token', _refreshToken);`
- Leave everything else (including how `_idToken`, `_refreshToken`, `_userEmail`, `_tokenExpiry` are set and used) unchanged.

No new methods or imports are required for this minimal fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
