### PR TITLE
Show catalogue number range in LoW gallery headers

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4075,11 +4075,26 @@ function renderSections(importId, sections, cfg) {
     filterCount.textContent = '';
     filterInput.addEventListener('input', () => _applyWorksFilter(filterInput.value, filterCount, totalWorks));
   }
-  container.innerHTML = sections.map(section => `
+  container.innerHTML = sections.map(section => {
+    // Cat-number range in the gallery header, alongside the work count.
+    // Only numeric raw_cat_nos contribute (catalogue numbers are integer in
+    // practice — a non-numeric entry would skew min/max meaninglessly).
+    const catNos = section.works
+      .map(w => Number(w.raw_cat_no))
+      .filter(n => Number.isFinite(n));
+    let rangeText = '';
+    if (catNos.length) {
+      const min = Math.min(...catNos);
+      const max = Math.max(...catNos);
+      rangeText = min === max
+        ? ` | number ${min}`
+        : ` | numbers ${min}\u2013${max}`;  // en-dash for numeric ranges
+    }
+    return `
     <details class="section-block" open>
       <summary class="section-summary">
         <span class="section-name">${esc(section.name)}</span>
-        <span class="section-meta">${section.works.length} work${section.works.length !== 1 ? 's' : ''}</span>
+        <span class="section-meta">${section.works.length} work${section.works.length !== 1 ? 's' : ''}${rangeText}</span>
         <button type="button" class="btn btn-xs btn-secondary section-export-btn"
           onclick="event.preventDefault();downloadExportWithTemplate('${esc(importId)}','tags','txt','${esc(section.id)}',this,'${esc(section.name)}')">
           Export section
@@ -4100,7 +4115,8 @@ function renderSections(importId, sections, cfg) {
           ${section.works.map(w => workRowHTML(importId, w, cfg)).join('')}
         </tbody>
       </table>
-    </details>`).join('');
+    </details>`;
+  }).join('');
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Alongside the existing '209 works' count, each gallery's <summary> now also shows the catalogue number range of its works, e.g. 'Large Weston Room | 203 works | numbers 1398–1600'.

Computed client-side from section.works[].raw_cat_no with a Number()/isFinite() filter — raw_cat_no comes through the JSON API as a string and is integer in practice but the filter avoids skewing min/max on the rare non-numeric entry. Single-work sections render as 'number N' (singular). Empty sections show no range. En-dash (U+2013) for the numeric range per typographic convention; written as \u2013 in the source to match the file-wide HTML-string escape convention (see ~/.claude/projects/.../memory/appjs_unicode_escape_convention.md).

No CSS or class changes — pure content extension inside the existing .section-meta span, so the shared .section-summary / .section-block / .section-meta surface (LoW + Audit + Index + Tools) is unaffected.