### PR TITLE
Add 'whole word only' option to text substitution rules

### DIFF
--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -270,11 +270,19 @@ class TextSubstitutionIn(BaseModel):
     """A literal find→replace rule scoped to one or more derived fields.
 
     Spaces in find/replace are significant and preserved (so " - " only matches a
-    spaced hyphen). find must be non-empty."""
+    spaced hyphen). find must be non-empty.
+
+    When ``whole_word`` is true the find is wrapped in regex word boundaries
+    so it only matches standalone occurrences — e.g. ``pla`` → ``PLA`` won't
+    mangle ``plaster`` or ``display``. Default false to preserve the legacy
+    plain-substring behaviour for existing rules (notably the ellipsis
+    ``...`` → ``…`` rule, which can't use word boundaries because ``.`` isn't
+    a word char on either side)."""
 
     find: str
     replace: str = ""
     fields: list[str] = ["title", "medium"]
+    whole_word: bool = False
 
     @field_validator("find")
     @classmethod

--- a/backend/app/services/normalisation_service.py
+++ b/backend/app/services/normalisation_service.py
@@ -173,7 +173,19 @@ def parse_edition(raw_edition, suppress_max: int = DEFAULT_EDITION_SUPPRESS_MAX)
 def apply_text_substitutions(value, substitutions, field_key: str):
     """Apply each literal find→replace whose ``fields`` includes ``field_key``,
     in list order. Spaces in ``find``/``replace`` are significant. A blank
-    ``find`` is skipped (a no-op guard, also enforced at the API)."""
+    ``find`` is skipped (a no-op guard, also enforced at the API).
+
+    When a rule has ``whole_word`` set, the find is wrapped in regex word
+    boundaries (``\\b...\\b``) so e.g. ``pla`` → ``PLA`` only matches the
+    standalone token and leaves ``plaster`` / ``display`` alone. The find
+    is regex-escaped first so any metacharacters in it (``.``, ``(``,
+    ``+`` …) are treated as literals; the replace string is also handled
+    literally (no backreference parsing) by passing it through a lambda.
+
+    Without ``whole_word`` the rule is a plain substring replace — needed
+    by rules whose find is non-alphanumeric (the ``...`` → ``…`` ellipsis
+    rule can't use word boundaries because ``.`` isn't a word char on
+    either side, so ``\\b...\\b`` would never match)."""
     if not value or not substitutions:
         return value
     out = value
@@ -181,8 +193,14 @@ def apply_text_substitutions(value, substitutions, field_key: str):
         find = (sub or {}).get("find")
         if not find:
             continue
-        if field_key in (sub.get("fields") or []):
-            out = out.replace(find, sub.get("replace", "") or "")
+        if field_key not in (sub.get("fields") or []):
+            continue
+        replace = sub.get("replace", "") or ""
+        if sub.get("whole_word"):
+            pattern = r"\b" + re.escape(find) + r"\b"
+            out = re.sub(pattern, lambda _m, r=replace: r, out)
+        else:
+            out = out.replace(find, replace)
     return out
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1268,7 +1268,7 @@ async function renderSettings() {
         <h4 class="panel-subheading" style="margin:0">Text substitutions</h4>
         ${ifAdmin('<button class="btn btn-sm" onclick="addSubstRule()">+ Add rule</button>')}
       </div>
-      <p class="form-hint" style="margin:0 0 12px">Literal find &rarr; replace on the chosen fields, applied in order. Spaces count (shown as <span class="ws-hint">&middot;</span>), so <code><span class="ws-hint">&middot;</span>-<span class="ws-hint">&middot;</span></code> changes a spaced hyphen but never the hyphen in &ldquo;double-barrelled&rdquo;.</p>
+      <p class="form-hint" style="margin:0 0 12px">Literal find &rarr; replace on the chosen fields, applied in order. Spaces count (shown as <span class="ws-hint">&middot;</span>), so <code><span class="ws-hint">&middot;</span>-<span class="ws-hint">&middot;</span></code> changes a spaced hyphen but never the hyphen in &ldquo;double-barrelled&rdquo;. <strong>Whole word only</strong> is the safe default for abbreviations (<code>mdf</code>&rarr;<code>MDF</code> won&rsquo;t touch <code>plaster</code>); turn it off for non-letter rules like <code>...</code>&rarr;<code>&hellip;</code>.</p>
       <div id="subst-rules">
         ${substRules.map(r => _substRuleRow(r)).join('')}
       </div>
@@ -1355,7 +1355,14 @@ function _visSpaces(s) {
 }
 
 function _substRuleRow(rule) {
-  const r = rule || { find: '', replace: '', fields: ['title', 'medium'] };
+  // New rules default whole_word ON — abbreviation expansion ("mdf"→"MDF",
+  // "pla"→"PLA") is the dominant use case and the failure mode of leaving
+  // it OFF is silent substring corruption ("plaster" → "PLAster"). Existing
+  // rules keep whatever flag they were saved with — which for legacy rules
+  // (notably "..." → "…") is the absent/false default, preserving behaviour.
+  const isNew = !rule;
+  const r = rule || { find: '', replace: '', fields: ['title', 'medium'], whole_word: true };
+  const wholeWord = isNew ? true : Boolean(r.whole_word);
   const disabled = canAdmin() ? '' : ' disabled';
   const checks = _SUBST_FIELDS.map(([key, label]) =>
     `<label class="inline-check" style="text-transform:none;font-weight:normal;margin-right:10px">
@@ -1368,7 +1375,12 @@ function _substRuleRow(rule) {
       <input type="text" class="subst-replace" value="${esc(r.replace)}" placeholder="replace" oninput="_updateSubstPreview(this)"${disabled}>
       ${ifAdmin('<button type="button" class="btn btn-sm subst-remove" onclick="removeSubstRule(this)" title="Remove rule">&times;</button>')}
     </div>
-    <div class="subst-fields">${checks}</div>
+    <div class="subst-fields">
+      ${checks}
+      <label class="inline-check" style="text-transform:none;font-weight:normal;margin-left:14px" title="Match only when find is a standalone word (no surrounding letters/digits). Leave OFF for non-letter rules like &ldquo;...&rdquo; &rarr; &ldquo;…&rdquo;.">
+        <input type="checkbox" class="subst-whole-word"${wholeWord ? ' checked' : ''}${disabled}> Whole word only
+      </label>
+    </div>
     <div class="subst-preview"><code>${_visSpaces(r.find)}</code> &rarr; <code>${_visSpaces(r.replace)}</code></div>
   </div>`;
 }
@@ -1396,6 +1408,7 @@ function _gatherSubstitutions() {
     // Spaces are significant \u2014 never trim find/replace.
     find: row.querySelector('.subst-find').value,
     replace: row.querySelector('.subst-replace').value,
+    whole_word: row.querySelector('.subst-whole-word')?.checked ?? false,
     fields: [...row.querySelectorAll('.subst-field')].filter(c => c.checked).map(c => c.dataset.field),
   })).filter(s => s.find !== '');  // drop blank-find rows (backend rejects them)
 }

--- a/tests/test_configurable_normalisation.py
+++ b/tests/test_configurable_normalisation.py
@@ -89,6 +89,76 @@ def test_blank_find_is_skipped():
 
 
 # ---------------------------------------------------------------------------
+# whole_word matching — the safety opt-in for short alphabetic abbreviations
+# ---------------------------------------------------------------------------
+
+
+def test_whole_word_does_not_mangle_substrings():
+    """Without whole_word, "pla" → "PLA" would corrupt "plaster" and
+    "display". With whole_word set, only the standalone token matches."""
+    subs = [{"find": "pla", "replace": "PLA",
+             "fields": ["medium"], "whole_word": True}]
+    assert apply_text_substitutions(
+        "pla, plaster on display", subs, "medium"
+    ) == "PLA, plaster on display"
+
+
+def test_whole_word_off_is_legacy_substring():
+    """Existing rules (whole_word absent or False) keep the old substring
+    behaviour — needed for the ``...`` → ``…`` rule whose find has no word
+    chars and so couldn't match with word boundaries anyway."""
+    subs = [{"find": "pla", "replace": "PLA", "fields": ["medium"]}]
+    assert apply_text_substitutions(
+        "pla, plaster", subs, "medium"
+    ) == "PLA, PLAster"
+
+
+def test_whole_word_matches_at_string_boundaries():
+    """Word boundaries must fire at start-of-string, end-of-string, and
+    next to punctuation — covers the real cases of medium fields like
+    "mdf" alone, "and mdf", or "mdf, perspex"."""
+    subs = [{"find": "mdf", "replace": "MDF",
+             "fields": ["medium"], "whole_word": True}]
+    assert apply_text_substitutions("mdf", subs, "medium") == "MDF"
+    assert apply_text_substitutions("oil on mdf", subs, "medium") == "oil on MDF"
+    assert apply_text_substitutions("mdf, paint", subs, "medium") == "MDF, paint"
+    assert apply_text_substitutions(
+        "perspex, petg, and mdf", subs, "medium"
+    ) == "perspex, petg, and MDF"
+
+
+def test_whole_word_treats_hyphen_as_boundary():
+    """\\b in Python regex treats hyphen as a non-word char — so "mdf-board"
+    has a word boundary between "mdf" and "-". Worth pinning so a future
+    reader knows the behaviour (some users might expect hyphenated
+    compounds to *not* match)."""
+    subs = [{"find": "mdf", "replace": "MDF",
+             "fields": ["medium"], "whole_word": True}]
+    assert apply_text_substitutions(
+        "mdf-board on oak", subs, "medium"
+    ) == "MDF-board on oak"
+
+
+def test_whole_word_with_regex_metachars_in_find_is_literal():
+    """The find is regex-escaped before being wrapped in word boundaries,
+    so a literal ``.`` doesn't act as "any char". (Combined with whole_word,
+    this is a rare combination but the safety still has to hold.)"""
+    subs = [{"find": "a.b", "replace": "AXB",
+             "fields": ["title"], "whole_word": True}]
+    # Should NOT match "axb" — the . in the find is a literal, not wildcard
+    assert apply_text_substitutions("a.b axb", subs, "title") == "AXB axb"
+
+
+def test_whole_word_with_dollar_sign_in_replace_is_literal():
+    """The replace string is passed through a lambda so regex backreference
+    syntax (``\\1``, ``\\g<name>``) isn't interpreted — important because
+    editors writing replacement text shouldn't have to escape backslashes."""
+    subs = [{"find": "mdf", "replace": r"M\1F",
+             "fields": ["medium"], "whole_word": True}]
+    assert apply_text_substitutions("mdf", subs, "medium") == r"M\1F"
+
+
+# ---------------------------------------------------------------------------
 # normalise_work integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Substitution rules use plain str.replace, which silently corrupts any content where the find string happens to appear inside a longer word — the motivating example is 'pla' → 'PLA' mangling 'plaster' into 'PLAster' and 'display' into 'disPLAy'. With ~1500-work catalogues full of medium descriptions ('jesmonite', 'plaster', 'display board' etc.) this rules out almost all the short alphabetic abbreviations editors actually want to expand (MDF, PLA, USB, ABS, CNC…).

Adds an opt-in 'whole_word' boolean per rule. When set, the find is regex-escaped and wrapped in \b...\b before matching, so only standalone occurrences are replaced. The replace string is passed through a lambda to avoid regex-replacement parsing — editors shouldn't have to escape backslashes in 'replace' fields.

Defaults are picked to make the safe behaviour the default for the common case without breaking the one shipped rule:

- Schema: 'whole_word' defaults to False. Existing saved rules (notably '...' → '…', whose find has no word chars and so couldn't be word- bounded anyway) deserialise with whole_word=False and keep working.
- Frontend: new rules created via '+ Add rule' default to CHECKED. Existing rules render with whatever flag they have saved. Hint text under the panel header points at the choice.

6 new unit tests cover: whole_word preventing substring mangling, whole_word=off legacy behaviour preserved, boundaries firing at string edges and next to punctuation, hyphen-as-boundary (worth knowing — 'mdf-board' DOES match 'mdf' because '-' is a non-word char), regex metachar in find treated literally, regex backreference syntax in replace treated literally.

953 → 959 tests passing.