### PR TITLE
Flag title-case preservations for false-positive review

### DIFF
--- a/backend/app/services/excel_importer.py
+++ b/backend/app/services/excel_importer.py
@@ -215,7 +215,9 @@ def import_excel(
 
         # Collect and store work-level validation warnings
         for warning_type, message in collect_work_warnings(
-            work, edition_suppress_max=edition_suppress_max
+            work,
+            edition_suppress_max=edition_suppress_max,
+            title_case_exceptions=title_case_exceptions,
         ):
             db.add(
                 ValidationWarning(
@@ -440,7 +442,9 @@ def reimport_excel(
 
         # Work-level validation warnings
         for warning_type, message in collect_work_warnings(
-            work, edition_suppress_max=edition_suppress_max
+            work,
+            edition_suppress_max=edition_suppress_max,
+            title_case_exceptions=title_case_exceptions,
         ):
             db.add(
                 ValidationWarning(

--- a/backend/app/services/normalisation_service.py
+++ b/backend/app/services/normalisation_service.py
@@ -208,6 +208,53 @@ def _looks_roman(core: str) -> bool:
     )
 
 
+def _title_token_reason(word: str, canon: dict) -> Tuple[str, Optional[str]]:
+    """Classify a single word for title-casing.
+
+    Returns ``(core, reason)`` where ``core`` is the word stripped of leading/
+    trailing punctuation and ``reason`` is ``"exception"`` (matched the curated
+    exceptions list), ``"roman_numeral"`` (matched the Roman pattern), or
+    ``None`` (no rule applies — let titlecase decide). ``canon`` maps an
+    upper-cased exception to its emitted form.
+
+    Single source of truth shared by :func:`to_title_case` (which acts on the
+    result) and :func:`title_case_preserved_tokens` (which reports it), so the
+    two can never drift.
+    """
+    core = re.sub(r"^[^0-9A-Za-z]+|[^0-9A-Za-z]+$", "", word)
+    if not core:
+        return "", None
+    if core.upper() in canon:
+        return core, "exception"
+    if _looks_roman(core):
+        return core, "roman_numeral"
+    return core, None
+
+
+def title_case_preserved_tokens(
+    text, exceptions: Optional[List[str]] = None
+) -> List[Tuple[str, str]]:
+    """Tokens that :func:`to_title_case` keeps uppercase, as ``(token, reason)``.
+
+    ``reason`` is ``"exception"`` or ``"roman_numeral"``. Order-preserving and
+    de-duplicated within the string. Used to flag potential false positives
+    (a real word matching the Roman pattern, or a stray exception hit like the
+    article "la" matching an "LA" exception) without re-implementing the rule.
+    """
+    if not text:
+        return []
+    canon = {e.upper(): e for e in (exceptions or []) if e}
+    out: List[Tuple[str, str]] = []
+    seen: Set[str] = set()
+    for word in str(text).split():
+        core, reason = _title_token_reason(word, canon)
+        if reason and core.upper() not in seen:
+            seen.add(core.upper())
+            display = canon[core.upper()] if reason == "exception" else core.upper()
+            out.append((display, reason))
+    return out
+
+
 def to_title_case(text, exceptions: Optional[List[str]] = None):
     """Best-effort Title Case for a display string.
 
@@ -230,12 +277,10 @@ def to_title_case(text, exceptions: Optional[List[str]] = None):
     canon = {e.upper(): e for e in (exceptions or []) if e}
 
     def _callback(word, **kwargs):
-        core = re.sub(r"^[^0-9A-Za-z]+|[^0-9A-Za-z]+$", "", word)
-        if not core:
-            return None
-        if core.upper() in canon:
+        core, reason = _title_token_reason(word, canon)
+        if reason == "exception":
             return word.replace(core, canon[core.upper()])
-        if _looks_roman(core):
+        if reason == "roman_numeral":
             return word.replace(core, core.upper())
         return None  # let titlecase decide
 
@@ -310,11 +355,14 @@ def normalise_work(
 
 
 def collect_work_warnings(
-    work, edition_suppress_max: int = DEFAULT_EDITION_SUPPRESS_MAX
+    work,
+    edition_suppress_max: int = DEFAULT_EDITION_SUPPRESS_MAX,
+    title_case_exceptions: Optional[List[str]] = None,
 ) -> List[Tuple[str, str]]:
     """
     Inspect a normalised Work and return a list of (warning_type, message) tuples.
-    Must be called after normalise_work() with the *same* edition_suppress_max.
+    Must be called after normalise_work() with the *same* edition_suppress_max
+    and title_case_exceptions.
 
     Warning types:
       whitespace_trimmed     – leading/trailing whitespace removed from fields
@@ -328,6 +376,10 @@ def collect_work_warnings(
       edition_suppressed_no_price – HIGH: a suppressed edition was the work's only
                                 price; its value should be restored via an override
       non_ascii_characters    – normalised fields contain chars outside ASCII-128
+      title_case_roman        – title-casing kept a token uppercase as a Roman
+                                numeral (review: it might be a real word)
+      title_case_exception    – title-casing kept a token uppercase via the
+                                exceptions list (review for false positives)
     """
     warnings: List[Tuple[str, str]] = []
 
@@ -447,5 +499,37 @@ def collect_work_warnings(
                 + "; ".join(non_ascii_hits),
             )
         )
+
+    # Title-case preservations — tokens the title-casing rule kept uppercase in
+    # the derived title_cased field. Surfaced (split by reason) so staff can spot
+    # false positives: a real word that matched the Roman-numeral pattern, or a
+    # stray exceptions-list hit such as the article "la" matching an "LA" entry.
+    if getattr(work, "title", None):
+        tc_exceptions = (
+            title_case_exceptions
+            if title_case_exceptions is not None
+            else DEFAULT_TITLE_CASE_EXCEPTIONS
+        )
+        preserved = title_case_preserved_tokens(work.title, tc_exceptions)
+        roman = [t for t, r in preserved if r == "roman_numeral"]
+        exc = [t for t, r in preserved if r == "exception"]
+        if roman:
+            warnings.append(
+                (
+                    "title_case_roman",
+                    "Title case kept as a Roman numeral: "
+                    + ", ".join(roman)
+                    + " — review in case it is a word.",
+                )
+            )
+        if exc:
+            warnings.append(
+                (
+                    "title_case_exception",
+                    "Title case kept uppercase via the exceptions list: "
+                    + ", ".join(exc)
+                    + " — review for false positives.",
+                )
+            )
 
     return warnings

--- a/docs/architecture_v1.md
+++ b/docs/architecture_v1.md
@@ -136,6 +136,8 @@ issue is suspected.
 | `edition_anomaly`             | Raw edition present but could not be parsed                    |
 | `edition_suppressed_no_price` | **High:** a suppressed edition was the work's only price — restore it via an override |
 | `non_ascii_characters`        | Normalised fields contain chars outside ASCII-128              |
+| `title_case_roman`            | Title-casing kept a token uppercase as a Roman numeral (might be a real word) |
+| `title_case_exception`        | Title-casing kept a token uppercase via the exceptions list (possible false positive, e.g. `LA` for "la") |
 | `duplicate_filename`          | A previous import with the same filename exists                |
 | `empty_spreadsheet`           | Column headers present but no data rows                        |
 | `missing_column`              | An optional column is absent from the spreadsheet              |
@@ -293,6 +295,13 @@ that keeps the exceptions list verbatim and uppercases multi-letter Roman
 numerals (`VIII`). It's lossy for all-caps input by nature, so `title_cased` is a
 derived field corrected per work via `title_cased_override` — not an export-time
 transform. The LOW keeps source caps; the LPG uses `title_cased`.
+
+Every token the callback keeps uppercase is flagged at import (one warning per
+work, split by reason: `title_case_roman` vs `title_case_exception`) so staff can
+review false positives — a real word matching the Roman pattern, or a stray
+exceptions hit such as the article "la" matching an `LA` entry. The detector
+(`title_case_preserved_tokens`) shares its classification with the casing
+callback, so the two cannot drift.
 
 ### Artists Index normalisation
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3896,6 +3896,8 @@ const _LOW_WARNING_LABELS = {
   unrecognised_price:   'Unrecognised price',
   edition_anomaly:      'Edition anomaly',
   non_ascii_characters: 'Non-ASCII chars',
+  title_case_roman:     'Title-case Roman',
+  title_case_exception: 'Title-case exception',
   duplicate_filename:   'Duplicate filename',
   missing_column:       'Missing column',
   empty_spreadsheet:    'Empty spreadsheet',

--- a/tests/test_title_case.py
+++ b/tests/test_title_case.py
@@ -12,6 +12,7 @@ import pytest
 from backend.app.services.normalisation_service import (
     DEFAULT_TITLE_CASE_EXCEPTIONS,
     normalise_work,
+    title_case_preserved_tokens,
     to_title_case,
 )
 from backend.app.services.override_service import resolve_effective_work
@@ -59,6 +60,45 @@ def test_intentional_mixed_case_preserved():
 def test_empty_and_none_pass_through():
     assert to_title_case("") == ""
     assert to_title_case(None) is None
+
+
+# ---------------------------------------------------------------------------
+# title_case_preserved_tokens (the false-positive detector)
+# ---------------------------------------------------------------------------
+
+
+def test_preserved_tokens_classifies_roman():
+    assert title_case_preserved_tokens("DIALOGUE II") == [("II", "roman_numeral")]
+
+
+def test_preserved_tokens_classifies_exception():
+    out = title_case_preserved_tokens("NYC SKYLINE", ["NYC"])
+    assert out == [("NYC", "exception")]
+
+
+def test_preserved_tokens_emits_canonical_exception_casing():
+    # The emitted token uses the exception's stored form, not the input's.
+    out = title_case_preserved_tokens("THE MoMA SHOW", ["MoMA"])
+    assert out == [("MoMA", "exception")]
+
+
+def test_preserved_tokens_dedupes_within_title():
+    assert title_case_preserved_tokens("WAVE II AND WAVE II") == [
+        ("II", "roman_numeral")
+    ]
+
+
+def test_preserved_tokens_empty_for_clean_title():
+    assert title_case_preserved_tokens("THE POSSIBILITY OF AN ISLAND") == []
+
+
+def test_preserved_tokens_skips_roman_denylist():
+    assert title_case_preserved_tokens("THE MIX") == []
+
+
+def test_preserved_tokens_none_and_empty():
+    assert title_case_preserved_tokens("") == []
+    assert title_case_preserved_tokens(None) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validation_warnings.py
+++ b/tests/test_validation_warnings.py
@@ -231,3 +231,48 @@ def test_no_whitespace_trimmed_when_value_actually_changed():
     work = make_work(raw_title="Old Title", title="New Title")
     types = [w[0] for w in collect_work_warnings(work)]
     assert "whitespace_trimmed" not in types
+
+
+# ---------------------------------------------------------------------------
+# title_case_roman / title_case_exception
+# ---------------------------------------------------------------------------
+
+
+def test_warns_title_case_roman_for_trailing_numeral():
+    work = make_work(title="DIALOGUE II")
+    msgs = {t: m for t, m in collect_work_warnings(work)}
+    assert "title_case_roman" in msgs
+    assert "II" in msgs["title_case_roman"]
+    assert "title_case_exception" not in msgs
+
+
+def test_warns_title_case_exception_for_curated_token():
+    # "USA" is in the shipped default exceptions list.
+    work = make_work(title="PORTRAIT OF THE USA")
+    msgs = {t: m for t, m in collect_work_warnings(work)}
+    assert "title_case_exception" in msgs
+    assert "USA" in msgs["title_case_exception"]
+    assert "title_case_roman" not in msgs
+
+
+def test_title_case_exception_honours_custom_exceptions():
+    # With a custom list that lacks "USA", no exception warning fires.
+    work = make_work(title="PORTRAIT OF THE USA")
+    types = [
+        t for t, _ in collect_work_warnings(work, title_case_exceptions=["RA"])
+    ]
+    assert "title_case_exception" not in types
+
+
+def test_no_title_case_warning_for_clean_title():
+    work = make_work(title="THE POSSIBILITY OF AN ISLAND")
+    types = [t for t, _ in collect_work_warnings(work)]
+    assert "title_case_roman" not in types
+    assert "title_case_exception" not in types
+
+
+def test_roman_denylist_word_does_not_warn():
+    # "MIX" matches the Roman pattern but is denylisted as a real word.
+    work = make_work(title="THE MIX")
+    types = [t for t, _ in collect_work_warnings(work)]
+    assert "title_case_roman" not in types


### PR DESCRIPTION
## What

When title-casing keeps a token uppercase, flag it at import so staff can spot false positives — symmetric to the existing normalisation flags. Two **independently filterable** warning types:

- **`title_case_roman`** — token matched the Roman-numeral pattern (might be a real word). *55 in the current import.*
- **`title_case_exception`** — token matched the exceptions list (possible false positive). *9 in the current import — including the `LA`-for-"la" mis-casings.*

Each surfaces in **both** places automatically: a filterable chip + drill-down in the **Flagged Issues** tool, and a per-work badge in the **Flags column** (yellow review tier). The message names the offending token(s) and the reason.

## Why two types

Real data showed the split matters: the Roman matches are mostly legit (`DIALOGUE II`, `WAVE II`), but the exception matches are mostly **wrong** — the default `LA` exception (Los Angeles) was catching the French/Spanish article *la* in 7 of 9 cases (`LA MAMA CON DAVID`, `CASA LA HUELLA`…). Separate chips let staff isolate the exception hits in one click.

## Implementation

- New `title_case_preserved_tokens(text, exceptions)` shares its classifier (`_title_token_reason`) with the `to_title_case` callback, so detection and casing **cannot drift**.
- `collect_work_warnings` gained a `title_case_exceptions` param, threaded from both import paths. It reads the **in-effect** exceptions list (the saved production config post-deploy) — **no config is mutated**, shipped defaults left untouched.
- Frontend: two labels added to the existing warning-rendering path (no new rendering code). 
- Docs: warning-types table + title-casing prose updated in `docs/architecture_v1.md`.

## Verification

- Reimported the real spreadsheet in local dev: Flagged Issues 1160 → **1224 (+64)**, new chips "Title-case Roman: 55" / "Title-case exception: 9"; Flags column shows "Title-case exception" on cat. 161 "LA MAMA CON DAVID". Counts match the offline analysis exactly.
- Tests: added detector unit tests + warning tests; full suite **913 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)