### PR TITLE
Escape <, >, \ in InDesign Tagged Text exports

### DIFF
--- a/backend/app/services/export_renderer.py
+++ b/backend/app/services/export_renderer.py
@@ -267,6 +267,30 @@ def escape_for_mac_roman(text: str) -> str:
     return "".join(out)
 
 
+def escape_tagged_text_chars(text: str) -> str:
+    """
+    Escape the three InDesign Tagged Text metacharacters in user-supplied
+    content: ``\\`` → ``\\\\``, ``<`` → ``\\<``, ``>`` → ``\\>``.
+
+    Without this, a literal ``>`` in a work title (e.g.
+    ``ENTANGLEMENT (200) INTERACTION > INTRA-ACTION``) reaches InDesign as
+    a stray closing-tag bracket and the whole file is rejected:
+    "A closing tag symbol > was found without the corresponding opening tag".
+    The same applies to ``<``; ``\\`` would silently absorb the following
+    character on import.
+
+    Backslash MUST be escaped first or a literal backslash followed by
+    ``<``/``>`` would be double-escaped on the second pass.
+
+    The parser inverts these escapes (see
+    ``backend/app/services/low_tag_parser.py``), so escaped exports
+    round-trip cleanly through reconcile.
+    """
+    if not text:
+        return text
+    return text.replace("\\", "\\\\").replace("<", "\\<").replace(">", "\\>")
+
+
 # Opening punctuation that must not be left stranded at the end of a line.
 _OPEN_PUNCT = set("'\"\u2018\u201c([")
 # Closing punctuation that must not appear at the start of a line.
@@ -425,10 +449,20 @@ def _sep(name: str, entry_style: str = "") -> str:
 
 
 def _cs(style: str, text: str) -> str:
-    """Wrap text in an InDesign character style tag, or return plain text."""
-    if not style or not text:
+    """Wrap text in an InDesign character style tag, or return plain text.
+
+    The text is run through ``escape_tagged_text_chars`` so literal ``<``,
+    ``>``, and ``\\`` characters in field values can't collide with the
+    Tagged Text grammar. This is the single chokepoint for inline render
+    paths; the wrapped-mode and section-heading paths escape separately
+    because they bypass this helper to assemble custom styled blocks.
+    """
+    if not text:
         return text
-    return f"<CharStyle:{style}>{text}<CharStyle:>"
+    escaped = escape_tagged_text_chars(text)
+    if not style:
+        return escaped
+    return f"<CharStyle:{style}>{escaped}<CharStyle:>"
 
 
 def _fmt_price(amount, config: "ExportConfig") -> str:
@@ -561,9 +595,8 @@ def render_import_as_tagged_text(
     for sec_idx, section in enumerate(sections):
         # A blank section_style suppresses the heading (LPG per-room files have none).
         if config.section_style:
-            lines.append(
-                f"<ParaStyle:{config.section_style}>{section['section_name']}"
-            )
+            heading = escape_tagged_text_chars(section["section_name"] or "")
+            lines.append(f"<ParaStyle:{config.section_style}>{heading}")
             lines.append("\r")
 
         for w in section["works"]:
@@ -647,8 +680,13 @@ def render_import_as_tagged_text(
                         entry += _sep(comp.separator_after, config.entry_style)
                         entry += nc_val  # NC inserted inline (empty string if no NC)
 
-                        # Remaining lines of TC, all in one reopened char style block
-                        rest = "\n".join(wrapped[1:])
+                        # Remaining lines of TC, all in one reopened char style
+                        # block. Escape per-line so the wrap count math (which
+                        # ran on the unescaped raw text) isn't thrown off by
+                        # inflated escape sequences.
+                        rest = "\n".join(
+                            escape_tagged_text_chars(line) for line in wrapped[1:]
+                        )
                         if style:
                             entry += f"<CharStyle:{style}>\n{rest}<CharStyle:>"
                         else:
@@ -661,8 +699,12 @@ def render_import_as_tagged_text(
                             elif not nc.omit_sep_when_empty:
                                 entry += _sep(nc.separator_after, config.entry_style)
                     else:
-                        # Multi-line, normal position: join with soft returns
-                        full = "\n".join(wrapped)
+                        # Multi-line, normal position: join with soft returns.
+                        # Escape per-line — see end_of_first_line branch above
+                        # for the wrap-length-vs-escape rationale.
+                        full = "\n".join(
+                            escape_tagged_text_chars(line) for line in wrapped
+                        )
                         if style:
                             entry += f"<CharStyle:{style}>{full}<CharStyle:>"
                         else:

--- a/backend/app/services/index_renderer.py
+++ b/backend/app/services/index_renderer.py
@@ -19,6 +19,7 @@ from backend.app.services.index_override_service import (
     lookup_known_artist,
 )
 from backend.app.services.index_importer import is_ra_member
+from backend.app.services.export_renderer import escape_tagged_text_chars
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +189,13 @@ def collect_index_entries(db: Session, import_id: UUID) -> List[ArtistExportEntr
 
 
 def _cstyle(style: str, text: str) -> str:
-    """Wrap text in an InDesign character style tag."""
+    """Wrap text in an InDesign character style tag.
+
+    ``text`` is assumed to already be Tagged-Text safe — see
+    ``_escape_entry_fields``, which pre-escapes every user-supplied field
+    on the entry before the layout helpers run. Don't escape again here:
+    escape isn't idempotent (``<`` → ``\\<`` → ``\\\\\\<``).
+    """
     if not style:
         return text
     return f"<cstyle:{style}>{text}<cstyle:>"
@@ -389,12 +396,57 @@ def _letter_key(entry: ArtistExportEntry) -> str:
     return "#" if ch.isdigit() else ch
 
 
+_ESCAPED_TEXT_FIELDS = (
+    "title",
+    "first_name",
+    "last_name",
+    "quals",
+    "company",
+    "courtesy",
+    "artist2_first_name",
+    "artist2_last_name",
+    "artist2_quals",
+    "artist3_first_name",
+    "artist3_last_name",
+    "artist3_quals",
+)
+
+
+def _escape_entry_fields(entry: ArtistExportEntry) -> ArtistExportEntry:
+    """Return a copy of ``entry`` with every user-supplied text field
+    Tagged-Text-escaped.
+
+    Done once at the top of ``render_index_tagged_text`` rather than at each
+    layout helper because the helpers concatenate raw text in many places
+    (``surname + ", "``, ``first_name + " "``, courtesy, company name…).
+    Escaping at the source means no future raw-concat addition can leak a
+    literal ``<``/``>``/``\\`` into the tagged output.
+
+    ``sort_key`` is deliberately *not* escaped: ``_letter_key`` takes its
+    first character, and escaping would turn a (vanishingly unlikely) leading
+    ``<`` / ``>`` / ``\\`` into a backslash and break letter grouping.
+    """
+    from dataclasses import replace
+
+    updates = {}
+    for fld in _ESCAPED_TEXT_FIELDS:
+        value = getattr(entry, fld, None)
+        if value:
+            updates[fld] = escape_tagged_text_chars(value)
+    return replace(entry, **updates) if updates else entry
+
+
 def render_index_tagged_text(
     entries: List[ArtistExportEntry],
     cfg: IndexExportConfig = DEFAULT_INDEX_CONFIG,
 ) -> str:
     """Render a list of ArtistExportEntry objects as InDesign Tagged Text."""
     lines: List[str] = ["<ASCII-MAC>"]
+
+    # Pre-escape every user-supplied field on each entry once, so the
+    # downstream layout helpers can splice text into output without
+    # worrying about Tagged Text metacharacters.
+    entries = [_escape_entry_fields(e) for e in entries]
 
     current_letter: Optional[str] = None
     for entry in entries:

--- a/backend/app/services/low_tag_parser.py
+++ b/backend/app/services/low_tag_parser.py
@@ -52,10 +52,13 @@ _SPAN_RE = re.compile(
 )
 _INDESIGN_HINT = re.compile(r"<(?:pstyle|cstyle):")
 _HEX_RE = re.compile(r"<0x([0-9A-Fa-f]+)>")
-_TAG_RE = re.compile(r"<[^>]*>")
 # InDesign escapes special characters with a backslash, in both content and
-# style names (e.g. "Work Number\/Name", "\<", "\\").
+# style names (e.g. "Work Number\/Name", "\<", "\\"). Used only for style-name
+# unescape; content is decoded by ``_decode_content`` which handles backslash
+# escapes and inline-tag stripping together (the two cannot be applied as
+# separate regex passes — see ``_decode_content``'s docstring).
 _BACKSLASH_RE = re.compile(r"\\(.)", re.DOTALL)
+_HEX_ONLY_RE = re.compile(r"^0x([0-9A-Fa-f]+)$")
 # Control characters InDesign embeds (soft returns, \x08/\x03 around headings).
 _CONTROL_RE = re.compile(r"[\x00-\x1f]")
 # A catalogue-number range in gallery titles, e.g. "works 200-286" or
@@ -87,43 +90,100 @@ class ParsedEntry:
     paragraph_index: int
 
 
+def _decode_content(value: str) -> str:
+    """Decode the body of a styled span (or a section-heading paragraph).
+
+    Walks the string left-to-right and resolves the three things that can
+    appear in tagged-text content, in one pass:
+
+    - ``\\X`` is a backslash-escaped literal — emits ``X`` verbatim. Covers
+      the renderer's ``\\<`` / ``\\>`` / ``\\\\`` escapes (without which a
+      title like ``A > B`` breaks InDesign import).
+    - ``<0x####>`` is a numeric Unicode escape — emits the character.
+      Forced line breaks come through as ``<0x000A>`` → ``\\n`` and are
+      stripped later by the caller's control-char pass.
+    - Any other ``<…>`` is an inline formatting tag InDesign may emit inside
+      a styled run (``<ccase:upper>``, ``<cs:…>``, kerning…) — discarded.
+
+    The single pass is load-bearing. A regex sequence "unescape backslashes,
+    then strip tags" would turn ``\\<x\\>`` into ``<x>`` and then delete it.
+    "Strip tags, then unescape backslashes" lets the tag regex greedily
+    consume ``<x\\>`` because the backslash doesn't break the ``[^>]*``
+    match. Neither order is correct; the walker treats ``\\<`` as a literal
+    before considering ``<`` as a tag opener.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(value)
+    while i < n:
+        ch = value[i]
+        if ch == "\\" and i + 1 < n:
+            out.append(value[i + 1])
+            i += 2
+            continue
+        if ch == "<":
+            j = value.find(">", i + 1)
+            if j < 0:
+                # Unterminated angle bracket — keep as literal so downstream
+                # comparison shows it rather than truncating the field.
+                out.append(ch)
+                i += 1
+                continue
+            tag_body = value[i + 1 : j]
+            hex_match = _HEX_ONLY_RE.match(tag_body)
+            if hex_match:
+                out.append(chr(int(hex_match.group(1), 16)))
+            # else: a foreign inline tag — drop it entirely.
+            i = j + 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _decode(s: str) -> str:
-    """Undo InDesign escaping: backslash escapes then ``<0x####>`` numeric
-    escapes (the latter incl. ``<0x000A>`` forced line breaks → ``\\n``)."""
-    s = _BACKSLASH_RE.sub(r"\1", s)
-    return _HEX_RE.sub(lambda m: chr(int(m.group(1), 16)), s)
+    """Decode a paragraph body for non-clean uses (section heading prep)."""
+    return _decode_content(s)
+
+
+def _post_decode(value: str) -> str:
+    """Final cleanup applied AFTER ``_decode_content`` has run: strip control
+    characters (soft returns arrive as ``<0x000A>``→``\\n`` and are removed
+    here — the breaking space was kept on the previous line by the renderer,
+    so this inverts the wrap), and NFC-normalise so composed/decomposed forms
+    compare equal in the diff."""
+    return unicodedata.normalize("NFC", _CONTROL_RE.sub("", value))
 
 
 def _clean(value: str) -> str:
-    """Recover a field value from a character-style span.
+    """Recover a field value from a raw (not-yet-decoded) span body.
 
-    Order matters: decode ``<0x####>`` escapes first (so ``£`` etc. survive),
-    then strip inline formatting tags InDesign leaves *inside* a styled run
-    (``<ccase:…>``, ``<cs:…>``, kerning, …), then unescape content backslashes,
-    then drop control characters (soft returns become ``<0x000A>``→newline and
-    are removed here — the breaking space is kept on the previous line, so this
-    inverts the renderer's wrapping).
+    Full pipeline: decode escapes/strip inline tags, then post-decode cleanup.
+    NOT idempotent — call this on each raw value exactly once.
     """
-    value = _HEX_RE.sub(lambda m: chr(int(m.group(1), 16)), value)
-    value = _TAG_RE.sub("", value)
-    value = _BACKSLASH_RE.sub(r"\1", value)
-    value = _CONTROL_RE.sub("", value)
-    return unicodedata.normalize("NFC", value)
+    return _post_decode(_decode_content(value))
 
 
 def _unescape_name(name: str) -> str:
-    """Style names are backslash-escaped by InDesign (e.g. ``Work Number\\/Name``)."""
+    """Style names are backslash-escaped by InDesign (e.g. ``Work Number\\/Name``).
+
+    Style names never contain numeric escapes or inline tags, so the simple
+    backslash unescape is sufficient — and we deliberately don't use
+    ``_decode_content`` here because we want a literal ``<`` inside a style
+    name (vanishingly unlikely, but possible) to survive."""
     return _BACKSLASH_RE.sub(r"\1", name)
 
 
 def _strip_inline(value: str) -> str:
-    """Decode ``<0x####>`` escapes, then remove inline formatting tags InDesign
-    emits *inside* a styled run (local leading ``<cl:…>``, ``<ccase:…>``, kerning,
-    …). Applied to a span value *before* splitting colliding runs on tab, so a
-    leading inline tag doesn't become a spurious piece (decode first so escaped
-    characters like ``<0x2019>`` survive the tag strip)."""
-    value = _HEX_RE.sub(lambda m: chr(int(m.group(1), 16)), value)
-    return _TAG_RE.sub("", value)
+    """Decode a span value before splitting colliding runs on tab.
+
+    Identical to ``_decode_content``: same single-pass walker, just named for
+    intent at the callsite (``_assign_spans`` needs values decoded but with
+    ``\\t`` characters intact so it can split on them — the post-decode
+    cleanup that strips control chars happens via ``_post_decode`` on each
+    piece *after* the split).
+    """
+    return _decode_content(value)
 
 
 def enabled_field_order(config: ExportConfig) -> list[str]:
@@ -182,18 +242,24 @@ def _assign_spans(
         if not fields:
             continue  # a style we don't track
         if len(fields) == 1:
-            out[fields[0]] = _clean("".join(values))
+            # ``values`` are already _decode_content'd via _strip_inline above.
+            # Call _post_decode (control-strip + NFC) only — running the full
+            # _clean here would walk the decoded text a second time and either
+            # double-strip (`\\<x\\>` → `<x>` → ``) or double-unescape (`\\\\`
+            # → `\\` → ``X)`` for `\\X`).
+            out[fields[0]] = _post_decode("".join(values))
             continue
         # Colliding style used by several components. They may arrive as separate
         # spans OR as one span with the inter-component tab(s) embedded (InDesign
         # collapses adjacent runs of the same character style). Split on tab,
-        # clean each piece, and keep only those with real content — so ANY local
-        # modification (inline tag, control char, stray whitespace), wherever it
-        # sits in the run, is ignored and the cat number is the first real piece.
+        # post-decode each piece, and keep only those with real content — so ANY
+        # local modification (inline tag, control char, stray whitespace),
+        # wherever it sits in the run, is ignored and the cat number is the
+        # first real piece.
         pieces: list[str] = []
         for v in values:
             for p in v.split("\t"):
-                c = _clean(p)
+                c = _post_decode(p)
                 if c.strip():
                     pieces.append(c)
         for i, fld in enumerate(fields[:-1]):
@@ -239,10 +305,13 @@ def parse_low_tags(
         body = para[m.end() :]
 
         if para_style in section_styles:
-            # Decode escapes, strip inline tags, replace control chars, drop any
-            # "works N-NN" catalogue-range suffix, and collapse whitespace to get
-            # the clean gallery name.
-            name = _TAG_RE.sub("", _decode(body))
+            # Decode content escapes + strip inline tags in one pass, replace
+            # control chars (incl. soft returns from ``<0x000A>``) with spaces,
+            # drop any "works N-NN" catalogue-range suffix, collapse whitespace.
+            # ``_decode`` is the single-pass walker, so an escaped ``\<`` in
+            # the gallery name survives as a literal ``<`` rather than being
+            # consumed as a tag opener.
+            name = _decode(body)
             name = _CONTROL_RE.sub(" ", name)
             name = _WORKS_RANGE_RE.sub("", name)
             name = re.sub(r"\s+", " ", name)

--- a/tests/test_tagged_text_escape.py
+++ b/tests/test_tagged_text_escape.py
@@ -1,0 +1,418 @@
+"""Tests for the InDesign Tagged Text metacharacter escape and its parser
+inverse.
+
+The trigger: work #263 in the 2026 catalogue has the title
+``ENTANGLEMENT (200) INTERACTION > INTRA-ACTION``. The literal ``>`` is a
+reserved character in Tagged Text grammar and InDesign rejects the whole
+file with
+``A closing tag symbol > was found without the corresponding opening tag``.
+
+These tests pin three behaviours:
+
+1. The renderer escapes ``\\``, ``<``, ``>`` in every user-supplied field
+   value and in section headings (both inline and wrapped paths).
+2. The parser's single-pass decoder unescapes them, including when escapes
+   are mixed with inline formatting tags InDesign may have left behind.
+3. Render → parse round-trips. Without this, every escaped export would
+   produce a wall of false-positive findings in the LOW reconcile.
+"""
+
+from types import SimpleNamespace
+
+from backend.app.services.export_renderer import (
+    ComponentConfig,
+    ExportConfig,
+    escape_tagged_text_chars,
+    render_import_as_tagged_text,
+)
+from backend.app.services.index_renderer import (
+    ArtistExportEntry,
+    IndexExportConfig,
+    render_index_tagged_text,
+)
+from backend.app.services.low_tag_parser import (
+    _clean,
+    _decode_content,
+    parse_low_tags,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes (mirrors tests/test_renderer.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeQuery:
+    def __init__(self, results):
+        self._results = results
+
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def all(self):
+        return self._results
+
+
+class _FakeSession:
+    def __init__(self, sections, works, overrides=None):
+        self.sections = sections
+        self.works = works
+        self.overrides = overrides or []
+
+    def query(self, model):
+        return {
+            "Section": _FakeQuery(self.sections),
+            "Work": _FakeQuery(self.works),
+            "WorkOverride": _FakeQuery(self.overrides),
+        }.get(model.__name__, _FakeQuery([]))
+
+
+def _section(id, name, position):
+    return SimpleNamespace(id=id, import_id="imp1", name=name, position=position)
+
+
+def _work(section_id, pos, cat_no, **kw):
+    base = dict(
+        id=f"w{cat_no}",
+        raw_cat_no=cat_no,
+        artist_name="",
+        artist_honorifics=None,
+        title="",
+        price_numeric=None,
+        price_text="",
+        edition_total=None,
+        edition_price_numeric=None,
+        artwork=None,
+        medium=None,
+        section_id=section_id,
+        position_in_section=pos,
+        include_in_export=True,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# escape_tagged_text_chars — the helper itself
+# ---------------------------------------------------------------------------
+
+
+def test_escape_helper_handles_each_metacharacter():
+    assert escape_tagged_text_chars("a < b") == "a \\< b"
+    assert escape_tagged_text_chars("a > b") == "a \\> b"
+    assert escape_tagged_text_chars("path\\file") == "path\\\\file"
+
+
+def test_escape_helper_order_does_not_double_escape():
+    """Backslash must be doubled BEFORE the angle brackets are escaped,
+    otherwise the inserted backslash from ``<`` → ``\\<`` would be doubled
+    on a second pass, breaking the parser."""
+    assert escape_tagged_text_chars("<>") == "\\<\\>"
+    # A pre-existing backslash followed by an angle bracket must not be
+    # absorbed: it stays a literal backslash plus an escaped bracket.
+    assert escape_tagged_text_chars("a\\<b") == "a\\\\\\<b"
+
+
+def test_escape_helper_passthrough():
+    assert escape_tagged_text_chars("") == ""
+    assert escape_tagged_text_chars(None) is None
+    assert escape_tagged_text_chars("Plain title — no metas") == "Plain title — no metas"
+
+
+# ---------------------------------------------------------------------------
+# Renderer — inline path (no wrap)
+# ---------------------------------------------------------------------------
+
+
+def _render_one_work(title, **work_kw):
+    section = _section("s1", "Room", 1)
+    work = _work("s1", 1, 1, title=title, artist_name="A", **work_kw)
+    return render_import_as_tagged_text("imp1", _FakeSession([section], [work]))
+
+
+def test_inline_render_escapes_gt_in_title():
+    out = _render_one_work("INTERACTION > INTRA-ACTION")
+    assert "INTERACTION \\> INTRA-ACTION" in out
+    # And the unescaped form must not survive — that's the InDesign-breaking byte.
+    assert "INTERACTION > INTRA-ACTION" not in out
+
+
+def test_inline_render_escapes_lt_in_title():
+    out = _render_one_work("Made with <fire>")
+    assert "Made with \\<fire\\>" in out
+
+
+def test_inline_render_escapes_backslash_in_title():
+    out = _render_one_work("path\\to\\work")
+    # Each \\ in the input becomes \\\\ in the output (one literal backslash → two).
+    assert "path\\\\to\\\\work" in out
+
+
+def test_inline_render_escapes_artist_and_medium():
+    section = _section("s1", "Room", 1)
+    work = _work(
+        "s1", 1, 1,
+        artist_name="A & <B>",
+        title="t",
+        medium="oil on <canvas>",
+    )
+    out = render_import_as_tagged_text("imp1", _FakeSession([section], [work]))
+    assert "A & \\<B\\>" in out
+    assert "oil on \\<canvas\\>" in out
+
+
+def test_render_escapes_section_name():
+    section = _section("s1", "Gallery < 1 >", 1)
+    work = _work("s1", 1, 1, artist_name="A", title="t")
+    out = render_import_as_tagged_text("imp1", _FakeSession([section], [work]))
+    assert "<ParaStyle:SectionTitle>Gallery \\< 1 \\>" in out
+
+
+# ---------------------------------------------------------------------------
+# Renderer — wrapped path (the direct-emission bypasses)
+# ---------------------------------------------------------------------------
+
+
+def test_wrapped_title_escapes_per_line():
+    """The wrapped-mode branch joins lines with ``\\n`` and constructs a single
+    ``<CharStyle:…>…<CharStyle:>`` block directly, bypassing ``_cs``. Each line
+    must still be escaped — and the parser must still recover the original
+    title from the wrapped output."""
+    config = ExportConfig(
+        components=[
+            ComponentConfig("work_number", "tab"),
+            ComponentConfig("title", "none", max_line_chars=12, balance_lines=False),
+        ],
+    )
+    title = "first > line second > line"
+    out = _render_one_work_with_config(title, config)
+    # Both ``>`` characters must be escaped wherever they end up in the wrap.
+    assert " > " not in out
+    assert "\\>" in out
+    # Parsing the wrapped output reconstructs the original title — the wrap
+    # produces multiple soft-return-separated lines inside one styled run,
+    # which the parser un-wraps by deleting the soft returns.
+    parsed = parse_low_tags(out, config)
+    assert parsed[0].fields["title"] == title
+
+
+def test_wrapped_title_end_of_first_line_escapes_per_line():
+    """The end_of_first_line branch is the one that 2026's template uses (price
+    interleaved between wrapped title lines). Both halves of the title must end
+    up escaped — that's the actual #263 layout."""
+    config = ExportConfig(
+        cat_no_style="Work Number/Name",
+        title_style="Work Number/Name",
+        price_style="Work Price",
+        components=[
+            ComponentConfig("work_number", "tab", omit_sep_when_empty=False),
+            ComponentConfig(
+                "title", "tab", max_line_chars=22, balance_lines=True,
+                next_component_position="end_of_first_line",
+            ),
+            ComponentConfig("price", "none", omit_sep_when_empty=False),
+        ],
+    )
+    out = _render_one_work_with_config(
+        "ENTANGLEMENT (200) INTERACTION > INTRA-ACTION", config, price_numeric=2400,
+    )
+    # Literal ``>`` from the title must never make it to the file body.
+    # Allow the ``>`` inside ``<ParaStyle:…>``, ``<CharStyle:…>``, ``<ASCII-MAC>``.
+    assert _has_no_unescaped_gt_in_content(out), (
+        f"unescaped > in body of:\n{out}"
+    )
+    # And the escape sequence is present.
+    assert "\\>" in out
+
+
+def _render_one_work_with_config(title, config, **work_kw):
+    section = _section("s1", "Room", 1)
+    work = _work("s1", 1, 1, title=title, artist_name="A", **work_kw)
+    return render_import_as_tagged_text("imp1", _FakeSession([section], [work]), config)
+
+
+def _has_no_unescaped_gt_in_content(out):
+    """Walk the rendered text once; any ``>`` that isn't (a) closing a Tagged
+    Text tag we opened, or (b) immediately preceded by an escaping backslash,
+    is the bug we're guarding against."""
+    i = 0
+    n = len(out)
+    while i < n:
+        ch = out[i]
+        if ch == "<":
+            # Skip to the matching '>' — that '>' is a tag terminator we wrote.
+            j = out.find(">", i + 1)
+            if j < 0:
+                return False
+            i = j + 1
+            continue
+        if ch == ">":
+            # In content, outside a tag, and not preceded by an unescaped '\\'.
+            if i == 0 or out[i - 1] != "\\":
+                return False
+        i += 1
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Parser — decoder behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_decode_content_unescapes_backslash_metacharacters():
+    assert _decode_content("a \\< b \\> c") == "a < b > c"
+    assert _decode_content("path\\\\file") == "path\\file"
+
+
+def test_decode_content_strips_inline_tags_but_preserves_escaped_brackets():
+    """The original two-pass implementation (strip-tags then unescape) would
+    greedily consume the ``<x\\>`` slice and lose the title body. The
+    single-pass walker keeps escaped brackets as literals first, then drops
+    the inline tag."""
+    assert (
+        _decode_content("Hello \\<world\\> <ccase:upper>X<ccase:>")
+        == "Hello <world> X"
+    )
+
+
+def test_decode_content_hex_escape_still_works():
+    assert _decode_content("M<0x2019>Coul") == "M’Coul"
+    # Hex inside an otherwise-escaped run — the cases compose.
+    assert (
+        _decode_content("\\<a<0x2014>b\\>") == "<a—b>"
+    )
+
+
+def test_clean_strips_control_chars_after_decoding():
+    # Soft return arrives as <0x000A> → \n; _clean drops it.
+    assert _clean("line one<0x000A>line two") == "line oneline two"
+    # And backslash-escaped angle brackets survive.
+    assert _clean("A \\<B\\> C") == "A <B> C"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: render then parse
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_title_with_metacharacters():
+    """The exact #263 shape: long title with a literal ``>`` mid-string, wrap +
+    interleaved price. Renders to a valid-looking file and parses straight back
+    to the original title."""
+    config = ExportConfig(
+        cat_no_style="Work Number/Name",
+        title_style="Work Number/Name",
+        price_style="Work Price",
+        components=[
+            ComponentConfig("work_number", "tab", omit_sep_when_empty=False),
+            ComponentConfig(
+                "title", "tab", max_line_chars=22, balance_lines=True,
+                next_component_position="end_of_first_line",
+            ),
+            ComponentConfig("price", "none", omit_sep_when_empty=False),
+        ],
+    )
+    title = "ENTANGLEMENT (200) INTERACTION > INTRA-ACTION"
+    section = _section("s1", "Room", 1)
+    work = _work("s1", 1, 263, title=title, artist_name="A", price_numeric=2400)
+    db = _FakeSession([section], [work])
+
+    text = render_import_as_tagged_text("imp1", db, config)
+    parsed = parse_low_tags(text, config)
+
+    assert len(parsed) == 1
+    assert parsed[0].cat_no == "263"
+    assert parsed[0].fields["title"] == title
+
+
+def test_roundtrip_inline_with_all_three_metacharacters():
+    title = "A < B > C and a backslash \\ too"
+    section = _section("s1", "Room", 1)
+    work = _work("s1", 1, 1, title=title, artist_name="A")
+    db = _FakeSession([section], [work])
+
+    text = render_import_as_tagged_text("imp1", db)
+    parsed = parse_low_tags(text, ExportConfig())
+    assert parsed[0].fields["title"] == title
+
+
+def test_roundtrip_preserves_section_name_metacharacters():
+    section = _section("s1", "Gallery <1>", 1)
+    work = _work("s1", 1, 1, title="t", artist_name="A")
+    db = _FakeSession([section], [work])
+    text = render_import_as_tagged_text("imp1", db)
+    parsed = parse_low_tags(text, ExportConfig())
+    assert parsed[0].section_name == "Gallery <1>"
+
+
+# ---------------------------------------------------------------------------
+# Index renderer
+# ---------------------------------------------------------------------------
+
+
+def _index_entry(**kw):
+    base = dict(
+        title=None,
+        first_name=None,
+        last_name=None,
+        quals=None,
+        company=None,
+        artist2_first_name=None,
+        artist2_last_name=None,
+        artist2_quals=None,
+        artist3_first_name=None,
+        artist3_last_name=None,
+        artist3_quals=None,
+        artist1_ra_styled=False,
+        artist2_ra_styled=False,
+        artist3_ra_styled=False,
+        artist2_shared_surname=False,
+        artist3_shared_surname=False,
+        is_ra_member=False,
+        is_company=False,
+        sort_key="z",
+        courtesy=None,
+        cat_nos=[1],
+    )
+    base.update(kw)
+    return ArtistExportEntry(**base)
+
+
+def test_index_renderer_escapes_surname_and_first_name():
+    entry = _index_entry(
+        first_name="Mary <Anne>",
+        last_name="O'Brien & Smith",
+        sort_key="o",
+    )
+    out = render_index_tagged_text([entry], IndexExportConfig())
+    assert "Mary \\<Anne\\>" in out
+    assert "<Anne>" not in out  # no unescaped form leaks through
+
+
+def test_index_renderer_escapes_company_and_quals():
+    entry = _index_entry(
+        last_name="Studio <X>",
+        company="Studio <X>",
+        quals="Hon < RA >",
+        is_company=True,
+        sort_key="s",
+    )
+    out = render_index_tagged_text([entry], IndexExportConfig())
+    assert "Studio \\<X\\>" in out
+    # Default config lowercases quals — verify the escape survives lowercasing
+    # (backslashes are stable across .lower()).
+    assert "hon \\< ra \\>" in out
+
+
+def test_index_renderer_does_not_break_letter_grouping():
+    """``sort_key`` is intentionally not escaped — letter grouping looks at the
+    first character to decide the bucket. Verify a normal sort_key still groups."""
+    a = _index_entry(first_name="A", last_name="Adams", sort_key="adams a")
+    b = _index_entry(first_name="B", last_name="Brown", sort_key="brown b")
+    out = render_index_tagged_text([a, b], IndexExportConfig())
+    # Both entries make it through and the separator between letter groups appears.
+    assert "Adams" in out
+    assert "Brown" in out


### PR DESCRIPTION
InDesign's Tagged Text grammar reserves \<, \>, and \\ as escapes for the metacharacters <, >, and \. The exporter was emitting field values verbatim, so a literal > in a work title (concrete trigger: work #263 'ENTANGLEMENT (200) INTERACTION > INTRA-ACTION') reached InDesign as a stray closing-tag bracket and the whole file was rejected: 'A closing tag symbol > was found without the corresponding opening tag'.

Renderer: new escape_tagged_text_chars() helper (backslash first to avoid double-escape on the second pass). Applied at _cs() for the inline render path and at the three direct-emission paths that bypass it: section heading, wrapped end-of-first-line branch, and wrapped multi-line branch. Escape is per-wrapped-line so max_line_chars math (which runs on unescaped text) is not thrown off by inflated escape sequences. Index renderer escapes every user-supplied field on the ArtistExportEntry once at the top of render_index_tagged_text, because its layout helpers concatenate raw text in many places; sort_key is intentionally not escaped so letter grouping still works.

Parser: replaced the regex sequence in low_tag_parser with a single-pass walker (_decode_content). The old hex/tag/backslash regex chain was forced wrong in both possible orderings: strip-tags-then-unescape greedily eats <x\> because the tag regex doesn't see backslashes; unescape-then-strip-tags turns \<x\> into <x> and then deletes it. The walker treats \< as a literal before considering < as a tag opener. Split into _decode_content (decode) + _post_decode (control-strip + NFC) so the colliding-style and single-field paths in _assign_spans don't double-walk the same text.

Tests: 20 new tests in test_tagged_text_escape.py — helper escape order, the three metacharacters in inline/wrapped/end-of-first-line render paths, section name escape, parser walker (including the case the old regex order would have eaten), round-trip render-then-parse for the #263 shape, and Index renderer surname/first-name/quals/company coverage. test_low_real_sample.py still passes (1729/1729 entries, 0 findings on the real 2025 export) — the parser refactor hasn't broken reconcile. 933 tests total across 38 files.