### PR TITLE
CI: bump checkout@v5 and setup-python@v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build Docker image
         run: docker compose build --build-arg BUILD_COMMIT=${{ github.sha }} app
@@ -136,7 +136,7 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
GitHub Actions is forcing the Node 20 → 24 runtime cutover (Node 20 actions
forced to Node 24 from June 2026, removed Sept 2026). The CI run on #58 flagged
`actions/checkout@v4` and `actions/setup-python@v5` as Node-20 actions.

This bumps just those two to their Node-24 majors:

- `actions/checkout@v4` → `@v5` (×3)
- `actions/setup-python@v5` → `@v6`

Routine runtime bumps — no behaviour change for our usage (default checkout +
`python-version: 3.12`). Other pins (`upload/download-artifact`, the AWS/ECR/ECS
actions) weren't flagged and are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)