### PR TITLE
Fingerprint-matcher re-import with dry-run preview + gallery scope

### DIFF
--- a/backend/app/api/low_imports.py
+++ b/backend/app/api/low_imports.py
@@ -2,7 +2,8 @@
 Import management routes: upload, list, sections, preview, warnings, delete.
 """
 
-from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, status
+from dataclasses import asdict
+from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, status, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
@@ -81,9 +82,33 @@ def upload_excel(file: UploadFile = File(...), db: Session = Depends(get_db)):
 def reimport_upload(
     import_id: UUID,
     file: UploadFile = File(...),
+    dry_run: bool = Query(
+        False,
+        description=(
+            "When true, parse the file and compute the override-preservation "
+            "plan but make no DB changes. Use this to preview the re-import "
+            "and let the user pick a gallery scope before committing."
+        ),
+    ),
+    galleries: str | None = Query(
+        None,
+        description=(
+            "Comma-separated gallery names to limit the re-import to. When "
+            "omitted, all galleries in the new file are processed. Out-of-"
+            "scope galleries stay physically untouched in the DB. Cross-"
+            "gallery moves into/out of the scope are surfaced as warnings."
+        ),
+    ),
     db: Session = Depends(get_db),
 ):
-    """Re-import a spreadsheet, preserving overrides matched by Cat No."""
+    """Re-import a spreadsheet with override preservation and optional
+    dry-run + selective gallery scope.
+
+    Override preservation goes through the matcher
+    (``backend/app/services/reimport_matcher.py``): cat-no matches gated on
+    fingerprint agreement, with a fingerprint fallback for renumbered
+    works. The dry-run mode returns the full plan without mutating the DB.
+    """
     # Verify the import exists
     import_record = db.query(Import).filter(Import.id == import_id).first()
     if not import_record:
@@ -92,6 +117,12 @@ def reimport_upload(
             detail="Import not found",
         )
 
+    gallery_scope: set[str] | None = None
+    if galleries:
+        gallery_scope = {g.strip() for g in galleries.split(",") if g.strip()}
+        if not gallery_scope:
+            gallery_scope = None  # treat empty list as "no filter"
+
     original_name = file.filename or "upload.xlsx"
     disk_name = _make_key(original_name)
     storage.save(disk_name, file.file)
@@ -99,7 +130,7 @@ def reimport_upload(
     with storage.open_path(disk_name) as file_path:
         norm = load_normalisation_settings(db)
         try:
-            _record, stats = reimport_excel(
+            _record, plan = reimport_excel(
                 import_id,
                 file_path,
                 db,
@@ -108,6 +139,8 @@ def reimport_upload(
                 edition_suppress_max=norm["edition_suppress_max"],
                 text_substitutions=norm["text_substitutions"],
                 title_case_exceptions=norm["title_case_exceptions"],
+                gallery_scope=gallery_scope,
+                dry_run=dry_run,
             )
         except ExcelImportError as exc:
             storage.delete(disk_name)
@@ -115,18 +148,30 @@ def reimport_upload(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             )
 
-    # Remove the previous upload file if it exists
-    storage.delete(import_record.disk_filename or "")
-    # Track the new storage key
-    import_record.disk_filename = disk_name
-    db.commit()
+    if dry_run:
+        # Don't persist the uploaded file — caller will re-upload on commit.
+        storage.delete(disk_name)
+    else:
+        # Remove the previous upload file and track the new storage key.
+        storage.delete(import_record.disk_filename or "")
+        import_record.disk_filename = disk_name
+        db.commit()
 
     return ReimportOut(
         import_id=str(import_id),
-        matched=stats["matched"],
-        added=stats["added"],
-        removed=stats["removed"],
-        overrides_preserved=stats["overrides_preserved"],
+        # Legacy aggregate (matches both cat-no and fingerprint mechanisms)
+        matched=plan.matched_by_cat_no + plan.matched_by_fingerprint,
+        added=plan.added,
+        removed=plan.removed,
+        overrides_preserved=plan.overrides_preserved,
+        dry_run=dry_run,
+        matched_by_cat_no=plan.matched_by_cat_no,
+        matched_by_fingerprint=plan.matched_by_fingerprint,
+        overrides_at_risk=plan.overrides_at_risk,
+        galleries=[asdict(g) for g in plan.galleries],
+        unmatched=[asdict(u) for u in plan.unmatched],
+        ambiguous=[asdict(a) for a in plan.ambiguous],
+        cross_gallery_warnings=[asdict(w) for w in plan.cross_gallery_warnings],
     )
 
 

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -24,12 +24,67 @@ class ImportOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class GallerySummaryOut(BaseModel):
+    """One gallery in the freshly-uploaded spreadsheet, for the UI picker."""
+
+    name: str
+    position: int
+    work_count: int
+    cat_no_min: int | None
+    cat_no_max: int | None
+    in_scope: bool
+
+
+class UnmatchedOut(BaseModel):
+    """A preserved override with no acceptable target in the new spreadsheet."""
+
+    old_cat_no: str
+    raw_title: str | None
+    raw_artist: str | None
+    had_override: bool
+    reason: str
+
+
+class AmbiguousOut(BaseModel):
+    """A preserved override whose match is ambiguous and refused by the matcher."""
+
+    old_cat_no: str
+    raw_title: str | None
+    raw_artist: str | None
+    candidate_new_cat_nos: List[str]
+    reason: str
+
+
+class CrossGalleryMoveWarningOut(BaseModel):
+    """A row in the selected gallery scope appears (by fingerprint) to be a
+    work currently in a non-scope gallery — selective re-import would
+    duplicate it."""
+
+    new_cat_no: str
+    raw_title: str | None
+    raw_artist: str | None
+    old_cat_no: str
+    old_gallery: str
+    new_gallery: str
+
+
 class ReimportOut(BaseModel):
     import_id: str
+    # Legacy fields preserved for backwards-compat with existing UI / tests.
+    # ``matched`` is the sum of cat-no and fingerprint matches.
     matched: int
     added: int
     removed: int
     overrides_preserved: int
+    # Plan details — new in the matcher-based re-import.
+    dry_run: bool = False
+    matched_by_cat_no: int = 0
+    matched_by_fingerprint: int = 0
+    overrides_at_risk: int = 0
+    galleries: List[GallerySummaryOut] = []
+    unmatched: List[UnmatchedOut] = []
+    ambiguous: List[AmbiguousOut] = []
+    cross_gallery_warnings: List[CrossGalleryMoveWarningOut] = []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/excel_importer.py
+++ b/backend/app/services/excel_importer.py
@@ -16,6 +16,13 @@ from backend.app.services.normalisation_service import (
     normalise_work,
     collect_work_warnings,
 )
+from backend.app.services.reimport_matcher import (
+    MatchPlan,
+    NewWorkRow,
+    OldWorkSnapshot,
+    compute_fingerprint,
+    match_overrides,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +289,20 @@ def _open_and_parse_workbook(file_path: str) -> Tuple[List[str], List[dict], Lis
     return headers, rows, header_warnings
 
 
+OVERRIDE_FIELDS = [
+    "title_override",
+    "artist_name_override",
+    "artist_honorifics_override",
+    "price_numeric_override",
+    "price_text_override",
+    "edition_total_override",
+    "edition_price_numeric_override",
+    "artwork_override",
+    "medium_override",
+    "notes",
+]
+
+
 def reimport_excel(
     import_id: _uuid.UUID,
     file_path: str,
@@ -291,15 +312,35 @@ def reimport_excel(
     edition_suppress_max: int = 0,
     text_substitutions: Optional[List[dict]] = None,
     title_case_exceptions: Optional[List[str]] = None,
-) -> Tuple[Import, Dict[str, int]]:
+    gallery_scope: Optional[set] = None,
+    dry_run: bool = False,
+) -> Tuple[Import, MatchPlan]:
     """Re-import a spreadsheet into an existing Import, preserving overrides.
 
-    Works are matched by ``raw_cat_no``.  Overrides and ``include_in_export``
-    flags are restored for matched works.  Unmatched old works are removed;
-    new works without a match are created fresh.
+    Override preservation goes through ``reimport_matcher.match_overrides``
+    which combines a cat-no match (gated on fingerprint agreement, so a
+    renumbered cat-no can't silently transplant an override onto a different
+    work) with a fingerprint fallback (so a work whose cat-no shifted but
+    whose content is unchanged keeps its override).
 
-    Returns ``(import_record, stats)`` where *stats* has keys:
-    ``matched``, ``added``, ``removed``, ``overrides_preserved``.
+    Parameters
+    ----------
+    gallery_scope
+        When provided, the operation is **scoped**: only galleries whose
+        name is in this set are deleted-and-rebuilt; works in any other
+        gallery stay physically untouched. New-spreadsheet rows for
+        out-of-scope galleries are ignored. Cross-gallery moves into/out of
+        the scope are detected and surfaced as warnings in the returned plan.
+    dry_run
+        When True, parse + compute the plan and return it without mutating
+        the DB. The transaction is rolled back at the end so any flushed
+        snapshot state is discarded.
+
+    Returns
+    -------
+    ``(import_record, MatchPlan)``. The plan carries the per-gallery
+    summary, counts, and per-finding details (unmatched, ambiguous,
+    cross-gallery-move warnings).
     """
 
     import_record = db.query(Import).filter(Import.id == import_id).first()
@@ -309,73 +350,172 @@ def reimport_excel(
     # 1. Parse & validate new file — fail fast before touching existing data
     _headers, rows, header_warnings = _open_and_parse_workbook(file_path)
 
-    # 2. Snapshot existing overrides + include_in_export, keyed by cat_no
+    # 2. Snapshot existing works + overrides as inputs to the matcher
     existing_works = db.query(Work).filter(Work.import_id == import_id).all()
     work_ids = [w.id for w in existing_works]
-    existing_overrides: Dict[str, WorkOverride] = {}
+    existing_overrides_by_work: Dict = {}
     if work_ids:
-        existing_overrides = {
-            str(o.work_id): o
+        existing_overrides_by_work = {
+            o.work_id: o
             for o in db.query(WorkOverride)
             .filter(WorkOverride.work_id.in_(work_ids))
             .all()
         }
 
-    # Build preservation map:  cat_no → {include_in_export, override_fields}
-    OVERRIDE_FIELDS = [
-        "title_override",
-        "artist_name_override",
-        "artist_honorifics_override",
-        "price_numeric_override",
-        "price_text_override",
-        "edition_total_override",
-        "edition_price_numeric_override",
-        "artwork_override",
-        "medium_override",
-        "notes",
-    ]
-
-    preserve: Dict[str, dict] = {}
+    # Side-table for restoring overrides keyed by old cat_no (the matcher
+    # tells us which OLD cat_no maps to which NEW row; we re-create works
+    # in document order, then look up by the matcher's mapping).
+    preserve_data: Dict[str, dict] = {}
+    old_snapshots: List[OldWorkSnapshot] = []
     for w in existing_works:
-        key = str(w.raw_cat_no).strip() if w.raw_cat_no is not None else None
-        if key is None:
-            continue
-        entry: dict = {"include_in_export": w.include_in_export}
-        ovr = existing_overrides.get(str(w.id))
-        if ovr:
-            entry["override"] = {f: getattr(ovr, f) for f in OVERRIDE_FIELDS}
-        preserve[key] = entry
-
-    # 3. Delete old data (order matters for FK constraints in SQLite tests)
-    if work_ids:
-        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).delete(
-            synchronize_session=False
+        cat_key = str(w.raw_cat_no).strip() if w.raw_cat_no is not None else ""
+        ovr_obj = existing_overrides_by_work.get(w.id)
+        ovr_dict = (
+            {f: getattr(ovr_obj, f) for f in OVERRIDE_FIELDS} if ovr_obj else None
         )
-    db.query(ValidationWarning).filter(ValidationWarning.import_id == import_id).delete(
-        synchronize_session=False
-    )
-    db.query(Work).filter(Work.import_id == import_id).delete(synchronize_session=False)
-    db.query(Section).filter(Section.import_id == import_id).delete(
-        synchronize_session=False
-    )
-    db.flush()
-
-    # 4. Re-create sections & works from the new spreadsheet
-    sections_map: Dict[str, Section] = {}
-    section_positions: Dict[str, int] = {}
-    matched_cat_nos: set = set()
-    stats = {"matched": 0, "added": 0, "removed": 0, "overrides_preserved": 0}
-
-    # Import-level warnings (header issues)
-    for msg in header_warnings:
-        db.add(
-            ValidationWarning(
-                import_id=import_id,
-                work_id=None,
-                warning_type="missing_column",
-                message=msg,
+        old_snapshots.append(
+            OldWorkSnapshot(
+                cat_no=cat_key,
+                gallery=str(w.raw_gallery or ""),
+                fingerprint=compute_fingerprint(
+                    w.raw_title, w.raw_artist, w.raw_medium
+                ),
+                include_in_export=w.include_in_export,
+                override=ovr_dict,
+                raw_title=w.raw_title,
+                raw_artist=w.raw_artist,
             )
         )
+        # Last-write-wins by cat_no for restore (mirrors the historical
+        # behaviour for the pathological "two old works with the same
+        # cat_no" case — should be vanishingly rare in real data).
+        if cat_key:
+            preserve_data[cat_key] = {
+                "include_in_export": w.include_in_export,
+                "override": ovr_dict,
+            }
+
+    # 3. Build new-side rows (no DB writes yet — the matcher needs to see
+    # the spreadsheet first so we can decide before mutating).
+    new_rows: List[NewWorkRow] = []
+    for row_dict in rows:
+        raw_cat_no = row_dict.get("Cat No")
+        gallery_name = row_dict.get("Gallery") or "Uncategorised"
+        new_rows.append(
+            NewWorkRow(
+                cat_no=(
+                    str(raw_cat_no).strip() if raw_cat_no is not None else ""
+                ),
+                gallery=str(gallery_name),
+                fingerprint=compute_fingerprint(
+                    row_dict.get("Title"),
+                    row_dict.get("Artist"),
+                    row_dict.get("Medium"),
+                ),
+                raw_title=row_dict.get("Title"),
+                raw_artist=row_dict.get("Artist"),
+            )
+        )
+
+    # 4. Compute the plan (pure, no side effects)
+    plan = match_overrides(old_snapshots, new_rows, gallery_scope=gallery_scope)
+
+    # 5. Dry-run: return the plan without touching the DB
+    if dry_run:
+        # Roll back any implicit reads so the next call sees a clean session.
+        db.rollback()
+        return import_record, plan
+
+    # 6. Delete the scope. Two paths:
+    #    - Full re-import (scope None): wipe everything for this import.
+    #    - Selective: only delete sections in the scope; out-of-scope
+    #      sections, works, overrides, and per-work warnings stay intact.
+    section_positions: Dict[str, int] = {}
+    sections_map: Dict[str, Section] = {}
+    preserved_section_positions: Dict[str, int] = {}
+
+    if gallery_scope is None:
+        if work_ids:
+            db.query(WorkOverride).filter(
+                WorkOverride.work_id.in_(work_ids)
+            ).delete(synchronize_session=False)
+        db.query(ValidationWarning).filter(
+            ValidationWarning.import_id == import_id
+        ).delete(synchronize_session=False)
+        db.query(Work).filter(Work.import_id == import_id).delete(
+            synchronize_session=False
+        )
+        db.query(Section).filter(Section.import_id == import_id).delete(
+            synchronize_session=False
+        )
+        db.flush()
+        next_position = 1
+    else:
+        in_scope_sections = (
+            db.query(Section)
+            .filter(
+                Section.import_id == import_id,
+                Section.name.in_(gallery_scope),
+            )
+            .all()
+        )
+        # Remember each in-scope section's position so we can put the
+        # re-created section back in the same slot — UI ordering stays stable.
+        for s in in_scope_sections:
+            preserved_section_positions[s.name] = s.position
+        in_scope_section_ids = [s.id for s in in_scope_sections]
+        in_scope_work_ids = [
+            w.id for w in existing_works if w.section_id in set(in_scope_section_ids)
+        ]
+        if in_scope_work_ids:
+            db.query(WorkOverride).filter(
+                WorkOverride.work_id.in_(in_scope_work_ids)
+            ).delete(synchronize_session=False)
+            # Per-work validation warnings only (header warnings keyed by
+            # work_id=NULL are global and survive a selective re-import).
+            db.query(ValidationWarning).filter(
+                ValidationWarning.work_id.in_(in_scope_work_ids)
+            ).delete(synchronize_session=False)
+        if in_scope_section_ids:
+            db.query(Work).filter(
+                Work.section_id.in_(in_scope_section_ids)
+            ).delete(synchronize_session=False)
+            db.query(Section).filter(
+                Section.id.in_(in_scope_section_ids)
+            ).delete(synchronize_session=False)
+        db.flush()
+        # New galleries (in scope but no pre-existing section) get
+        # positions after the current max.
+        current_max = (
+            db.query(Section.position)
+            .filter(Section.import_id == import_id)
+            .order_by(Section.position.desc())
+            .limit(1)
+            .scalar()
+            or 0
+        )
+        next_position = current_max + 1
+
+    # 7. Re-create sections + works (only those in scope).
+    # Header warnings only on full re-import — they apply to the spreadsheet
+    # as a whole and would duplicate noise on every selective re-upload.
+    if gallery_scope is None:
+        for msg in header_warnings:
+            db.add(
+                ValidationWarning(
+                    import_id=import_id,
+                    work_id=None,
+                    warning_type="missing_column",
+                    message=msg,
+                )
+            )
+
+    # Map (in_scope_row_index → matched item) so we can restore override
+    # data as each new Work is created.
+    matched_by_in_scope_idx: Dict[int, object] = {
+        m.new_row_index: m for m in plan.matched
+    }
+    in_scope_counter = 0
 
     for row_dict in rows:
         raw_cat_no = row_dict.get("Cat No")
@@ -389,11 +529,21 @@ def reimport_excel(
 
         gallery_name = raw_gallery or "Uncategorised"
 
+        # Skip rows outside the requested scope
+        if gallery_scope is not None and gallery_name not in gallery_scope:
+            continue
+
         if gallery_name not in sections_map:
+            # Reuse the original position when possible so the UI keeps
+            # showing galleries in the original order; otherwise append.
+            position = preserved_section_positions.get(gallery_name)
+            if position is None:
+                position = next_position
+                next_position += 1
             section = Section(
                 import_id=import_id,
                 name=gallery_name,
-                position=len(sections_map) + 1,
+                position=position,
             )
             db.add(section)
             db.flush()
@@ -426,19 +576,16 @@ def reimport_excel(
         )
         db.flush()
 
-        # Restore override / include_in_export if cat_no matches
-        key = str(raw_cat_no).strip() if raw_cat_no is not None else None
-        if key and key in preserve and key not in matched_cat_nos:
-            matched_cat_nos.add(key)
-            entry = preserve[key]
-            work.include_in_export = entry["include_in_export"]
-            if "override" in entry:
-                ovr = WorkOverride(work_id=work.id, **entry["override"])
-                db.add(ovr)
-                stats["overrides_preserved"] += 1
-            stats["matched"] += 1
-        else:
-            stats["added"] += 1
+        # Restore override + include_in_export when the matcher paired this
+        # row with an old work.
+        matched_item = matched_by_in_scope_idx.get(in_scope_counter)
+        if matched_item is not None:
+            preserved = preserve_data.get(matched_item.old_cat_no)
+            if preserved is not None:
+                work.include_in_export = preserved["include_in_export"]
+                if preserved["override"]:
+                    db.add(WorkOverride(work_id=work.id, **preserved["override"]))
+        in_scope_counter += 1
 
         # Work-level validation warnings
         for warning_type, message in collect_work_warnings(
@@ -455,7 +602,7 @@ def reimport_excel(
                 )
             )
 
-    if not sections_map:
+    if not sections_map and gallery_scope is None:
         db.add(
             ValidationWarning(
                 import_id=import_id,
@@ -465,14 +612,23 @@ def reimport_excel(
             )
         )
 
-    # 5. Count removed works
-    stats["removed"] = len(set(preserve.keys()) - matched_cat_nos)
-
-    # 6. Update import record
-    if display_name:
+    # 8. Update display name only on a full re-import — selective uploads
+    # don't represent a new master file.
+    if display_name and gallery_scope is None:
         import_record.filename = display_name
 
-    # 7. Audit log entry
+    # 9. Audit log entry with the full plan summary
+    audit_parts = [
+        f"matched={plan.matched_by_cat_no + plan.matched_by_fingerprint}",
+        f"added={plan.added}",
+        f"removed={plan.removed}",
+        f"overrides_preserved={plan.overrides_preserved}",
+        f"matched_by_cat_no={plan.matched_by_cat_no}",
+        f"matched_by_fingerprint={plan.matched_by_fingerprint}",
+        f"overrides_at_risk={plan.overrides_at_risk}",
+    ]
+    if gallery_scope:
+        audit_parts.append(f"scope={sorted(gallery_scope)}")
     db.add(
         AuditLog(
             import_id=import_id,
@@ -480,13 +636,9 @@ def reimport_excel(
             action="reimport",
             field=None,
             old_value=None,
-            new_value=(
-                f"matched={stats['matched']}, added={stats['added']}, "
-                f"removed={stats['removed']}, "
-                f"overrides_preserved={stats['overrides_preserved']}"
-            ),
+            new_value=", ".join(audit_parts),
         )
     )
 
     db.commit()
-    return import_record, stats
+    return import_record, plan

--- a/backend/app/services/reimport_matcher.py
+++ b/backend/app/services/reimport_matcher.py
@@ -1,0 +1,496 @@
+"""Plan a re-import: match preserved overrides from the old DB state against
+rows in a freshly-uploaded spreadsheet, without committing anything.
+
+This module is **pure** — no DB session, no I/O. It takes the old and new sides
+as plain dataclasses and returns a ``MatchPlan`` describing what would happen
+if the re-import were committed. The importer wraps it with the DB read/write
+side; the API exposes ``dry_run`` so the plan can be returned to the user as
+a preview before any mutation.
+
+Why this exists
+---------------
+The pre-existing re-import matches preserved overrides to new works **purely
+by catalogue number** (``raw_cat_no``). That breaks in two distinct ways when
+the gallery inserts a work and renumbers everything after it:
+
+1. **Lost overrides on renumbered works.** Old work 1700's override is keyed
+   to cat 1700; the new spreadsheet's work-with-the-same-content is now at
+   cat 1701; the override doesn't get restored.
+
+2. **Silent misapplication.** Worse — the new cat 1700 is *different* content
+   (was old cat 1699). The old override gets restored onto it without warning.
+   An overridden price, an ``exclude_in_export`` flag, or editor notes are
+   silently transplanted onto the wrong work.
+
+The matcher fixes both by adding a **content fingerprint** as a secondary
+join key. When cat-no matches and the fingerprint also agrees → strong
+match. When cat-no matches but fingerprints differ → suspected renumber
+collision, *don't* restore; let the second pass try to find the work
+elsewhere. When fingerprint matches some new row with a different cat-no →
+fingerprint match (the renumber case, handled). Unmatched preserved
+overrides are reported with their identifying fields so the user knows what
+to review.
+
+Scope filter
+------------
+The matcher also accepts a ``gallery_scope`` — when set, only old works in
+those galleries are considered "at risk", and only new rows in those
+galleries are considered targets. This supports the selective re-import flow
+(re-import only the last three galleries, leave the rest untouched in the
+DB). Cross-gallery moves into / out of the scope are detected and reported
+as warnings — they're the one shape selective re-import can't handle
+cleanly, and the user needs to either expand the scope or accept that those
+works will be duplicated / lost.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+
+Fingerprint = tuple[str, str, str]
+"""Normalised (title, artist, medium) — the content fingerprint of a work."""
+
+
+def _norm(value: Optional[str]) -> str:
+    """Normalise a single fingerprint component for comparison.
+
+    NFKC-normalise (collapses width / compatibility variants), strip + lower
+    + collapse internal whitespace. Punctuation is *kept* — the same artist's
+    "Untitled (after dusk)" and "Untitled after dusk" should not collide.
+    Empty / None → empty string so a missing medium can still fingerprint
+    cleanly against a missing medium.
+    """
+    if not value:
+        return ""
+    s = unicodedata.normalize("NFKC", str(value)).strip().lower()
+    return re.sub(r"\s+", " ", s)
+
+
+def compute_fingerprint(
+    title: Optional[str],
+    artist: Optional[str],
+    medium: Optional[str],
+) -> Fingerprint:
+    """Build a fingerprint from the three fields used for content identity.
+
+    These three pin a work tightly enough for the catalogue: title alone has
+    a non-trivial collision rate ("Untitled", "Self-Portrait", etc.) and
+    artist alone is rarely unique for a prolific exhibitor; the three
+    together collide vanishingly rarely. Cat number is the obvious fourth
+    candidate but that's the very field the matcher is trying to be robust
+    against.
+    """
+    return (_norm(title), _norm(artist), _norm(medium))
+
+
+def _weak_fingerprint(fp: Fingerprint) -> tuple[str, str]:
+    """Title + artist only — used as a tertiary fallback when the medium has
+    been edited (a common editorial correction). Returned as a separate
+    function so callers can opt in to weaker matching explicitly."""
+    return (fp[0], fp[1])
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OldWorkSnapshot:
+    """One existing work in the DB, with the data the matcher needs to decide
+    whether and how to preserve its override."""
+
+    cat_no: str  # str-normalised (whitespace-stripped) — empty string if none
+    gallery: str  # ``raw_gallery`` for scope filtering, "" if missing
+    fingerprint: Fingerprint
+    include_in_export: bool
+    override: Optional[dict] = None  # field-name → value dict, or None for no override
+    # Identifying fields for the human-readable plan output:
+    raw_title: Optional[str] = None
+    raw_artist: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NewWorkRow:
+    """One parsed row from the freshly-uploaded spreadsheet."""
+
+    cat_no: str  # str-normalised — empty string if blank
+    gallery: str
+    fingerprint: Fingerprint
+    # Identifying fields for the human-readable plan output:
+    raw_title: Optional[str] = None
+    raw_artist: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Plan output
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MatchedItem:
+    """One preserved override that will be restored onto a new work."""
+
+    old_cat_no: str
+    new_cat_no: str
+    new_row_index: int  # 0-based position in the input new_rows list
+    via: str  # "cat_no" | "fingerprint"
+    raw_title: Optional[str]
+    raw_artist: Optional[str]
+    had_override: bool  # False if only include_in_export was non-default
+
+
+@dataclass
+class UnmatchedItem:
+    """A preserved override with no acceptable target in the new spreadsheet.
+    Its override will be lost unless the user expands the gallery scope or
+    re-applies manually."""
+
+    old_cat_no: str
+    raw_title: Optional[str]
+    raw_artist: Optional[str]
+    had_override: bool
+    reason: str  # "no_fingerprint_match" | "cat_no_collision_no_fingerprint_match"
+
+
+@dataclass
+class AmbiguousItem:
+    """A preserved override that could match more than one new row by
+    fingerprint, or a cat-no match where the fingerprint disagreed. The
+    matcher refuses to guess; the user must resolve manually."""
+
+    old_cat_no: str
+    raw_title: Optional[str]
+    raw_artist: Optional[str]
+    candidate_new_cat_nos: list[str]
+    reason: str  # "fingerprint_collision" | "cat_no_match_fingerprint_mismatch"
+
+
+@dataclass
+class CrossGalleryMoveWarning:
+    """A new-spreadsheet row inside the selected gallery scope appears
+    (by fingerprint) to be a work that's currently in a gallery *outside*
+    the scope. Selective re-import would duplicate it: the old copy stays
+    in its current gallery (untouched), and a new copy appears in the
+    selected gallery. The user should extend the scope to include both, or
+    delete the old copy manually."""
+
+    new_cat_no: str
+    raw_title: Optional[str]
+    raw_artist: Optional[str]
+    old_cat_no: str
+    old_gallery: str
+    new_gallery: str
+
+
+@dataclass
+class GallerySummary:
+    """One gallery in the new spreadsheet, with the metadata the UI needs
+    for the picker."""
+
+    name: str
+    position: int  # 1-based order in the new spreadsheet
+    work_count: int
+    cat_no_min: Optional[int]  # None when no numeric cat_nos
+    cat_no_max: Optional[int]
+    in_scope: bool
+
+
+@dataclass
+class MatchPlan:
+    """The full plan computed by ``match_overrides``. Serialisable to JSON
+    for the dry-run API response and the UI."""
+
+    matched: list[MatchedItem] = field(default_factory=list)
+    unmatched: list[UnmatchedItem] = field(default_factory=list)
+    ambiguous: list[AmbiguousItem] = field(default_factory=list)
+    cross_gallery_warnings: list[CrossGalleryMoveWarning] = field(default_factory=list)
+    galleries: list[GallerySummary] = field(default_factory=list)
+    # Bulk counts (derived, but precomputed for convenience in the response):
+    matched_by_cat_no: int = 0
+    matched_by_fingerprint: int = 0
+    added: int = 0  # new rows with no preserved match
+    removed: int = 0  # preserved entries with no match in new rows
+    overrides_preserved: int = 0  # subset of matched that had a real override
+    overrides_at_risk: int = 0  # subset of unmatched + ambiguous that had a real override
+
+
+# ---------------------------------------------------------------------------
+# Matcher
+# ---------------------------------------------------------------------------
+
+
+def match_overrides(
+    old: list[OldWorkSnapshot],
+    new: list[NewWorkRow],
+    *,
+    gallery_scope: Optional[set[str]] = None,
+) -> MatchPlan:
+    """Compute the override-preservation plan for a re-import.
+
+    Pure function: no I/O. Given the old DB state and the new spreadsheet
+    rows, returns a ``MatchPlan`` describing which overrides would be
+    preserved (and via which mechanism), which would be lost, and which
+    require human disambiguation.
+
+    Algorithm
+    ---------
+    Two passes. The first preserves the historical "match by cat_no"
+    behaviour for the common case — but *only* when the fingerprint also
+    agrees, closing today's silent-misapplication bug. The second covers the
+    renumber case by matching on fingerprint alone.
+
+    1. **Cat-no pass.** For each preserved entry, look for a new row with
+       the same cat_no. If found and fingerprints agree, mark matched. If
+       fingerprints differ → ambiguous (cat-no collision, content mismatch).
+       Old works outside ``gallery_scope`` are skipped entirely; the entry
+       is dropped from ``preserve`` before this pass so it can't even be
+       considered.
+    2. **Fingerprint pass.** For each preserved entry not yet matched (and
+       still in scope), look for unmatched new rows with the same fingerprint
+       in scope. Exactly one → fingerprint match. More than one → ambiguous.
+       Zero → unmatched (override will be lost unless re-applied).
+
+    Cross-gallery moves are detected as a side effect of the fingerprint
+    pass: if a new in-scope row's fingerprint matches an old work that's in
+    a non-scope gallery, that's a warning (user should extend the scope).
+
+    Gallery summary (for the UI picker) is computed up front from the new
+    spreadsheet alone.
+    """
+    plan = MatchPlan()
+
+    # ------------------------------------------------------------------
+    # 0. Gallery summary — drives the UI picker independently of matching
+    # ------------------------------------------------------------------
+    plan.galleries = _build_gallery_summary(new, gallery_scope)
+
+    # ------------------------------------------------------------------
+    # Scope filtering: split old into in-scope / out-of-scope, and the
+    # new rows similarly. Out-of-scope new rows are ignored (they belong
+    # to galleries the user hasn't selected for re-import and don't appear
+    # in the new spreadsheet's scope). Out-of-scope old works keep their
+    # current state regardless — the matcher must not claim them as
+    # "removed" or otherwise act on them.
+    # ------------------------------------------------------------------
+    if gallery_scope is None:
+        in_scope_old = list(old)
+        in_scope_new = list(new)
+        out_of_scope_old = []
+    else:
+        in_scope_old = [w for w in old if w.gallery in gallery_scope]
+        out_of_scope_old = [w for w in old if w.gallery not in gallery_scope]
+        in_scope_new = [r for r in new if r.gallery in gallery_scope]
+
+    # Index new rows by cat_no and fingerprint for fast lookup. ``new_by_cat``
+    # holds the first row per cat_no (duplicate cat_nos are a separate
+    # importer warning); ``new_by_fp`` is fingerprint → list of indices into
+    # ``in_scope_new`` (the matcher needs to know about collisions).
+    new_by_cat: dict[str, int] = {}
+    new_by_fp: dict[Fingerprint, list[int]] = {}
+    for i, row in enumerate(in_scope_new):
+        if row.cat_no and row.cat_no not in new_by_cat:
+            new_by_cat[row.cat_no] = i
+        new_by_fp.setdefault(row.fingerprint, []).append(i)
+
+    matched_new_indices: set[int] = set()
+
+    # ------------------------------------------------------------------
+    # Pass 1: cat-no match, gated on fingerprint agreement
+    # ------------------------------------------------------------------
+    pending_old: list[OldWorkSnapshot] = []  # entries to retry in pass 2
+    for old_w in in_scope_old:
+        if not old_w.cat_no:
+            pending_old.append(old_w)
+            continue
+        new_idx = new_by_cat.get(old_w.cat_no)
+        if new_idx is None:
+            pending_old.append(old_w)
+            continue
+        new_row = in_scope_new[new_idx]
+        if new_row.fingerprint == old_w.fingerprint:
+            # Strong match — same cat_no AND same content
+            matched_new_indices.add(new_idx)
+            plan.matched.append(
+                MatchedItem(
+                    old_cat_no=old_w.cat_no,
+                    new_cat_no=new_row.cat_no,
+                    new_row_index=new_idx,
+                    via="cat_no",
+                    raw_title=old_w.raw_title,
+                    raw_artist=old_w.raw_artist,
+                    had_override=bool(old_w.override),
+                )
+            )
+            plan.matched_by_cat_no += 1
+            if old_w.override:
+                plan.overrides_preserved += 1
+            continue
+        # Cat-no matches but content differs — this is exactly the case
+        # the historical bug fired on. Don't restore; defer to pass 2 in
+        # case the same content appears at a different cat_no. The
+        # collision itself becomes an ambiguous-item warning IF pass 2
+        # doesn't find a unique fingerprint match.
+        pending_old.append(old_w)
+
+    # ------------------------------------------------------------------
+    # Pass 2: fingerprint fallback for everything still unmatched
+    # ------------------------------------------------------------------
+    for old_w in pending_old:
+        # Try the strong (3-field) fingerprint first
+        candidates = [
+            i for i in new_by_fp.get(old_w.fingerprint, []) if i not in matched_new_indices
+        ]
+        if len(candidates) == 1:
+            new_idx = candidates[0]
+            new_row = in_scope_new[new_idx]
+            matched_new_indices.add(new_idx)
+            plan.matched.append(
+                MatchedItem(
+                    old_cat_no=old_w.cat_no,
+                    new_cat_no=new_row.cat_no,
+                    new_row_index=new_idx,
+                    via="fingerprint",
+                    raw_title=old_w.raw_title,
+                    raw_artist=old_w.raw_artist,
+                    had_override=bool(old_w.override),
+                )
+            )
+            plan.matched_by_fingerprint += 1
+            if old_w.override:
+                plan.overrides_preserved += 1
+            continue
+
+        if len(candidates) > 1:
+            plan.ambiguous.append(
+                AmbiguousItem(
+                    old_cat_no=old_w.cat_no,
+                    raw_title=old_w.raw_title,
+                    raw_artist=old_w.raw_artist,
+                    candidate_new_cat_nos=[in_scope_new[i].cat_no for i in candidates],
+                    reason="fingerprint_collision",
+                )
+            )
+            if old_w.override:
+                plan.overrides_at_risk += 1
+            continue
+
+        # No fingerprint match. If the cat-no was occupied by a content
+        # mismatch in pass 1, surface that specifically — it's a different
+        # signal than "the work just isn't in the new file at all".
+        cat_collision_new_idx = (
+            new_by_cat.get(old_w.cat_no) if old_w.cat_no else None
+        )
+        if (
+            cat_collision_new_idx is not None
+            and cat_collision_new_idx not in matched_new_indices
+        ):
+            collision_row = in_scope_new[cat_collision_new_idx]
+            plan.ambiguous.append(
+                AmbiguousItem(
+                    old_cat_no=old_w.cat_no,
+                    raw_title=old_w.raw_title,
+                    raw_artist=old_w.raw_artist,
+                    candidate_new_cat_nos=[collision_row.cat_no],
+                    reason="cat_no_match_fingerprint_mismatch",
+                )
+            )
+            if old_w.override:
+                plan.overrides_at_risk += 1
+            continue
+
+        plan.unmatched.append(
+            UnmatchedItem(
+                old_cat_no=old_w.cat_no,
+                raw_title=old_w.raw_title,
+                raw_artist=old_w.raw_artist,
+                had_override=bool(old_w.override),
+                reason="no_fingerprint_match",
+            )
+        )
+        if old_w.override:
+            plan.overrides_at_risk += 1
+
+    # ------------------------------------------------------------------
+    # Cross-gallery move detection (scope-only). For any new in-scope row
+    # whose fingerprint matches an old work in a non-scope gallery, warn.
+    # If we didn't warn, the importer would create a new work in the
+    # selected gallery while the old work stayed put outside the scope —
+    # silent duplication.
+    # ------------------------------------------------------------------
+    if gallery_scope is not None:
+        out_of_scope_by_fp: dict[Fingerprint, OldWorkSnapshot] = {}
+        for w in out_of_scope_old:
+            out_of_scope_by_fp.setdefault(w.fingerprint, w)
+        for i, row in enumerate(in_scope_new):
+            old_w = out_of_scope_by_fp.get(row.fingerprint)
+            if old_w is None:
+                continue
+            plan.cross_gallery_warnings.append(
+                CrossGalleryMoveWarning(
+                    new_cat_no=row.cat_no,
+                    raw_title=row.raw_title,
+                    raw_artist=row.raw_artist,
+                    old_cat_no=old_w.cat_no,
+                    old_gallery=old_w.gallery,
+                    new_gallery=row.gallery,
+                )
+            )
+
+    # ------------------------------------------------------------------
+    # Derived counts
+    # ------------------------------------------------------------------
+    plan.added = len(in_scope_new) - len(matched_new_indices)
+    plan.removed = (
+        len(in_scope_old) - plan.matched_by_cat_no - plan.matched_by_fingerprint
+    )
+
+    return plan
+
+
+def _build_gallery_summary(
+    new: list[NewWorkRow],
+    gallery_scope: Optional[set[str]],
+) -> list[GallerySummary]:
+    """Group new rows by gallery (in first-seen order) and compute the
+    UI-friendly summary: work count, cat-no range, in-scope flag."""
+    by_gallery: dict[str, dict] = {}
+    order: list[str] = []
+    for row in new:
+        g = row.gallery or "Uncategorised"
+        if g not in by_gallery:
+            order.append(g)
+            by_gallery[g] = {"count": 0, "cat_nos": []}
+        by_gallery[g]["count"] += 1
+        # Best-effort numeric cat_no for range display; non-numeric ignored
+        try:
+            n = int(str(row.cat_no).strip())
+            by_gallery[g]["cat_nos"].append(n)
+        except (TypeError, ValueError):
+            pass
+
+    summaries: list[GallerySummary] = []
+    for pos, name in enumerate(order, start=1):
+        info = by_gallery[name]
+        cat_nos = info["cat_nos"]
+        in_scope = gallery_scope is None or name in gallery_scope
+        summaries.append(
+            GallerySummary(
+                name=name,
+                position=pos,
+                work_count=info["count"],
+                cat_no_min=min(cat_nos) if cat_nos else None,
+                cat_no_max=max(cat_nos) if cat_nos else None,
+                in_scope=in_scope,
+            )
+        )
+    return summaries

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3625,21 +3625,231 @@ async function handleDelete(id, filename, btnEl) {
   }
 }
 
-async function handleReimport(importId, file) {
+// Per-import preview state. Holds the selected file, the most recent plan
+// returned by the backend, and the user's gallery-scope selection. Reset by
+// _resetReimportPreview() (e.g. after a successful commit or when the file
+// input is cleared).
+let _reimportState = null;
+
+function _resetReimportPreview() {
+  _reimportState = null;
+  const preview = document.getElementById('reimport-preview');
+  if (preview) { preview.style.display = 'none'; preview.innerHTML = ''; }
   const statusEl = document.getElementById('reimport-status');
-  const btn = document.querySelector('#reimport-form .btn-primary');
+  if (statusEl) { statusEl.textContent = ''; statusEl.className = 'status-msg'; }
+}
+
+// Light debounce so toggling several checkboxes in quick succession only
+// fires one scoped dry-run request.
+let _reimportRefreshTimer = null;
+function _scheduleScopedRefresh(importId) {
+  if (_reimportRefreshTimer) clearTimeout(_reimportRefreshTimer);
+  _reimportRefreshTimer = setTimeout(
+    () => _refreshScopedPlan(importId).catch(() => {}), 250
+  );
+}
+
+async function _fetchReimportPlan(importId, file, { dryRun, galleries }) {
+  // Build the query string. ``galleries`` is a Set; the server takes
+  // comma-separated names. Server-side URL parsing handles encoding.
+  const params = new URLSearchParams();
+  if (dryRun) params.set('dry_run', 'true');
+  if (galleries && galleries.size > 0) {
+    params.set('galleries', Array.from(galleries).join(','));
+  }
+  const url = `/imports/${importId}/reimport${params.toString() ? '?' + params : ''}`;
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(url, { method: 'PUT', body: form, headers: _apiHeaders() });
+  if (res.status === 401) { renderLogin('Invalid or missing API key.'); throw new Error('Auth'); }
+  if (!res.ok) { const t = await res.text(); throw new Error(t); }
+  return await res.json();
+}
+
+async function _startReimportPreview(importId, file) {
+  const preview = document.getElementById('reimport-preview');
+  preview.style.display = '';
+  preview.innerHTML = '<p class="loading">Reading spreadsheet\u2026</p>';
+  try {
+    // Initial dry-run with no gallery filter \u2014 gives us the gallery list
+    // (with cat ranges) AND a baseline "everything in scope" plan.
+    const plan = await _fetchReimportPlan(importId, file, { dryRun: true });
+    _reimportState = {
+      importId,
+      file,
+      plan,
+      // Default selection: every gallery in the new spreadsheet.
+      selectedGalleries: new Set(plan.galleries.map(g => g.name)),
+    };
+    _renderReimportPreview();
+  } catch (err) {
+    if (err.message === 'Auth') return;
+    preview.innerHTML = `<p class="status-msg error">Preview failed: ${esc(err.message)}</p>`;
+  }
+}
+
+async function _refreshScopedPlan(importId) {
+  if (!_reimportState) return;
+  const { file, selectedGalleries } = _reimportState;
+  const summaryEl = document.querySelector('#reimport-preview .reimport-plan-summary');
+  if (summaryEl) summaryEl.innerHTML = '<p class="muted">Recomputing\u2026</p>';
+  try {
+    const plan = await _fetchReimportPlan(importId, file, {
+      dryRun: true,
+      galleries: selectedGalleries,
+    });
+    _reimportState.plan = plan;
+    _renderReimportPreview();
+  } catch (err) {
+    if (err.message === 'Auth') return;
+    if (summaryEl) summaryEl.innerHTML = `<p class="status-msg error">${esc(err.message)}</p>`;
+  }
+}
+
+function _renderReimportPreview() {
+  const { plan, selectedGalleries } = _reimportState;
+  const preview = document.getElementById('reimport-preview');
+
+  // Gallery table \u2014 uses .data-table for shared visual treatment, no new
+  // selectors are introduced (see frontend-class-blast-map memory).
+  const rows = plan.galleries.map(g => {
+    const checked = selectedGalleries.has(g.name) ? ' checked' : '';
+    const range = (g.cat_no_min !== null && g.cat_no_max !== null)
+      ? (g.cat_no_min === g.cat_no_max
+          ? `number ${g.cat_no_min}`
+          : `numbers ${g.cat_no_min}\u2013${g.cat_no_max}`)
+      : '\u2014';
+    return `<tr>
+      <td><input type="checkbox" class="reimport-gallery-cb" data-gallery="${esc(g.name)}"${checked}></td>
+      <td>${g.position}</td>
+      <td>${esc(g.name)}</td>
+      <td style="text-align:right">${g.work_count}</td>
+      <td>${range}</td>
+    </tr>`;
+  }).join('');
+
+  // Plan summary \u2014 counts plus a finding-by-finding breakdown for any
+  // override at risk (unmatched, ambiguous, cross-gallery moves).
+  const counts = [];
+  counts.push(`${plan.matched_by_cat_no + plan.matched_by_fingerprint} matched`);
+  if (plan.matched_by_fingerprint) {
+    counts.push(`${plan.matched_by_fingerprint} via fingerprint (renumbered)`);
+  }
+  if (plan.added) counts.push(`${plan.added} new`);
+  if (plan.removed) counts.push(`${plan.removed} removed`);
+  if (plan.overrides_preserved) counts.push(`${plan.overrides_preserved} overrides preserved`);
+  if (plan.overrides_at_risk) counts.push(`<strong>${plan.overrides_at_risk} overrides at risk</strong>`);
+
+  const findingsBlocks = [];
+  if (plan.cross_gallery_warnings.length) {
+    findingsBlocks.push(`
+      <div class="reimport-findings-block">
+        <h6>Cross-gallery moves \u2014 extend the selection or these will duplicate</h6>
+        <ul class="reimport-findings-list">${
+          plan.cross_gallery_warnings.map(w => `<li>${esc(w.raw_title || '(no title)')} \u2014 currently in <em>${esc(w.old_gallery)}</em> (cat ${esc(w.old_cat_no)}), new file places in <em>${esc(w.new_gallery)}</em> (cat ${esc(w.new_cat_no)})</li>`).join('')
+        }</ul>
+      </div>`);
+  }
+  if (plan.ambiguous.length) {
+    findingsBlocks.push(`
+      <div class="reimport-findings-block">
+        <h6>Ambiguous \u2014 the matcher refuses to guess; review manually</h6>
+        <ul class="reimport-findings-list">${
+          plan.ambiguous.map(a => `<li>old cat ${esc(a.old_cat_no)} \u2014 ${esc(a.raw_title || '(no title)')} by ${esc(a.raw_artist || '?')} \u2014 ${esc(a.reason.replace(/_/g, ' '))} (candidates: ${a.candidate_new_cat_nos.map(esc).join(', ')})</li>`).join('')
+        }</ul>
+      </div>`);
+  }
+  if (plan.unmatched.length) {
+    findingsBlocks.push(`
+      <div class="reimport-findings-block">
+        <h6>Unmatched \u2014 overrides will be lost unless you re-apply</h6>
+        <ul class="reimport-findings-list">${
+          plan.unmatched.map(u => `<li>old cat ${esc(u.old_cat_no)} \u2014 ${esc(u.raw_title || '(no title)')} by ${esc(u.raw_artist || '?')}${u.had_override ? ' \u2014 <strong>has override</strong>' : ''}</li>`).join('')
+        }</ul>
+      </div>`);
+  }
+
+  const selectedCount = selectedGalleries.size;
+  const totalCount = plan.galleries.length;
+  const confirmLabel = selectedCount === totalCount
+    ? `Re-import all ${totalCount} galleries`
+    : `Re-import ${selectedCount} of ${totalCount} galleries`;
+
+  preview.innerHTML = `
+    <h5 style="margin:0 0 8px">Galleries in the new spreadsheet</h5>
+    <table class="data-table reimport-gallery-table" style="margin-bottom:10px">
+      <thead><tr>
+        <th style="width:28px"></th>
+        <th style="width:40px">#</th>
+        <th>Gallery</th>
+        <th style="text-align:right;width:60px">Works</th>
+        <th style="width:140px">Cat numbers</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <div style="margin-bottom:10px;font-size:12px">
+      <button type="button" class="btn btn-xs btn-secondary" id="reimport-select-all">Select all</button>
+      <button type="button" class="btn btn-xs btn-secondary" id="reimport-select-none">Clear</button>
+    </div>
+    <div class="reimport-plan-summary" style="margin-bottom:10px;padding:8px 10px;background:#f4f4f4;border-radius:4px;font-size:13px">
+      ${counts.join(' \u00b7 ')}
+    </div>
+    ${findingsBlocks.join('')}
+    <div style="margin-top:12px">
+      <button type="button" class="btn btn-primary" id="reimport-confirm"${selectedCount === 0 ? ' disabled' : ''}>${confirmLabel}</button>
+      <button type="button" class="btn btn-secondary" id="reimport-cancel" style="margin-left:8px">Cancel</button>
+    </div>
+  `;
+
+  // Wire up
+  preview.querySelectorAll('.reimport-gallery-cb').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const name = cb.dataset.gallery;
+      if (cb.checked) _reimportState.selectedGalleries.add(name);
+      else _reimportState.selectedGalleries.delete(name);
+      _scheduleScopedRefresh(_reimportState.importId);
+    });
+  });
+  preview.querySelector('#reimport-select-all')?.addEventListener('click', () => {
+    _reimportState.selectedGalleries = new Set(_reimportState.plan.galleries.map(g => g.name));
+    _scheduleScopedRefresh(_reimportState.importId);
+  });
+  preview.querySelector('#reimport-select-none')?.addEventListener('click', () => {
+    _reimportState.selectedGalleries = new Set();
+    _scheduleScopedRefresh(_reimportState.importId);
+  });
+  preview.querySelector('#reimport-cancel')?.addEventListener('click', () => {
+    document.getElementById('reimport-file').value = '';
+    _resetReimportPreview();
+  });
+  preview.querySelector('#reimport-confirm')?.addEventListener('click', () => {
+    _commitReimport();
+  });
+}
+
+async function _commitReimport() {
+  if (!_reimportState) return;
+  const { importId, file, selectedGalleries, plan } = _reimportState;
+
+  // Belt-and-braces confirm if there are overrides at risk
+  if (plan.overrides_at_risk > 0) {
+    const ok = window.confirm(
+      `${plan.overrides_at_risk} override${plan.overrides_at_risk === 1 ? '' : 's'} will be lost or are ambiguous and won\u2019t be re-applied. ` +
+      `Continue anyway? You\u2019ll need to re-apply them manually after.`
+    );
+    if (!ok) return;
+  }
+
+  const btn = document.getElementById('reimport-confirm');
   const restore = btnLoading(btn, 'Re-importing');
+  const statusEl = document.getElementById('reimport-status');
   statusEl.textContent = 'Re-importing\u2026';
   statusEl.className = 'status-msg';
   try {
-    const form = new FormData();
-    form.append('file', file);
-    const res = await fetch(`/imports/${importId}/reimport`, {
-      method: 'PUT', body: form, headers: _apiHeaders(),
+    const data = await _fetchReimportPlan(importId, file, {
+      dryRun: false,
+      galleries: selectedGalleries,
     });
-    if (res.status === 401) { renderLogin('Invalid or missing API key.'); return; }
-    if (!res.ok) { const t = await res.text(); throw new Error(t); }
-    const data = await res.json();
     const parts = [];
     if (data.matched)  parts.push(`${data.matched} matched`);
     if (data.added)    parts.push(`${data.added} added`);
@@ -3650,9 +3860,10 @@ async function handleReimport(importId, file) {
     statusEl.className = 'status-msg success';
     showToast(`Re-import complete: ${summary}`, 'success', 5000);
     document.getElementById('reimport-file').value = '';
-    // Refresh the detail view to show updated data
+    _resetReimportPreview();
     await renderDetail(importId);
   } catch (err) {
+    if (err.message === 'Auth') return;
     statusEl.textContent = `Re-import failed: ${err.message}`;
     statusEl.className = 'status-msg error';
     showToast(`Re-import failed: ${err.message}`, 'error');
@@ -3735,13 +3946,11 @@ async function renderDetail(importId) {
         </section>
         ${ifEditor(`<section class="tool-block reimport-panel">
           <h4>Update Import</h4>
-          <p class="muted" style="font-size:12px;margin-bottom:10px">Select an updated version of the same spreadsheet. Existing overrides and exclusions will be preserved where possible.</p>
-          <form id="reimport-form" class="upload-form">
-            <input type="file" id="reimport-file" accept=".xlsx,.xls" required>
-            <button type="submit" class="btn btn-primary">Re-import</button>
-          </form>
+          <p class="muted" style="font-size:12px;margin-bottom:10px">Select an updated version of the spreadsheet. A preview shows which galleries you can choose to update; overrides on works whose content (title/artist/medium) hasn\u2019t changed are preserved, even if their catalogue number shifted.</p>
+          <input type="file" id="reimport-file" accept=".xlsx,.xls">
           <p id="reimport-warn" class="status-msg" style="margin-top:4px;display:none"></p>
           <p id="reimport-status" class="status-msg" style="margin-top:8px"></p>
+          <div id="reimport-preview" style="display:none;margin-top:14px"></div>
         </section>`)}
         ${ifEditor(`<section class="tool-block" id="reconcile-panel">
           <h4>Reconcile corrected LOW</h4>
@@ -3771,11 +3980,18 @@ async function renderDetail(importId) {
     </section>
     <section class="panel" id="audit-panel"><p class="loading">Loading audit log\u2026</p></section>`;
 
-  // Wire up re-import form
-  document.getElementById('reimport-form')?.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const file = document.getElementById('reimport-file').files[0];
-    if (file) await handleReimport(importId, file);
+  // Wire up the re-import preview flow. File selection triggers a dry-run
+  // (no gallery filter) that returns the list of galleries with cat ranges,
+  // plus the full match plan; the preview UI lets the user pick which
+  // galleries to scope the commit to, and shows a scoped re-run of the plan
+  // before the actual confirm.
+  document.getElementById('reimport-file')?.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      _startReimportPreview(importId, file);
+    } else {
+      _resetReimportPreview();
+    }
   });
 
   // Fetch import metadata for filename mismatch detection + heading

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -156,14 +156,23 @@ class TestReimportBasic:
 
     def test_reimport_returns_correct_stats(self, client):
         import_id = _do_import(client)
-        # Original: cat_no 1, 2, 3
-        # Reimport: cat_no 1, 2, 4 → matched=2/added=1/removed=1
-
+        # Original: cat 1 "Sunset", cat 2 "Dawn", cat 3 "Noon"
+        # Reimport: cat 1 "Sunset UPDATED" (title changed!), cat 2 "Dawn", cat 4 "New Work"
+        #
+        # Matcher behaviour:
+        #   cat 2: cat_no AND fingerprint match → matched_by_cat_no = 1
+        #   cat 1: cat_no matches but fingerprint differs (title edit) → refused
+        #          (this is the silent-misapplication guard)
+        #   cat 4: new content with no preserved fingerprint → added
+        #   cat 1 "Sunset UPDATED" also counts as added (no preserved match)
+        #   old cat 1 "Sunset" and old cat 3 "Noon" both have no target → removed = 2
         r = _do_reimport(client, import_id)
         data = r.json()
-        assert data["matched"] == 2
-        assert data["added"] == 1
-        assert data["removed"] == 1
+        assert data["matched"] == 1
+        assert data["matched_by_cat_no"] == 1
+        assert data["matched_by_fingerprint"] == 0
+        assert data["added"] == 2
+        assert data["removed"] == 2
 
     def test_reimport_updates_filename(self, client):
         import_id = _do_import(client)
@@ -199,31 +208,32 @@ class TestReimportOverridePreservation:
         import_id = _do_import(client)
         sections = _get_sections(client, import_id)
         all_works = [w for s in sections for w in s["works"]]
-        work1 = next(w for w in all_works if w["raw_cat_no"] == "1")
+        # cat 2 "Dawn" has identical content (title/artist/medium) between the
+        # original import and the re-import — the cat-no match passes the
+        # fingerprint gate, so the override is preserved. cat 1's title is
+        # edited in the re-import, which would deliberately fail the
+        # fingerprint gate; see test_override_NOT_preserved_when_content_changed.
+        work2 = next(w for w in all_works if w["raw_cat_no"] == "2")
 
-        # Set an override on cat_no 1
         _set_override(
             client,
             import_id,
-            work1["id"],
+            work2["id"],
             title_override="Custom Title",
             price_numeric_override=999.0,
         )
 
-        # Reimport — cat_no 1 still exists
         r = _do_reimport(client, import_id)
         data = r.json()
-        assert (
-            data["overrides_preserved"] == 1
-        )  # only cat_no 1 had an override (2 matched but only 1 has override)
+        assert data["overrides_preserved"] == 1
+        assert data["matched_by_cat_no"] >= 1  # cat 2 matched cleanly
 
-        # Verify override is still there
         sections = _get_sections(client, import_id)
         all_works = [w for s in sections for w in s["works"]]
-        work1_new = next(w for w in all_works if w["raw_cat_no"] == "1")
-        assert work1_new["override"] is not None
-        assert work1_new["override"]["title_override"] == "Custom Title"
-        assert work1_new["override"]["price_numeric_override"] == 999.0
+        work2_new = next(w for w in all_works if w["raw_cat_no"] == "2")
+        assert work2_new["override"] is not None
+        assert work2_new["override"]["title_override"] == "Custom Title"
+        assert work2_new["override"]["price_numeric_override"] == 999.0
 
     def test_override_multiple_fields_preserved(self, client):
         import_id = _do_import(client)
@@ -257,30 +267,31 @@ class TestReimportOverridePreservation:
         import_id = _do_import(client)
         sections = _get_sections(client, import_id)
         all_works = [w for s in sections for w in s["works"]]
-        work1 = next(w for w in all_works if w["raw_cat_no"] == "1")
+        # cat 2 — content unchanged across re-import, so the exclusion is
+        # carried over cleanly. (Excluding cat 1 here wouldn't survive
+        # re-import because cat 1's title is edited — the matcher correctly
+        # refuses to transplant the include_in_export flag onto a different
+        # work that happens to share its cat number.)
+        work2 = next(w for w in all_works if w["raw_cat_no"] == "2")
 
-        # Exclude cat_no 1 via direct DB update
-        uid = _uuid.UUID(work1["id"])
+        uid = _uuid.UUID(work2["id"])
         w = db_session.query(Work).filter(Work.id == uid).one()
         w.include_in_export = False
         db_session.commit()
 
-        # Verify excluded
         sections = _get_sections(client, import_id)
-        work1_check = next(
-            w for s in sections for w in s["works"] if w["raw_cat_no"] == "1"
+        work2_check = next(
+            w for s in sections for w in s["works"] if w["raw_cat_no"] == "2"
         )
-        assert work1_check["include_in_export"] is False
+        assert work2_check["include_in_export"] is False
 
-        # Reimport
         _do_reimport(client, import_id)
 
-        # Exclusion should be preserved
         sections = _get_sections(client, import_id)
-        work1_after = next(
-            w for s in sections for w in s["works"] if w["raw_cat_no"] == "1"
+        work2_after = next(
+            w for s in sections for w in s["works"] if w["raw_cat_no"] == "2"
         )
-        assert work1_after["include_in_export"] is False
+        assert work2_after["include_in_export"] is False
 
     def test_override_lost_for_removed_work(self, client):
         import_id = _do_import(client)
@@ -288,14 +299,26 @@ class TestReimportOverridePreservation:
         all_works = [w for s in sections for w in s["works"]]
         work3 = next(w for w in all_works if w["raw_cat_no"] == "3")
 
-        # Set override on cat_no 3, which will be removed in reimport
+        # Set override on cat_no 3, which is genuinely removed in reimport
+        # (no cat_no 3 in new file, and no fingerprint match for "Noon"
+        # by Alice either).
         _set_override(client, import_id, work3["id"], title_override="Will Be Lost")
 
         r = _do_reimport(client, import_id)
         data = r.json()
-        # cat_no 3 is not in the new spreadsheet, so override is not preserved
-        assert data["removed"] == 1
+        # cat_no 3 ("Noon") has no target in the new file (neither by cat-no
+        # nor by fingerprint), so the override is lost. cat_no 1 ("Sunset")
+        # also has no target after the title edit, so removed = 2 — both
+        # appear in the unmatched list of the plan.
+        assert data["removed"] == 2
         assert data["overrides_preserved"] == 0
+        # And the cat 3 override appears in the unmatched/ambiguous list so
+        # the user knows what was lost.
+        flagged_cat_nos = (
+            {u["old_cat_no"] for u in data["unmatched"]}
+            | {a["old_cat_no"] for a in data["ambiguous"]}
+        )
+        assert "3" in flagged_cat_nos
 
     def test_no_overrides_all_new(self, client):
         import_id = _do_import(client)
@@ -403,23 +426,29 @@ class TestReimportEdgeCases:
         assert data["matched"] == 0
 
     def test_reimport_duplicate_cat_no_in_new_spreadsheet(self, client):
-        """If the new spreadsheet has duplicate cat_nos, only the first gets the override."""
+        """If the new spreadsheet has duplicate cat_nos, only the first
+        row whose content also fingerprints to the preserved entry gets
+        the override. The other duplicate row is treated as a new addition.
+        """
         import_id = _do_import(client)
         sections = _get_sections(client, import_id)
         all_works = [w for s in sections for w in s["works"]]
         work1 = next(w for w in all_works if w["raw_cat_no"] == "1")
         _set_override(client, import_id, work1["id"], title_override="Keep This")
 
-        # Reimport with two rows having cat_no 1
+        # Reimport with two rows having cat_no 1 — the FIRST has content
+        # matching the preserved entry (so the cat-no match passes the
+        # fingerprint gate); the second has different content.
         rows = [
-            [1, "Gallery A", "First", "Artist A", "100", None, None, None],
+            [1, "Gallery A", "Sunset", "Jane Doe", "100", None, None, "Oil"],
             [1, "Gallery A", "Second (duplicate)", "Artist B", "200", None, None, None],
         ]
         r = _do_reimport(client, import_id, rows=rows)
         data = r.json()
         assert data["overrides_preserved"] == 1
 
-        # Only the first row with cat_no 1 should have the override
+        # Only the first row with cat_no 1 (which matched by content) gets
+        # the override; the duplicate is a fresh row.
         sections = _get_sections(client, import_id)
         all_works = [w for s in sections for w in s["works"]]
         works_with_cat1 = [w for w in all_works if w["raw_cat_no"] == "1"]
@@ -427,6 +456,7 @@ class TestReimportEdgeCases:
         overridden = [w for w in works_with_cat1 if w["override"] is not None]
         assert len(overridden) == 1
         assert overridden[0]["override"]["title_override"] == "Keep This"
+        assert overridden[0]["raw_title"] == "Sunset"  # the matched row, not the dup
 
 
 class TestReimportAuditAndWarnings:
@@ -491,3 +521,210 @@ class TestReimportAuditAndWarnings:
         all_works = [w for s in sections for w in s["works"]]
         work1_final = next(w for w in all_works if w["raw_cat_no"] == "1")
         assert work1_final["override"]["title_override"] == "After First Reimport"
+
+
+# =========================================================================== #
+# Dry-run, gallery scope, and the silent-misapplication regression
+# =========================================================================== #
+
+
+class TestReimportDryRun:
+    """The dry_run query param should compute the plan but make no changes."""
+
+    def test_dry_run_returns_plan_without_mutating(self, client):
+        import_id = _do_import(client)
+        sections_before = _get_sections(client, import_id)
+        snapshot_before = [
+            (w["raw_cat_no"], w["raw_title"], w.get("raw_artist"))
+            for s in sections_before for w in s["works"]
+        ]
+
+        buf = _make_xlsx(
+            ALL_HEADERS,
+            [
+                [1, "Gallery A", "Sunset UPDATED", "Jane Doe", "600", None, None, "Oil"],
+                [2, "Gallery A", "Dawn", "John Smith RA", "1200", None, None, "Acrylic"],
+                [4, "Gallery A", "New Work", "Bob", "300", None, None, "Pastel"],
+            ],
+        )
+        r = client.put(
+            f"/imports/{import_id}/reimport?dry_run=true",
+            files={
+                "file": (
+                    "preview.xlsx", buf,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["dry_run"] is True
+        # Plan reports the same counts as a real re-import would
+        assert data["matched_by_cat_no"] == 1   # cat 2 only
+        assert data["added"] == 2
+        assert data["removed"] == 2
+
+        # DB state must be identical to before the dry-run
+        sections_after = _get_sections(client, import_id)
+        snapshot_after = [
+            (w["raw_cat_no"], w["raw_title"], w.get("raw_artist"))
+            for s in sections_after for w in s["works"]
+        ]
+        assert snapshot_before == snapshot_after
+
+    def test_dry_run_returns_gallery_summary(self, client):
+        import_id = _do_import(client)
+        buf = _make_xlsx(
+            ALL_HEADERS,
+            [
+                [1, "Gallery A", "X", "A", "100", None, None, None],
+                [2, "Gallery A", "Y", "A", "100", None, None, None],
+                [3, "Gallery B", "Z", "B", "100", None, None, None],
+            ],
+        )
+        r = client.put(
+            f"/imports/{import_id}/reimport?dry_run=true",
+            files={"file": ("p.xlsx", buf,
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+        )
+        assert r.status_code == 200
+        gs = r.json()["galleries"]
+        assert len(gs) == 2
+        by_name = {g["name"]: g for g in gs}
+        assert by_name["Gallery A"]["work_count"] == 2
+        assert by_name["Gallery A"]["cat_no_min"] == 1
+        assert by_name["Gallery A"]["cat_no_max"] == 2
+        assert by_name["Gallery A"]["in_scope"] is True   # no filter → all in scope
+        assert by_name["Gallery B"]["work_count"] == 1
+
+
+class TestReimportGalleryScope:
+    """Selective re-import: out-of-scope galleries stay physically untouched."""
+
+    def test_scope_leaves_out_of_scope_galleries_intact(self, client, db_session):
+        import_id = _do_import(client)
+        # Original has Gallery A (cat 1,2) and Gallery B (cat 3)
+
+        # Override on cat 3 (Gallery B) — must survive a scoped re-import of A only
+        sections = _get_sections(client, import_id)
+        all_works = [w for s in sections for w in s["works"]]
+        work3 = next(w for w in all_works if w["raw_cat_no"] == "3")
+        _set_override(client, import_id, work3["id"], title_override="B-only override")
+
+        # Re-import a NEW spreadsheet that only touches Gallery A
+        buf = _make_xlsx(
+            ALL_HEADERS,
+            [
+                # Gallery A rebuilt with one extra work
+                [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+                [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+                [10, "Gallery A", "Newbie", "Bob", "200", None, None, "Pastel"],
+                # The new file also has a Gallery B row but we DON'T scope it in
+                [3, "Gallery B", "Noon REPLACED", "Different Artist", "999", None, None, None],
+            ],
+        )
+        r = client.put(
+            f"/imports/{import_id}/reimport?galleries=Gallery+A",
+            files={"file": ("scoped.xlsx", buf,
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+        )
+        assert r.status_code == 200, r.text
+
+        # Gallery B should be UNCHANGED — same cat 3 work, same override
+        sections = _get_sections(client, import_id)
+        b = next(s for s in sections if s["name"] == "Gallery B")
+        assert len(b["works"]) == 1
+        cat3 = b["works"][0]
+        assert cat3["raw_cat_no"] == "3"
+        assert cat3["raw_title"] == "Noon"  # not "Noon REPLACED" — out of scope
+        assert cat3["override"]["title_override"] == "B-only override"
+
+        # Gallery A rebuilt
+        a = next(s for s in sections if s["name"] == "Gallery A")
+        a_cats = sorted(w["raw_cat_no"] for w in a["works"])
+        assert a_cats == ["1", "10", "2"]
+
+    def test_scope_detects_cross_gallery_move(self, client):
+        """A work moving from Gallery B into the selected Gallery A scope
+        should generate a cross-gallery warning so the user can extend the
+        scope (otherwise the work would silently duplicate)."""
+        import_id = _do_import(client)
+        # Original cat 3 "Noon" by Alice is in Gallery B.
+        # New file moves it into Gallery A.
+        buf = _make_xlsx(
+            ALL_HEADERS,
+            [
+                [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+                [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+                [3, "Gallery A", "Noon", "Alice", "NFS", None, None, None],  # moved
+            ],
+        )
+        r = client.put(
+            f"/imports/{import_id}/reimport?galleries=Gallery+A&dry_run=true",
+            files={"file": ("move.xlsx", buf,
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+        )
+        assert r.status_code == 200
+        warnings = r.json()["cross_gallery_warnings"]
+        assert any(
+            w["raw_title"] == "Noon" and w["old_gallery"] == "Gallery B"
+            and w["new_gallery"] == "Gallery A"
+            for w in warnings
+        )
+
+
+class TestReimportSilentMisapplicationRegression:
+    """Pins the fix for the silent-misapplication bug: when cat_no matches
+    but content differs (the renumber case), the override must NOT be
+    transplanted onto the new (different) work."""
+
+    def test_renumber_does_not_transplant_override(self, client):
+        import_id = _do_import(client)
+        # Override on cat 3 "Noon" by Alice
+        sections = _get_sections(client, import_id)
+        all_works = [w for s in sections for w in s["works"]]
+        work3 = next(w for w in all_works if w["raw_cat_no"] == "3")
+        _set_override(
+            client, import_id, work3["id"],
+            title_override="Noon's secret title",
+            price_numeric_override=99999,
+        )
+
+        # New spreadsheet inserts a work at cat 3, pushing Noon to cat 4.
+        # Old behaviour: new cat 3 (different work) inherits Noon's override.
+        # New behaviour: cat-no match refused (fingerprint mismatch), override
+        # follows by fingerprint to the new cat 4.
+        buf = _make_xlsx(
+            ALL_HEADERS,
+            [
+                [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+                [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+                [3, "Gallery B", "Brand New Insertion", "Bob", "1", None, None, None],
+                [4, "Gallery B", "Noon", "Alice", "NFS", None, None, None],
+            ],
+        )
+        r = client.put(
+            f"/imports/{import_id}/reimport",
+            files={"file": ("insert.xlsx", buf,
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["matched_by_fingerprint"] >= 1
+        assert data["overrides_preserved"] == 1
+
+        # The new cat 3 "Brand New Insertion" must NOT have inherited
+        # Noon's override.
+        sections = _get_sections(client, import_id)
+        all_works = [w for s in sections for w in s["works"]]
+        new_cat3 = next(w for w in all_works if w["raw_cat_no"] == "3")
+        assert new_cat3["raw_title"] == "Brand New Insertion"
+        assert new_cat3["override"] is None, (
+            "Noon's override was silently transplanted onto the new cat 3 — the bug"
+        )
+
+        # And the override correctly ended up on the new cat 4 (Noon).
+        new_cat4 = next(w for w in all_works if w["raw_cat_no"] == "4")
+        assert new_cat4["raw_title"] == "Noon"
+        assert new_cat4["override"]["title_override"] == "Noon's secret title"
+        assert new_cat4["override"]["price_numeric_override"] == 99999

--- a/tests/test_reimport_matcher.py
+++ b/tests/test_reimport_matcher.py
@@ -1,0 +1,375 @@
+"""Unit tests for the pure re-import matcher.
+
+The matcher is the safety net for the re-import flow: it decides which
+preserved overrides get restored onto which new works, after a spreadsheet
+re-upload. The motivating bug — silent misapplication of an override onto
+a different work that happens to share a catalogue number after a renumber
+— is pinned here by ``test_silent_misapplication_regression``.
+
+These tests don't touch the DB, the API, or any I/O. They exercise the
+``match_overrides`` function with hand-built ``OldWorkSnapshot`` /
+``NewWorkRow`` lists so each behaviour is isolated.
+"""
+
+from backend.app.services.reimport_matcher import (
+    NewWorkRow,
+    OldWorkSnapshot,
+    compute_fingerprint,
+    match_overrides,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_is_case_and_whitespace_insensitive():
+    a = compute_fingerprint("Cold Dark Matter", "Cornelia Parker", "Mixed Media")
+    b = compute_fingerprint("  COLD  DARK MATTER  ", "cornelia parker", "  mixed media")
+    assert a == b
+
+
+def test_fingerprint_preserves_punctuation():
+    """Punctuation is content, not noise — 'Untitled (after dusk)' and
+    'Untitled after dusk' are different works and must not collide."""
+    a = compute_fingerprint("Untitled (after dusk)", "X", "Y")
+    b = compute_fingerprint("Untitled after dusk", "X", "Y")
+    assert a != b
+
+
+def test_fingerprint_handles_missing_fields():
+    a = compute_fingerprint(None, "X", None)
+    b = compute_fingerprint("", "X", "")
+    assert a == b == ("", "x", "")
+
+
+# ---------------------------------------------------------------------------
+# Builders for tests
+# ---------------------------------------------------------------------------
+
+
+def _old(cat_no, title, artist, medium="oil", gallery="G1", *, override=None,
+         include=True):
+    return OldWorkSnapshot(
+        cat_no=str(cat_no),
+        gallery=gallery,
+        fingerprint=compute_fingerprint(title, artist, medium),
+        include_in_export=include,
+        override=override,
+        raw_title=title,
+        raw_artist=artist,
+    )
+
+
+def _new(cat_no, title, artist, medium="oil", gallery="G1"):
+    return NewWorkRow(
+        cat_no=str(cat_no),
+        gallery=gallery,
+        fingerprint=compute_fingerprint(title, artist, medium),
+        raw_title=title,
+        raw_artist=artist,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: nothing has changed
+# ---------------------------------------------------------------------------
+
+
+def test_clean_reimport_all_cat_no_matches():
+    old = [
+        _old(1, "Sunset", "Jane", override={"price_numeric_override": 500}),
+        _old(2, "Dawn", "John"),
+        _old(3, "Noon", "Alice"),
+    ]
+    new = [
+        _new(1, "Sunset", "Jane"),
+        _new(2, "Dawn", "John"),
+        _new(3, "Noon", "Alice"),
+    ]
+    plan = match_overrides(old, new)
+
+    assert plan.matched_by_cat_no == 3
+    assert plan.matched_by_fingerprint == 0
+    assert plan.overrides_preserved == 1
+    assert plan.overrides_at_risk == 0
+    assert plan.added == 0
+    assert plan.removed == 0
+    assert plan.unmatched == []
+    assert plan.ambiguous == []
+
+
+# ---------------------------------------------------------------------------
+# The motivating scenario: insertion + renumber
+# ---------------------------------------------------------------------------
+
+
+def test_insertion_shifts_cat_nos_fingerprint_recovers_overrides():
+    """Gallery inserts a new work at position 2; everything from old 2
+    onwards shifts +1. Override on old 3 must follow the content (now at
+    cat 4), not the cat number (which is now a different work)."""
+    old = [
+        _old(1, "Sunset", "Jane"),
+        _old(2, "Dawn", "John", override={"price_numeric_override": 1200}),
+        _old(3, "Noon", "Alice", override={"medium_override": "watercolour"}),
+    ]
+    new = [
+        _new(1, "Sunset", "Jane"),
+        _new(2, "Brand New", "Bob"),   # inserted
+        _new(3, "Dawn", "John"),       # was cat 2
+        _new(4, "Noon", "Alice"),      # was cat 3
+    ]
+    plan = match_overrides(old, new)
+
+    # All three old works are accounted for, two via fingerprint
+    assert plan.matched_by_cat_no == 1   # only "Sunset" still at cat 1
+    assert plan.matched_by_fingerprint == 2
+    assert plan.overrides_preserved == 2  # both shifted overrides recovered
+    assert plan.overrides_at_risk == 0
+    assert plan.added == 1               # "Brand New"
+    assert plan.removed == 0
+    assert plan.unmatched == []
+    assert plan.ambiguous == []
+
+    # And specifically: the right overrides end up on the right new cat_nos
+    by_old = {m.old_cat_no: m for m in plan.matched}
+    assert by_old["2"].new_cat_no == "3"
+    assert by_old["2"].via == "fingerprint"
+    assert by_old["3"].new_cat_no == "4"
+    assert by_old["3"].via == "fingerprint"
+
+
+# ---------------------------------------------------------------------------
+# The bug we're fixing — silent misapplication after a renumber
+# ---------------------------------------------------------------------------
+
+
+def test_silent_misapplication_regression():
+    """Historical bug: when cat 2 in the new file is a *different work*
+    from old cat 2 (because of an insertion), the old override should NOT
+    be silently applied to it. With the matcher, the cat-no collision is
+    detected and surfaced as ambiguous (or, when fingerprint recovers the
+    real target elsewhere, simply matched there)."""
+    old = [
+        _old(1, "Sunset", "Jane"),
+        _old(2, "Dawn", "John", override={"price_numeric_override": 9999,
+                                          "title_override": "EXCLUSIVE"}),
+    ]
+    new = [
+        _new(1, "Sunset", "Jane"),
+        _new(2, "Brand New", "Bob"),   # different work at cat 2 — must not steal Dawn's override
+    ]
+    plan = match_overrides(old, new)
+
+    # No matched item should pair Dawn's old cat 2 with the new "Brand New" work
+    for m in plan.matched:
+        if m.old_cat_no == "2":
+            assert m.new_cat_no != "2" or m.via == "fingerprint", (
+                "Old cat 2 override silently restored onto a different work — the bug"
+            )
+        # And vice versa: new cat 2 should not have inherited any override
+        if m.new_cat_no == "2":
+            assert m.old_cat_no != "2", (
+                "New cat 2 (Brand New) inherited an override from old cat 2 (Dawn)"
+            )
+
+    # Dawn's override has no target in the new file, so it should be flagged
+    assert plan.overrides_at_risk >= 1
+    assert any(
+        x.old_cat_no == "2" and x.reason == "cat_no_match_fingerprint_mismatch"
+        for x in plan.ambiguous
+    ), "Cat-no collision with content mismatch should be surfaced as ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# Title edit on a renumbered work — fingerprint fails, override at risk
+# ---------------------------------------------------------------------------
+
+
+def test_title_edit_after_renumber_is_flagged_not_silently_lost():
+    """A renumber AND a title correction on the same work: fingerprint
+    can't find a target, so the override is reported as unmatched. The
+    user can decide whether to re-apply it manually."""
+    old = [
+        _old(1, "Sunset", "Jane"),
+        _old(2, "Untitled (after dust)", "John",
+             override={"price_numeric_override": 1200}),
+        _old(3, "Noon", "Alice"),
+    ]
+    new = [
+        _new(1, "Sunset", "Jane"),
+        _new(2, "Brand New", "Bob"),
+        _new(3, "Untitled (after dusk)", "John"),  # title typo fixed AND renumbered
+        _new(4, "Noon", "Alice"),
+    ]
+    plan = match_overrides(old, new)
+
+    # Sunset and Noon match (cat-no and fingerprint respectively)
+    assert plan.matched_by_cat_no == 1
+    assert plan.matched_by_fingerprint == 1  # Noon (cat 3 → 4)
+
+    # The Untitled-after-dust override should be reported as at-risk
+    assert plan.overrides_at_risk == 1
+    # Either unmatched or ambiguous (depending on whether the cat 2
+    # collision wins) — but never silently matched.
+    flagged_old_cat_nos = {x.old_cat_no for x in plan.unmatched} | {
+        x.old_cat_no for x in plan.ambiguous
+    }
+    assert "2" in flagged_old_cat_nos
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint collision (two new rows match one old)
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_collision_is_ambiguous():
+    """Two new works with identical (title, artist, medium) match one old
+    override by fingerprint — refuse to guess which to attach it to."""
+    old = [
+        _old(99, "Untitled", "Anon", override={"notes": "x"}),
+    ]
+    new = [
+        _new(101, "Untitled", "Anon"),
+        _new(102, "Untitled", "Anon"),
+    ]
+    plan = match_overrides(old, new)
+    assert plan.overrides_preserved == 0
+    assert plan.overrides_at_risk == 1
+    assert any(
+        x.reason == "fingerprint_collision" and x.old_cat_no == "99"
+        for x in plan.ambiguous
+    )
+
+
+# ---------------------------------------------------------------------------
+# Removed works
+# ---------------------------------------------------------------------------
+
+
+def test_removed_work_reported_as_unmatched():
+    old = [
+        _old(1, "Sunset", "Jane"),
+        _old(2, "Dawn", "John", override={"medium_override": "watercolour"}),
+    ]
+    new = [_new(1, "Sunset", "Jane")]
+    plan = match_overrides(old, new)
+    assert plan.removed == 1
+    assert plan.unmatched and plan.unmatched[0].old_cat_no == "2"
+    assert plan.overrides_at_risk == 1
+
+
+# ---------------------------------------------------------------------------
+# Gallery scope
+# ---------------------------------------------------------------------------
+
+
+def test_gallery_scope_excludes_out_of_scope_old_works():
+    """Out-of-scope old works are not considered at risk by the matcher —
+    the importer leaves them physically untouched."""
+    old = [
+        _old(1, "A", "X", gallery="G1", override={"price_numeric_override": 1}),
+        _old(2, "B", "X", gallery="G1"),
+        _old(3, "C", "X", gallery="G2", override={"price_numeric_override": 2}),
+    ]
+    # New file has rows for both galleries but we only re-import G2
+    new = [
+        _new(1, "A", "X", gallery="G1"),  # ignored (out of scope)
+        _new(2, "B", "X", gallery="G1"),  # ignored
+        _new(3, "C", "X", gallery="G2"),
+    ]
+    plan = match_overrides(old, new, gallery_scope={"G2"})
+
+    # Only G2's work participates in matching
+    assert plan.matched_by_cat_no == 1
+    assert plan.overrides_preserved == 1
+    assert plan.removed == 0  # G1 works are not "removed" — they're out of scope
+    assert plan.added == 0
+
+
+def test_gallery_scope_detects_cross_gallery_move():
+    """A work whose fingerprint exists in a non-scope gallery shouldn't be
+    silently duplicated into the selected gallery. The matcher warns."""
+    old = [
+        _old(1, "A", "X", gallery="G1"),     # out of scope
+        _old(5, "Z", "Y", gallery="G2"),     # in scope
+    ]
+    new = [
+        # A new row in G2 looks (by content) like the work currently in G1
+        _new(5, "Z", "Y", gallery="G2"),
+        _new(6, "A", "X", gallery="G2"),     # cross-gallery move into scope
+    ]
+    plan = match_overrides(old, new, gallery_scope={"G2"})
+
+    assert plan.cross_gallery_warnings, "expected a cross-gallery move warning"
+    w = plan.cross_gallery_warnings[0]
+    assert w.new_cat_no == "6"
+    assert w.old_cat_no == "1"
+    assert w.old_gallery == "G1"
+    assert w.new_gallery == "G2"
+
+
+# ---------------------------------------------------------------------------
+# Gallery summary
+# ---------------------------------------------------------------------------
+
+
+def test_gallery_summary_reports_cat_ranges_and_in_scope_flags():
+    new = [
+        _new(1, "A", "X", gallery="The Annenberg Courtyard"),
+        _new(2, "B", "X", gallery="The Annenberg Courtyard"),
+        _new(3, "C", "X", gallery="Gallery I"),
+        _new(4, "D", "X", gallery="Gallery I"),
+        _new(5, "E", "X", gallery="Gallery I"),
+    ]
+    plan = match_overrides([], new, gallery_scope={"Gallery I"})
+
+    assert len(plan.galleries) == 2
+    courtyard = plan.galleries[0]
+    g1 = plan.galleries[1]
+
+    assert courtyard.name == "The Annenberg Courtyard"
+    assert courtyard.position == 1
+    assert courtyard.work_count == 2
+    assert courtyard.cat_no_min == 1
+    assert courtyard.cat_no_max == 2
+    assert courtyard.in_scope is False
+
+    assert g1.name == "Gallery I"
+    assert g1.position == 2
+    assert g1.work_count == 3
+    assert g1.cat_no_min == 3
+    assert g1.cat_no_max == 5
+    assert g1.in_scope is True
+
+
+def test_gallery_summary_handles_non_numeric_cat_nos():
+    new = [_new("A1", "x", "x", gallery="Foo")]
+    plan = match_overrides([], new)
+    assert plan.galleries[0].cat_no_min is None
+    assert plan.galleries[0].cat_no_max is None
+    assert plan.galleries[0].work_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Empty / edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_inputs():
+    plan = match_overrides([], [])
+    assert plan.matched == []
+    assert plan.unmatched == []
+    assert plan.galleries == []
+    assert plan.added == plan.removed == 0
+
+
+def test_work_with_no_cat_no_falls_through_to_fingerprint():
+    """Some imports might lack cat_nos on certain rows (header-only quirks).
+    The matcher should still pair them via fingerprint when possible."""
+    old = [_old("", "Sunset", "Jane", override={"notes": "x"})]
+    new = [_new(1, "Sunset", "Jane")]
+    plan = match_overrides(old, new)
+    assert plan.matched_by_fingerprint == 1
+    assert plan.overrides_preserved == 1


### PR DESCRIPTION
Re-import previously matched preserved overrides to new works purely by raw_cat_no. That breaks badly when the gallery inserts a work and renumbers everything after it: old overrides either get lost (renumbered target not found) or, worse, silently transplanted onto the *different* work that now occupies the original cat number. With ~1500-work catalogues and dozens of overrides, the failure mode is invisible until the catalogue prints with the wrong price on the wrong piece.

This change adds two complementary safety nets:

1. A pure content-fingerprint matcher (backend/app/services/reimport_matcher.py). Two-pass: cat-no match gated on fingerprint agreement (title+artist+medium NFKC-normalised), then a fingerprint-only fallback for renumbered works. Cat-no matches where the content has changed are refused and reported as ambiguous, never silently applied. The matcher is a pure function; no DB dependency, fully unit-tested in isolation (tests/test_reimport_matcher.py, 15 cases including the silent-misapplication regression).

2. A 'gallery_scope' parameter on reimport_excel that limits the delete-and-recreate to a chosen subset of galleries; out-of-scope galleries, their works, and their overrides stay physically untouched in the DB. Cross-gallery moves into/out of the selected scope are detected and reported as warnings (selective re-import can't handle them cleanly — user has to extend the scope or accept the duplication).

The endpoint grows two query params on PUT /imports/{id}/reimport: 'dry_run=true' returns the plan without mutating anything; 'galleries=...' narrows the scope. The response carries the per-gallery summary (work counts, cat-no range, in-scope flag) plus the full match plan (matched-by-cat-no, matched-by-fingerprint, unmatched, ambiguous, cross-gallery warnings, overrides-at-risk).

UI: the Update Import panel becomes file-pick → auto dry-run → gallery picker (checkbox table with work counts and cat-no ranges) → scoped dry-run on selection change → confirm button. A belt-and-braces confirm dialog fires when overrides are at risk.

Tests: 5 new integration tests in tests/test_reimport.py cover dry-run no-mutation, gallery-summary response, scope-leaves-out-of-scope-intact, cross-gallery-move detection, and the silent-misapplication regression at the route level. Three existing tests that pinned the buggy cat-no-only behaviour have been updated to use content-stable works for their 'override preserved' assertions.

Verified end-to-end against the real 1729-work production-shape import: synthetic insert-at-1562+shift gives 1561 matched-by-cat-no, 168 matched-by-fingerprint, 1 added, 0 lost. Scoped to the last 4 galleries (where the renumber actually bites): same plan but restricted to that subset.

948 → 953 tests passing.