### PR TITLE
List of Works + Index review-page refinements (Claude Design handoff)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -583,6 +583,14 @@ controls and editor UX around it.
     corrections by type, ranked by frequency, splitting systematic (→ a
     normalisation rule) from idiosyncratic (→ leave it). No new infrastructure.
 - Per-gallery catalogue-number styles in the LOW template (numerals vs text)
+- **House-style pill update.** Make every `.badge` instance pill-shaped
+  (`border-radius: 9999px`) for visual consistency between the import-notes
+  chips (already pill-shaped) and the row-level flag pills, honorifics pill,
+  warning labels, and other badge surfaces (currently `border-radius: 3px`).
+  Deferred from the 2026-05-28 Claude Design handoff (PR #74) — the chips were
+  made pill-shaped in isolation; doing the same to every other `.badge` is a
+  larger blast radius (touches every surface using the primitive) and worth
+  doing as its own change with before/after eyeballing.
 - Undo / revision history for overrides
 - Bulk override import from Excel
 - Multi-user conflict resolution (optimistic locking)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4204,7 +4204,7 @@ function _renderImportNotesPanel(opts) {
     const muted = hidden.has(type);
     const cls = `badge ${badgeClassOf(type)} warning-filter-btn${muted ? ' badge-muted' : ''}`;
     const title = `${muted ? 'Click: show' : 'Click: hide'} · Alt+click: show this only`;
-    return `<button type="button" class="${cls}" data-type="${esc(type)}" title="${title}">${esc(labelOf(type))}: ${counts[type]}</button>`;
+    return `<button type="button" class="${cls}" data-type="${esc(type)}" title="${title}">${esc(labelOf(type))}<span class="chip-count">${counts[type].toLocaleString()}</span></button>`;
   }
 
   const autoChipsHTML = changedTypes.map(chipHTML).join('');
@@ -4223,11 +4223,12 @@ function _renderImportNotesPanel(opts) {
     ? `${total.toLocaleString()} items`
     : `${visible.length.toLocaleString()} of ${total.toLocaleString()} items`;
 
-  // Counts line — only mention sub-counts that are non-zero
+  // Counts line — only mention sub-counts that are non-zero. Separators are
+  // styled spans so the dot can sit in a calmer colour than the body text.
   const countsLineParts = [`<strong>${total.toLocaleString()}</strong> item${total !== 1 ? 's' : ''}`];
   if (autoTotal) countsLineParts.push(`<strong>${autoTotal.toLocaleString()}</strong> auto-normalised`);
   if (reviewTotal) countsLineParts.push(`<strong>${reviewTotal.toLocaleString()}</strong> need${reviewTotal === 1 ? 's' : ''} review`);
-  const countsLine = countsLineParts.join(' · ');
+  const countsLine = countsLineParts.join('<span class="sep">·</span>');
 
   const groupsHTML = [
     autoChipsHTML ? `
@@ -4244,12 +4245,14 @@ function _renderImportNotesPanel(opts) {
 
   container.innerHTML = `
     <div class="import-notes">
-      <h3 class="import-notes-title">⚠ Import notes</h3>
-      <div class="import-notes-counts">${countsLine}</div>
-      ${groupsHTML}
-      <div class="import-notes-hint">Click a chip to hide that type · <kbd>⌥</kbd> Alt-click to show only that type</div>
+      <div class="import-notes-head">
+        <h3 class="import-notes-title">⚠ Import notes</h3>
+        <div class="import-notes-counts">${countsLine}</div>
+      </div>
+      <div class="import-notes-groups">${groupsHTML}</div>
+      <div class="import-notes-hint"><kbd>Click</kbd> a chip to hide that type · <kbd>⌥ Alt-click</kbd> to show only that type</div>
       <details class="import-notes-detail">
-        <summary class="warnings-toggle">Show detail — ${detailSummary}</summary>
+        <summary>Show detail — ${detailSummary}</summary>
         <table class="data-table warnings-table" style="margin-top:10px">
           <thead><tr><th>Type</th><th>Message</th><th>${esc(detailColumnLabel)}</th></tr></thead>
           <tbody>${rows}</tbody>
@@ -4410,7 +4413,7 @@ function renderSections(importId, sections, cfg) {
           <th class="col-no">No.</th>
           <th>Artist</th>
           <th>Title</th>
-          <th>Price</th>
+          <th class="col-price">Price</th>
           <th>Edition</th>
           ${cfg.show_artwork_column ? '<th>Artwork</th>' : ''}
           <th>Medium</th>
@@ -4751,11 +4754,11 @@ function workRowHTML(importId, w, cfg) {
       <td class="col-no">${esc(w.raw_cat_no ?? '')}</td>
       <td class="${hasOverride && o?.artist_name_override ? 'cell-overridden' : ''}">${esc(eff.artist_name ?? '')}${honorifics}</td>
       <td class="${hasOverride && o?.title_override ? 'cell-overridden' : ''}">${esc(eff.title ?? '')}${cfg.show_title_cased && eff.title_cased ? `<div class="title-cased-scan">${esc(eff.title_cased)}</div>` : ''}</td>
-      <td class="${hasOverride && (o?.price_numeric_override || o?.price_text_override) ? 'cell-overridden' : ''}">${esc(priceDisplay)}</td>
+      <td class="col-price ${hasOverride && (o?.price_numeric_override || o?.price_text_override) ? 'cell-overridden' : ''}">${esc(priceDisplay)}</td>
       <td class="${hasOverride && (o?.edition_total_override || o?.edition_price_numeric_override) ? 'cell-overridden' : ''}">${esc(editionDisplay)}</td>
       ${cfg.show_artwork_column ? `<td class="${hasOverride && o?.artwork_override ? 'cell-overridden' : ''}">${w.artwork != null ? esc(String(w.artwork)) : ''}</td>` : ''}
       <td class="col-medium ${hasOverride && o?.medium_override ? 'cell-overridden' : ''}">${esc(eff.medium ?? '')}</td>
-      <td class="col-flags">${flags.join(' ')}</td>
+      <td class="col-flags"><div class="cell-flags">${flags.join('')}</div></td>
       <td class="col-chev" aria-hidden="true"><span class="works-row-chev">&rsaquo;</span></td>
     </tr>
     <tr id="ovr-${esc(w.id)}" class="override-form-row" style="display:none">

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4114,8 +4114,12 @@ function renderWarningsPanel(warnings) {
 const _LOW_WARNING_LABELS = {
   // Changed: normalisation engine modified data
   whitespace_trimmed:     'Whitespace trimmed',
-  zero_edition_suppressed: 'Edition stripped',
-  edition_suppressed:      'Edition stripped',
+  // Distinct edition-suppression cases — see normalisation_service.py:374-477.
+  // zero_edition_suppressed: edition was explicitly 0 → there is no edition at all.
+  // edition_suppressed: edition total was within the (admin-configurable) suppress
+  // threshold → it IS the work itself, not a separate run, so it's folded in.
+  zero_edition_suppressed: 'Zero-edition dropped',
+  edition_suppressed:      'Small edition merged with work',
   // High severity: needs a decision
   edition_suppressed_no_price: 'Edition price lost',
   // Info: data quality issues needing review
@@ -4150,80 +4154,152 @@ function _lowWarnBadgeClass(type) {
   return 'badge-warning';
 }
 
-function _buildWarningsPanel() {
-  const warnings = _warningsAll;
-  const panel = document.getElementById('warnings-panel');
+// Shared "Import notes" panel renderer \u2014 used by both the LoW and Index
+// import-review pages. Same chip click/Alt-click contract as before; chips
+// split into two visually-labelled groups (auto-normalised vs needs review).
+// The Index has no high-severity tier, so opts.isHigh always returns false
+// there; that just means the red-first sort within Needs review is a no-op.
+function _renderImportNotesPanel(opts) {
+  const {
+    container, warnings, labelOf, badgeClassOf, isChanged, isHigh,
+    getHidden, setHidden, rebuild, detailColumnLabel, detailRefCellFor,
+  } = opts;
+  if (!container) return;
+
   if (!warnings.length) {
-    panel.innerHTML = '<p class="no-warnings">\u2713 No flagged issues</p>';
+    container.classList.remove('has-warnings', 'all-auto-normalised');
+    container.innerHTML = '<p class="no-warnings">\u2713 No flagged issues</p>';
     return;
   }
-  panel.classList.add('has-warnings');
+  container.classList.add('has-warnings');
 
-  // Summary counts by type
+  // Counts by type
   const counts = {};
   for (const w of warnings) {
     counts[w.warning_type] = (counts[w.warning_type] || 0) + 1;
   }
-  const summaryBadges = Object.entries(counts)
-    .sort((a, b) => b[1] - a[1])
-    .map(([type, n]) => {
-      const muted = _hiddenWarningTypes.has(type);
-      const badgeClass = `badge ${_lowWarnBadgeClass(type)} warning-filter-btn`;
-      return `<button type="button" class="${badgeClass}${muted ? ' badge-muted' : ''}" data-type="${esc(type)}" title="${muted ? 'Click: show' : 'Click: hide'} · Alt+click: show this only">${esc(_lowWarnLabel(type))}: ${n}</button>`;
-    }).join('');
+  const allTypes = Object.keys(counts);
+  const hidden = getHidden();
 
-  // Detailed rows — filtered by hidden types
-  const visible = warnings.filter(w => !_hiddenWarningTypes.has(w.warning_type));
-  const rows = visible.map(w => {
-    const who = [w.cat_no, w.artist_name, w.title].filter(Boolean).join(' \u2013 ');
-    const workCell = (w.work_id && who)
-      ? `<button type="button" class="link-btn" onclick="scrollToWork('${esc(w.work_id)}')">${esc(who)}</button>`
-      : (esc(who) || '\u2014');
-    return `<tr>
-      <td><span class="badge ${_lowWarnBadgeClass(w.warning_type)}">${esc(_lowWarnLabel(w.warning_type))}</span></td>
+  // Group types: auto-normalised (engine changed data) vs needs review.
+  // Within Needs review, high-severity (red) types sort first, then by count.
+  const changedTypes = allTypes.filter(t => isChanged(t))
+    .sort((a, b) => counts[b] - counts[a]);
+  const reviewTypes = allTypes.filter(t => !isChanged(t))
+    .sort((a, b) => {
+      const aHi = isHigh(a) ? 1 : 0;
+      const bHi = isHigh(b) ? 1 : 0;
+      if (aHi !== bHi) return bHi - aHi;
+      return counts[b] - counts[a];
+    });
+
+  const autoTotal = changedTypes.reduce((s, t) => s + counts[t], 0);
+  const reviewTotal = reviewTypes.reduce((s, t) => s + counts[t], 0);
+  const total = warnings.length;
+
+  // Calmer border when nothing needs review (all auto-normalised)
+  container.classList.toggle('all-auto-normalised', reviewTotal === 0);
+
+  function chipHTML(type) {
+    const muted = hidden.has(type);
+    const cls = `badge ${badgeClassOf(type)} warning-filter-btn${muted ? ' badge-muted' : ''}`;
+    const title = `${muted ? 'Click: show' : 'Click: hide'} · Alt+click: show this only`;
+    return `<button type="button" class="${cls}" data-type="${esc(type)}" title="${title}">${esc(labelOf(type))}: ${counts[type]}</button>`;
+  }
+
+  const autoChipsHTML = changedTypes.map(chipHTML).join('');
+  const reviewChipsHTML = reviewTypes.map(chipHTML).join('');
+
+  // Detail rows — filtered by hidden types
+  const visible = warnings.filter(w => !hidden.has(w.warning_type));
+  const rows = visible.map(w => `
+    <tr>
+      <td><span class="badge ${badgeClassOf(w.warning_type)}">${esc(labelOf(w.warning_type))}</span></td>
       <td>${esc(w.message)}</td>
-      <td class="muted col-work">${workCell}</td>
-    </tr>`;
-  }).join('');
+      <td class="muted col-work">${detailRefCellFor(w)}</td>
+    </tr>`).join('');
 
-  const hiddenCount = warnings.length - visible.length;
-  const countLabel = hiddenCount > 0
-    ? `${visible.length} shown of ${warnings.length}`
-    : String(warnings.length);
+  const detailSummary = visible.length === total
+    ? `${total.toLocaleString()} items`
+    : `${visible.length.toLocaleString()} of ${total.toLocaleString()} items`;
 
-  panel.innerHTML = `
-    <h3>\u26a0 Flagged Issues (${countLabel})</h3>
-    <div class="warning-filter-bar">${summaryBadges}</div>
-    <details>
-      <summary class="warnings-toggle">Show detail</summary>
-      <table class="data-table warnings-table" style="margin-top:10px">
-        <thead><tr><th>Type</th><th>Message</th><th>Work</th></tr></thead>
-        <tbody>${rows}</tbody>
-      </table>
-    </details>`;
+  // Counts line — only mention sub-counts that are non-zero
+  const countsLineParts = [`<strong>${total.toLocaleString()}</strong> item${total !== 1 ? 's' : ''}`];
+  if (autoTotal) countsLineParts.push(`<strong>${autoTotal.toLocaleString()}</strong> auto-normalised`);
+  if (reviewTotal) countsLineParts.push(`<strong>${reviewTotal.toLocaleString()}</strong> need${reviewTotal === 1 ? 's' : ''} review`);
+  const countsLine = countsLineParts.join(' · ');
 
-  // Attach badge click handlers after innerHTML
-  panel.querySelectorAll('.warning-filter-btn').forEach(btn => {
+  const groupsHTML = [
+    autoChipsHTML ? `
+      <div class="import-notes-group">
+        <div class="import-notes-grouplbl"><span class="import-notes-dot dot-auto"></span>Auto-normalised — applied automatically</div>
+        <div class="warning-filter-bar">${autoChipsHTML}</div>
+      </div>` : '',
+    reviewChipsHTML ? `
+      <div class="import-notes-group">
+        <div class="import-notes-grouplbl"><span class="import-notes-dot dot-review"></span>Needs review — may affect export</div>
+        <div class="warning-filter-bar">${reviewChipsHTML}</div>
+      </div>` : '',
+  ].join('');
+
+  container.innerHTML = `
+    <div class="import-notes">
+      <h3 class="import-notes-title">⚠ Import notes</h3>
+      <div class="import-notes-counts">${countsLine}</div>
+      ${groupsHTML}
+      <div class="import-notes-hint">Click a chip to hide that type · <kbd>⌥</kbd> Alt-click to show only that type</div>
+      <details class="import-notes-detail">
+        <summary class="warnings-toggle">Show detail — ${detailSummary}</summary>
+        <table class="data-table warnings-table" style="margin-top:10px">
+          <thead><tr><th>Type</th><th>Message</th><th>${esc(detailColumnLabel)}</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </details>
+    </div>`;
+
+  // Chip click handlers — preserve the two-action contract:
+  //   Click     — toggle this type in the hidden set
+  //   Alt+click — solo this type; Alt+click the lone visible type to restore all
+  container.querySelectorAll('.warning-filter-btn').forEach(btn => {
     btn.addEventListener('click', (e) => {
       const type = btn.dataset.type;
-      const allTypes = Object.keys(counts);
+      const h = getHidden();
+      let next;
       if (e.altKey) {
-        // Solo / unsolo: Alt+click shows only this type
-        const visibleTypes = allTypes.filter(t => !_hiddenWarningTypes.has(t));
+        const visibleTypes = allTypes.filter(t => !h.has(t));
         if (visibleTypes.length === 1 && visibleTypes[0] === type) {
-          _hiddenWarningTypes = new Set();  // unsolo — restore all
+          next = new Set();  // unsolo
         } else {
-          _hiddenWarningTypes = new Set(allTypes.filter(t => t !== type));
+          next = new Set(allTypes.filter(t => t !== type));
         }
       } else {
-        if (_hiddenWarningTypes.has(type)) {
-          _hiddenWarningTypes.delete(type);
-        } else {
-          _hiddenWarningTypes.add(type);
-        }
+        next = new Set(h);
+        if (next.has(type)) next.delete(type); else next.add(type);
       }
-      _buildWarningsPanel();
+      setHidden(next);
+      rebuild();
     });
+  });
+}
+
+function _buildWarningsPanel() {
+  _renderImportNotesPanel({
+    container: document.getElementById('warnings-panel'),
+    warnings: _warningsAll,
+    labelOf: _lowWarnLabel,
+    badgeClassOf: _lowWarnBadgeClass,
+    isChanged: (t) => _LOW_CHANGED_TYPES.has(t),
+    isHigh: (t) => _LOW_HIGH_SEVERITY_TYPES.has(t),
+    getHidden: () => _hiddenWarningTypes,
+    setHidden: (s) => { _hiddenWarningTypes = s; },
+    rebuild: _buildWarningsPanel,
+    detailColumnLabel: 'Work',
+    detailRefCellFor: (w) => {
+      const who = [w.cat_no, w.artist_name, w.title].filter(Boolean).join(' \u2013 ');
+      return (w.work_id && who)
+        ? `<button type="button" class="link-btn" onclick="scrollToWork('${esc(w.work_id)}')">${esc(who)}</button>`
+        : (esc(who) || '\u2014');
+    },
   });
 }
 
@@ -4339,6 +4415,7 @@ function renderSections(importId, sections, cfg) {
           ${cfg.show_artwork_column ? '<th>Artwork</th>' : ''}
           <th>Medium</th>
           <th class="col-flags">Flags</th>
+          <th class="col-chev" aria-hidden="true"></th>
         </tr></thead>
         <tbody id="tbody-${esc(section.id)}">
           ${section.works.map(w => workRowHTML(importId, w, cfg)).join('')}
@@ -4669,7 +4746,7 @@ function workRowHTML(importId, w, cfg) {
   }
 
   return `
-    <tr id="wr-${esc(w.id)}" class="work-row ${included ? '' : 'row-excluded'}" style="cursor:pointer"
+    <tr id="wr-${esc(w.id)}" class="work-row ${included ? '' : 'row-excluded'}"
       onclick="toggleOverrideForm('${esc(importId)}','${esc(w.id)}')">
       <td class="col-no">${esc(w.raw_cat_no ?? '')}</td>
       <td class="${hasOverride && o?.artist_name_override ? 'cell-overridden' : ''}">${esc(eff.artist_name ?? '')}${honorifics}</td>
@@ -4679,9 +4756,10 @@ function workRowHTML(importId, w, cfg) {
       ${cfg.show_artwork_column ? `<td class="${hasOverride && o?.artwork_override ? 'cell-overridden' : ''}">${w.artwork != null ? esc(String(w.artwork)) : ''}</td>` : ''}
       <td class="col-medium ${hasOverride && o?.medium_override ? 'cell-overridden' : ''}">${esc(eff.medium ?? '')}</td>
       <td class="col-flags">${flags.join(' ')}</td>
+      <td class="col-chev" aria-hidden="true"><span class="works-row-chev">&rsaquo;</span></td>
     </tr>
     <tr id="ovr-${esc(w.id)}" class="override-form-row" style="display:none">
-      <td colspan="${cfg.show_artwork_column ? 8 : 7}" id="ovc-${esc(w.id)}"></td>
+      <td colspan="${cfg.show_artwork_column ? 9 : 8}" id="ovc-${esc(w.id)}"></td>
     </tr>`;
 }
 
@@ -5806,79 +5884,20 @@ function _idxWarningsBadges(artistId) {
 }
 
 function _buildIndexWarningsPanel() {
-  const warnings = _indexWarningsAll;
-  const panel = document.getElementById('index-warnings-panel');
-  if (!warnings.length) {
-    panel.innerHTML = '<p class="no-warnings">\u2713 No flagged issues</p>';
-    return;
-  }
-  panel.classList.add('has-warnings');
-
-  // Summary counts by type
-  const counts = {};
-  for (const w of warnings) {
-    counts[w.warning_type] = (counts[w.warning_type] || 0) + 1;
-  }
-  const summaryBadges = Object.entries(counts)
-    .sort((a, b) => b[1] - a[1])
-    .map(([type, n]) => {
-      const muted = _hiddenIndexWarningTypes.has(type);
-      const isChanged = _IDX_CHANGED_TYPES.has(type);
-      const badgeClass = isChanged ? 'badge badge-info warning-filter-btn' : 'badge badge-warning warning-filter-btn';
-      return `<button type="button" class="${badgeClass}${muted ? ' badge-muted' : ''}" data-type="${esc(type)}" title="${muted ? 'Click: show' : 'Click: hide'} · Alt+click: show this only">${esc(_idxWarnLabel(type))}: ${n}</button>`;
-    }).join('');
-
-  // Detailed rows — filtered by hidden types
-  const visible = warnings.filter(w => !_hiddenIndexWarningTypes.has(w.warning_type));
-  const rows = visible.map(w => {
-    const rowCell = (w.artist_id && w.row_number)
-      ? `<button type="button" class="link-btn" onclick="scrollToIndexArtist('${esc(w.artist_id)}')">${esc('Row ' + w.row_number)}</button>`
-      : (w.row_number ? esc('Row ' + w.row_number) : '\u2014');
-    return `<tr>
-      <td><span class="badge ${_IDX_CHANGED_TYPES.has(w.warning_type) ? 'badge-info' : 'badge-warning'}">${esc(_idxWarnLabel(w.warning_type))}</span></td>
-      <td>${esc(w.message)}</td>
-      <td class="muted col-work">${rowCell}</td>
-    </tr>`;
-  }).join('');
-
-  const hiddenCount = warnings.length - visible.length;
-  const countLabel = hiddenCount > 0
-    ? `${visible.length} shown of ${warnings.length}`
-    : String(warnings.length);
-
-  panel.innerHTML = `
-    <h3>\u26a0 Flagged Issues (${countLabel})</h3>
-    <div class="warning-filter-bar">${summaryBadges}</div>
-    <details>
-      <summary class="warnings-toggle">Show detail</summary>
-      <table class="data-table warnings-table" style="margin-top:10px">
-        <thead><tr><th>Type</th><th>Message</th><th>Row</th></tr></thead>
-        <tbody>${rows}</tbody>
-      </table>
-    </details>`;
-
-  // Attach badge click handlers
-  panel.querySelectorAll('.warning-filter-btn').forEach(btn => {
-    btn.addEventListener('click', (e) => {
-      const type = btn.dataset.type;
-      const allTypes = Object.keys(counts);
-      if (e.altKey) {
-        // Solo / unsolo: Alt+click shows only this type
-        const visibleTypes = allTypes.filter(t => !_hiddenIndexWarningTypes.has(t));
-        if (visibleTypes.length === 1 && visibleTypes[0] === type) {
-          _hiddenIndexWarningTypes = new Set();  // unsolo — restore all
-        } else {
-          _hiddenIndexWarningTypes = new Set(allTypes.filter(t => t !== type));
-        }
-      } else {
-        if (_hiddenIndexWarningTypes.has(type)) {
-          _hiddenIndexWarningTypes.delete(type);
-        } else {
-          _hiddenIndexWarningTypes.add(type);
-        }
-      }
-      _buildIndexWarningsPanel();
-    });
+  _renderImportNotesPanel({
+    container: document.getElementById('index-warnings-panel'),
+    warnings: _indexWarningsAll,
+    labelOf: _idxWarnLabel,
+    badgeClassOf: (t) => _IDX_CHANGED_TYPES.has(t) ? 'badge-info' : 'badge-warning',
+    isChanged: (t) => _IDX_CHANGED_TYPES.has(t),
+    isHigh: () => false,  // Index has no high-severity warning tier
+    getHidden: () => _hiddenIndexWarningTypes,
+    setHidden: (s) => { _hiddenIndexWarningTypes = s; },
+    rebuild: _buildIndexWarningsPanel,
+    detailColumnLabel: 'Row',
+    detailRefCellFor: (w) => (w.artist_id && w.row_number)
+      ? `<button type="button" class="link-btn" onclick="scrollToIndexArtist('${esc(w.artist_id)}')">Row ${esc(String(w.row_number))}</button>`
+      : (w.row_number ? `Row ${esc(String(w.row_number))}` : '\u2014'),
   });
 }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -678,6 +678,45 @@ details.section-block[open] > .section-summary::before {
 .works-table .col-flags .badge { white-space: nowrap; }
 .work-row.row-excluded td.col-no::after { content: ' ✕'; color: #c0392b; font-size: 0.85em; text-decoration: none; }
 
+/* Row density — tighten the title cell (the two-line UPPERCASE + Title Case
+   block is the main driver of row height on large imports). The base .data-table
+   td padding is already 7px; not increasing per the design spec because that
+   would work against the spec's "denser rows" intent on this codebase. */
+.works-table tbody td { line-height: 1.35; }
+.works-table .title-cased-scan {
+  font-size: 12.5px;
+  margin-top: 1px;
+  line-height: 1.35;
+}
+
+/* Row hover affordance — rows open the work detail panel on click. The
+   .data-table tr:hover background already ships at #fafafa, so we only add
+   the cursor + transition, and a slide-in chevron on hover. */
+.works-table tbody tr.work-row {
+  cursor: pointer;
+  transition: background 0.08s;
+}
+.works-table tbody tr.work-row:hover .works-row-chev {
+  opacity: 1;
+  transform: translateX(0);
+}
+.works-row-chev {
+  display: inline-block;
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.12s, transform 0.12s;
+  color: #888;
+  font-size: 14px;
+  line-height: 1;
+}
+.works-table .col-chev {
+  width: 28px;
+  text-align: right;
+  white-space: nowrap;
+  padding-left: 0;
+}
+.work-row.row-excluded td.col-chev { text-decoration: none; }
+
 .index-row.row-excluded td { opacity: 0.45; text-decoration: line-through; text-decoration-color: #999; }
 .index-row.row-excluded td.col-flags { text-decoration: none; }
 
@@ -899,6 +938,64 @@ details.section-block[open] > .section-summary::before {
   gap: 10px;
   padding-top: 4px;
 }
+
+/* ------------------------------------------------------------------ */
+/* Import notes panel — new "Import notes" layout (shared LoW + Index) */
+/* ------------------------------------------------------------------ */
+
+.import-notes-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ra-dark);
+  margin: 0 0 4px;
+}
+.import-notes-counts {
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+.import-notes-counts strong { color: var(--ra-dark); font-weight: 600; }
+.import-notes-group { margin-bottom: 10px; }
+.import-notes-grouplbl {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.import-notes-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.import-notes-dot.dot-auto   { background: #5fb8ca; }   /* matches badge-info palette */
+.import-notes-dot.dot-review { background: #f0c040; }   /* matches badge-warning palette */
+.import-notes-hint {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--muted);
+  margin: 4px 0 8px;
+}
+.import-notes-hint kbd {
+  display: inline-block;
+  padding: 0 4px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: #fafafa;
+  font-family: var(--font);
+  font-size: 11px;
+  color: var(--ra-dark);
+  font-style: normal;
+}
+
+/* Calmer info-blue border when only auto-normalised notes remain (nothing to review) */
+.panel.has-warnings.all-auto-normalised { border-left-color: #5fb8ca; }
 
 /* ------------------------------------------------------------------ */
 /* Warning filter badges (clickable summary row)                       */

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -672,10 +672,23 @@ details.section-block[open] > .section-summary::before {
 .works-table td:nth-child(2) { min-width: 180px; } /* Artist column */
 .works-table .col-actions { width: 70px; text-align: center; }
 
+/* Tabular numerals so cat numbers and prices vertically align across rows. */
+.works-table .col-no,
+.works-table .col-price { font-variant-numeric: tabular-nums; }
+
 .work-row.row-excluded td { opacity: 0.45; text-decoration: line-through; text-decoration-color: #999; }
 .work-row.row-excluded td.col-flags { text-decoration: none; }
-.works-table .col-flags { text-align: right; max-width: 160px; white-space: normal; line-height: 1.8; }
+.works-table .col-flags { text-align: right; max-width: 160px; white-space: normal; }
 .works-table .col-flags .badge { white-space: nowrap; }
+/* Flag pills laid out via flex+gap (replaces the old line-height: 1.8 hack)
+   — gives consistent 4px gaps in both axes when pills wrap. */
+.cell-flags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;     /* keep each pill at its natural height (no stretch) */
+  gap: 4px;
+  justify-content: flex-end;
+}
 .work-row.row-excluded td.col-no::after { content: ' ✕'; color: #c0392b; font-size: 0.85em; text-decoration: none; }
 
 /* Row density — tighten the title cell (the two-line UPPERCASE + Title Case
@@ -943,19 +956,40 @@ details.section-block[open] > .section-summary::before {
 /* Import notes panel — new "Import notes" layout (shared LoW + Index) */
 /* ------------------------------------------------------------------ */
 
+/* Title + counts share one row at the top of the panel; wraps on narrow widths. */
+.import-notes-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin-bottom: 12px;
+}
 .import-notes-title {
   font-size: 14px;
   font-weight: 600;
   color: var(--ra-dark);
-  margin: 0 0 4px;
+  margin: 0;
 }
 .import-notes-counts {
   font-size: 13px;
   color: var(--muted);
-  margin-bottom: 14px;
+}
+.import-notes-counts .sep {
+  color: var(--border-strong);
+  margin: 0 8px;
 }
 .import-notes-counts strong { color: var(--ra-dark); font-weight: 600; }
-.import-notes-group { margin-bottom: 10px; }
+
+/* Two-column grid on wide viewports; auto-stacks when there isn't room for
+   two ~280px columns side by side. Gap handles inter-group spacing in both
+   axes, so no margin-bottom on .import-notes-group. */
+.import-notes-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  margin-bottom: 14px;
+}
+.import-notes-group { min-width: 0; }  /* let chips wrap inside narrow columns */
 .import-notes-grouplbl {
   font-size: 10px;
   font-weight: 700;
@@ -987,8 +1021,8 @@ details.section-block[open] > .section-summary::before {
   padding: 0 4px;
   border: 1px solid var(--border);
   border-radius: 3px;
-  background: #fafafa;
-  font-family: var(--font);
+  background: #f0f0f0;
+  font-family: var(--mono);
   font-size: 11px;
   color: var(--ra-dark);
   font-style: normal;
@@ -997,6 +1031,34 @@ details.section-block[open] > .section-summary::before {
 /* Calmer info-blue border when only auto-normalised notes remain (nothing to review) */
 .panel.has-warnings.all-auto-normalised { border-left-color: #5fb8ca; }
 
+/* "Show detail" disclosure — reads as a clickable action (RA red, rotating
+   marker, dashed top border) rather than a subheading. */
+.import-notes-detail {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--border);
+}
+.import-notes-detail > summary {
+  cursor: pointer;
+  color: var(--ra-red);
+  font-weight: 500;
+  font-size: 13px;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+}
+.import-notes-detail > summary::-webkit-details-marker { display: none; }
+.import-notes-detail > summary::before {
+  content: "▶";
+  font-size: 9px;
+  color: var(--ra-red);
+  transition: transform 0.15s;
+  flex-shrink: 0;
+}
+.import-notes-detail[open] > summary::before { transform: rotate(90deg); }
+
 /* ------------------------------------------------------------------ */
 /* Warning filter badges (clickable summary row)                       */
 /* ------------------------------------------------------------------ */
@@ -1004,9 +1066,27 @@ details.section-block[open] > .section-summary::before {
 .warning-filter-bar { margin-bottom: 12px; display: flex; flex-wrap: wrap; gap: 6px; }
 
 .warning-filter-btn {
-  /* inherits .badge sizing via class; override to behave as a button */
+  /* inherits .badge palette via class; override sizing for chip shape
+     (pill, slightly larger than the base .badge). Scoped to the chip class
+     so it doesn't propagate to row-level badges — those keep their 3px
+     radius until the house-style pill update lands (see roadmap). */
   cursor: pointer;
   transition: opacity 0.15s, background 0.15s, border-color 0.15s;
+  padding: 3px 9px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 9999px;
+}
+
+/* Chip count — sits inside each filter chip, separated from the label by a
+   subtle vertical divider (currentColor so it inherits the chip's text colour
+   across blue/amber/red variants). */
+.warning-filter-btn .chip-count {
+  margin-left: 6px;
+  padding-left: 6px;
+  border-left: 1px solid currentColor;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Hover: deepen the existing colour */
@@ -1572,11 +1652,10 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .badge-ra {
   background: var(--ra-red);
   color: #fff;
-  font-size: 10px;
   font-weight: 700;
-  padding: 1px 5px;
-  border-radius: 3px;
   letter-spacing: 0.5px;
+  /* Inherits font-size, padding, border-radius from base .badge so it sits at
+     the same intrinsic height as Trimmed/Override/Norm in the flags column. */
 }
 
 .badge-company {
@@ -1623,10 +1702,9 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
   background: #e8f4f0;
   color: #1a7a5a;
   border: 1px solid #8fd6b8;
-  font-size: 10px;
   font-weight: 600;
-  padding: 1px 5px;
-  border-radius: 3px;
+  /* Inherits font-size/padding/border-radius from base .badge so it sits
+     at the same intrinsic height as other flag pills (was 10px / 1px 5px). */
 }
 
 .badge-known {
@@ -1639,14 +1717,16 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
   border-radius: 3px;
 }
 
+/* Override = "a human has edited this work". Semantically the opposite of the
+   amber 'needs review' warnings — so it gets the editorial-layer slate-blue
+   palette that's already used for .cell-overridden (italic slate) and the
+   work-detail panel borders. Inherits font-size/padding/border-radius from
+   base .badge so it sits at the same intrinsic height as other flag pills. */
 .badge-override {
-  background: #fff3e0;
-  color: #b36b00;
-  border: 1px solid #f0c040;
-  font-size: 10px;
+  background: #eef2fa;
+  color: #5070a0;
+  border: 1px solid #c7d8f5;
   font-weight: 600;
-  padding: 1px 5px;
-  border-radius: 3px;
 }
 
 .badge-merged {


### PR DESCRIPTION
Implements 4 of 5 changes from the Claude Design handoff for the import-review page. **Sticky venue + thead headers (Change 4) deferred** — low priority and would require scoping work on the shared `.section-summary` selector (used by LoW sections, Index letter groups, audit log panels, and the Tools accordion).

### Change 1 — Disambiguate the two "Edition stripped" chips
- `zero_edition_suppressed` → **Zero-edition dropped** (always means an edition of exactly 0)
- `edition_suppressed` → **Small edition merged with work** (edition total ≤ the admin-configurable `edition_suppress_max`; the listed edition IS the work itself, not a separate run)

Labels propagate to row-level flag pills via `_lowWarnLabel`. See `normalisation_service.py:374-477`.

### Change 2 — Warnings panel rebuilt as "Import notes" (LoW + Index)
Extracted `_renderImportNotesPanel(opts)` so both `_buildWarningsPanel` (LoW) and `_buildIndexWarningsPanel` (Index) render through one helper. Header + counts line (e.g. `1,224 items · 953 auto-normalised · 271 need review`) + two labelled chip groups (Auto-normalised, Needs review; high-severity reds sort first within Needs review) + helper hint with a `<kbd>⌥</kbd>` glyph + "Show detail — N of M items" disclosure. Panel border switches to calmer info-blue when nothing needs review. Chip click/Alt-click contract preserved verbatim.

### Change 3 — Tighten works-table row density
`line-height: 1.35` on \`tbody td\` + \`.title-cased-scan\` tightened (12.5px / 1px / 1.35).

**Deviation from spec:** did NOT adopt \`padding: 9px\` on cells. The base \`.data-table td\` is already 7px, so adopting 9px would work against the spec's density intent (spec appears mock-calibrated rather than codebase-calibrated). Line-height and subtitle tightening deliver the density.

### Change 5 — Row hover affordance + slide-in chevron
New \`.col-chev\` column + \`.works-row-chev\` span; inline \`cursor:pointer\` moved into CSS.

**Deviation from spec:** did NOT duplicate the spec's \`tr:hover { background: #fafafa }\` rule — it already ships via \`.data-table tr:hover td\` (style.css:599).

### Verification
- 959 tests pass
- JS parses (\`node --check frontend/app.js\`)
- Verified against the real \`Catalogue List 2025_260527.xlsx\` import (1,224 warnings → 953 auto-normalised / 271 need review)

### Blast-radius note
\`.warning-filter-bar\` is shared between the LoW and Index warnings panels — the rebuild was applied to both via the shared helper, so they stay in lockstep. No leak risk; this was the intentional scope.