### PR TITLE
Replace python-jose with PyJWT to resolve ecdsa CVE

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -32,7 +32,8 @@ from functools import lru_cache
 from typing import Optional
 
 from fastapi import Header, HTTPException, Request, status, Depends
-from jose import JWTError, jwt
+import jwt
+from jwt.exceptions import InvalidTokenError as JWTError
 
 from backend.app.config import (
     API_KEY,
@@ -98,12 +99,12 @@ def _decode_cognito_token(token: str) -> dict:
         )
 
     kid = unverified_header.get("kid")
-    key = None
+    jwk_dict = None
     for k in jwks.get("keys", []):
         if k["kid"] == kid:
-            key = k
+            jwk_dict = k
             break
-    if key is None:
+    if jwk_dict is None:
         # Force JWKS refresh in case keys were rotated
         _get_jwks.cache_clear()
         try:
@@ -112,13 +113,16 @@ def _decode_cognito_token(token: str) -> dict:
             pass
         for k in jwks.get("keys", []):
             if k["kid"] == kid:
-                key = k
+                jwk_dict = k
                 break
-    if key is None:
+    if jwk_dict is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token signing key not found",
         )
+
+    # PyJWT requires a key object rather than a raw JWK dict
+    key = jwt.algorithms.RSAAlgorithm.from_jwk(jwk_dict)
 
     issuer = (
         f"https://cognito-idp.{COGNITO_REGION}.amazonaws.com/" f"{COGNITO_USER_POOL_ID}"

--- a/docs/architecture_v1.md
+++ b/docs/architecture_v1.md
@@ -788,7 +788,7 @@ on environment configuration:
 
 - JWKS fetched once per process from the Cognito well-known endpoint and cached.
 - Token signature, expiry, audience (`aud`), and issuer (`iss`) are verified
-  using `python-jose`.
+  using `PyJWT`.
 - User email extracted from the `email` claim.
 - Role derived from Cognito groups mapped to the `Role` IntEnum
   (admin=3 > editor=2 > viewer=1); highest-precedence group wins.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,7 +239,7 @@
 
 - **Amazon Cognito** user pool replacing single shared API key
 - Three-mode auth: Cognito JWT → API key (legacy) → no auth (local dev)
-- JWT validation via `python-jose` (signature, expiry, audience, issuer)
+- JWT validation via `PyJWT` (signature, expiry, audience, issuer)
 - Cognito groups mapped to application roles (admin > editor > viewer)
 - `ContextVar`-based request-scoped user context
 - Audit log `user_email` column auto-populated from request context

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ openpyxl==3.1.5
 aiofiles==25.1.0
 boto3>=1.35.0
 python-dotenv==1.2.1
-python-jose[cryptography]==3.5.0
+PyJWT[crypto]==2.10.1
 email-validator>=2.0


### PR DESCRIPTION
- Swap python-jose[cryptography]==3.5.0 for PyJWT[crypto]==2.10.1
- Update auth.py imports and JWK handling (PyJWT requires key object via RSAAlgorithm.from_jwk)
- Removes transitive ecdsa dependency (Minerva timing attack, no upstream fix)
- Update docs references
- All 818 tests pass, Docker container verified