### PR TITLE
Settings page redesign (Claude Design handoff)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -862,6 +862,8 @@ function router() {
   const indexDetailMatch = hash.match(/^#\/index\/([^/?]+)/);
   const tmplEditMatch = hash.match(/^#\/templates\/([^/]+)\/edit$/);
   const idxTmplEditMatch = hash.match(/^#\/index-templates\/([^/]+)\/edit$/);
+  // Settings deep-link: #/settings or #/settings/<users|preview|normalisation|reconciliation>
+  const settingsMatch = hash.match(/^#\/settings(?:\/([a-z]+))?\/?$/);
   if (importMatch)             renderDetail(importMatch[1]);
   else if (indexDetailMatch)   renderIndexDetail(indexDetailMatch[1]);
   else if (idxTmplEditMatch)   renderIndexTemplateEdit(idxTmplEditMatch[1]);
@@ -870,7 +872,7 @@ function router() {
   else if (hash === '#/templates')         renderTemplates();
   else if (hash === '#/audit')             renderAuditLog();
   else if (hash === '#/compare')           renderCompare();
-  else if (hash === '#/settings')          renderSettings();
+  else if (settingsMatch)                  renderSettings(settingsMatch[1] || null);
   else                                     renderList();
 }
 
@@ -1099,7 +1101,7 @@ function _reconcileRulesPanel(rc) {
     </section>`;
 }
 
-async function renderSettings() {
+async function renderSettings(initialTab) {
   const app = document.getElementById('app');
   app.innerHTML = '<p class="loading" style="padding:40px 0">Loading settings&hellip;</p>';
   let cfg, knownArtists, reconcileCfg;
@@ -1110,6 +1112,9 @@ async function renderSettings() {
       api('GET', '/reconcile-config').catch(() => null),
     ]);
   } catch (e) { app.innerHTML = `<p class="error">${esc(e.message)}</p>`; return; }
+
+  // Clear any prior dirty state from a previous Settings mount.
+  if (typeof _settingsDirty !== 'undefined') _settingsDirty.clear();
 
   // Load display prefs from localStorage
   const dispCfg = _getDisplayCfg();
@@ -1141,182 +1146,398 @@ async function renderSettings() {
     ? '<code>Edition of 0</code> is suppressed.'
     : `Editions of ${editionSuppressMax} or fewer are suppressed (an &ldquo;edition of 1&rdquo; is the work itself).`;
 
+  // --- Tab definitions ---
+  // Each tab carries a scope-chip explaining where its saves land. Users tab
+  // only renders for admins on Cognito auth (same guard as the old layout).
+  const isAdminCognito = canAdmin() && _authMode === 'cognito';
+  const tabDefs = [];
+  if (isAdminCognito) tabDefs.push({ key: 'users',          label: 'Users',          scope: 'access',       scopeTitle: 'User accounts and roles \u2014 saved server-side' });
+  tabDefs.push({                       key: 'preview',        label: 'Preview',        scope: 'this device',  scopeTitle: 'Stored in localStorage \u2014 affects this browser only' });
+  tabDefs.push({                       key: 'normalisation',  label: 'Normalisation',  scope: 'next import',  scopeTitle: 'Server config \u2014 applies on the next import' });
+  tabDefs.push({                       key: 'reconciliation', label: 'Reconciliation', scope: 'read-only',    scopeTitle: 'Hard-coded for now (not yet editable)' });
+  const validKeys = tabDefs.map(t => t.key);
+  // Default tab: respect deep-link; otherwise admin\u2192users, viewer\u2192preview.
+  let activeTab = (initialTab && validKeys.includes(initialTab))
+    ? initialTab
+    : (isAdminCognito ? 'users' : 'preview');
+
+  const tabBar = `<div class="settings-tabs" role="tablist">
+    ${tabDefs.map(t => `<button type="button" class="settings-tab${t.key === activeTab ? ' is-on' : ''}" role="tab" data-settings-tab="${t.key}" onclick="_settingsActivateTab('${t.key}')">${esc(t.label)}<span class="settings-tab-scope" title="${esc(t.scopeTitle)}">${esc(t.scope)}</span></button>`).join('')}
+  </div>`;
+
+  // --- Users pane (admin + Cognito only) ---
+  const usersPane = isAdminCognito ? `
+    <div class="settings-tab-pane" data-settings-tab="users"${activeTab === 'users' ? '' : ' hidden'}>
+      <h3 class="settings-group-heading">Users</h3>
+      <p class="settings-group-desc">Manage who can access the Catalogue Tool and their permission level.</p>
+      <section class="panel" id="users-panel">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+          <h4 class="panel-subheading" style="margin:0">User Accounts</h4>
+          <button class="btn btn-sm btn-primary" onclick="_showCreateUserForm()">+ New User</button>
+        </div>
+        <div id="create-user-form-slot"></div>
+        <table class="data-table" id="users-table">
+          <thead><tr><th>Email</th><th>Role</th><th>Status</th><th style="width:180px">Actions</th></tr></thead>
+          <tbody><tr><td colspan="4" class="muted">Loading&hellip;</td></tr></tbody>
+        </table>
+      </section>
+    </div>` : '';
+
+  // --- Preview pane ---
+  const previewPane = `
+    <div class="settings-tab-pane" data-settings-tab="preview"${activeTab === 'preview' ? '' : ' hidden'}>
+      <h3 class="settings-group-heading">Preview</h3>
+      <p class="settings-group-desc">Controls how values appear in this browser view only &mdash; stored locally, never sent to the server.</p>
+      <section class="panel">
+        <h4 class="panel-subheading">HTML Preview Formatting</h4>
+        <div class="settings-form">
+          <div class="form-row">
+            <label>Currency symbol</label>
+            <input id="disp-currency" type="text" value="${esc(dispCurr)}" style="max-width:80px">
+          </div>
+          <div class="form-row">
+            <label>Thousands separator</label>
+            <select id="disp-thousands-sep">${sepOpts(dispSep)}</select>
+          </div>
+          <div class="form-row">
+            <label>Decimal places</label>
+            <select id="disp-decimal-places">${dpOpts(dispDp)}</select>
+          </div>
+        </div>
+        <hr style="border:none;border-top:1px solid var(--border);margin:14px 0">
+        <div class="settings-form">
+          <div class="form-row">
+            <label>Edition prefix</label>
+            <input id="disp-edition-prefix" type="text" value="${esc(dispEdPrefix)}" style="max-width:200px">
+            <span class="form-hint">e.g. &ldquo;edition of&rdquo; &rarr; &ldquo;edition of 10 at &pound;500&rdquo;</span>
+          </div>
+          <div class="form-row">
+            <label>Edition brackets</label>
+            <label class="inline-check" style="text-transform:none;font-weight:normal">
+              <input type="checkbox" id="disp-edition-brackets"${dispEdBrackets ? ' checked' : ''}>
+              Wrap edition info in brackets
+            </label>
+          </div>
+        </div>
+        <hr style="border:none;border-top:1px solid var(--border);margin:14px 0">
+        <div class="settings-form">
+          <div class="form-row">
+            <label>Artwork column</label>
+            <label class="inline-check" style="text-transform:none;font-weight:normal">
+              <input type="checkbox" id="disp-show-artwork"${dispCfg.show_artwork_column ? ' checked' : ''}>
+              Show &ldquo;Artwork&rdquo; column in the List of Works
+            </label>
+            <span class="form-hint">The field remains editable in the override form regardless of this setting.</span>
+          </div>
+          <div class="form-row">
+            <label>Title case under title</label>
+            <label class="inline-check" style="text-transform:none;font-weight:normal">
+              <input type="checkbox" id="disp-show-title-cased"${dispCfg.show_title_cased ? ' checked' : ''}>
+              Show the title-cased title beneath each title in the List of Works
+            </label>
+            <span class="form-hint">A quick-scan aid for spotting title-casing mistakes. The all-caps title sits above its title-cased form.</span>
+          </div>
+        </div>
+        <div class="form-actions" style="margin-top:12px">
+          <button class="btn btn-primary btn-sm" onclick="savePreviewSettings()">Save Preview Settings</button>
+          <span id="preview-settings-status" class="status-msg"></span>
+        </div>
+      </section>
+    </div>`;
+
+  // --- Normalisation pane ---
+  // Part 4.4: "What\u2019s normalised automatically" moved to first position and
+  // wrapped in <details> so it's collapsed by default.
+  // Part 4.1: the four per-panel Save buttons are gone \u2014 replaced by a
+  // single sticky save bar at the bottom of this pane.
+  // Part 4.7: Honorifics + Title casing form-rows get the .form-row--wide modifier.
+  const normPane = `
+    <div class="settings-tab-pane" data-settings-tab="normalisation"${activeTab === 'normalisation' ? '' : ' hidden'}>
+      <h3 class="settings-group-heading">Normalisation</h3>
+      <p class="settings-group-desc">Applied when an Excel file is imported. Changes here take effect on the <em>next</em> import.</p>
+
+      <details class="settings-explainer">
+        <summary>What&rsquo;s normalised automatically</summary>
+        <div class="settings-explainer-body">
+          <p class="form-hint" style="margin:0 0 10px">Deterministic rules applied to every imported value. The raw spreadsheet value is always preserved alongside the normalised one.</p>
+          <table class="data-table">
+            <thead><tr><th>Field</th><th>Rule</th></tr></thead>
+            <tbody>
+              <tr><td>Price</td><td>Currency symbols and separators stripped to a number. A value with no parseable number (e.g. <code>NFS</code>, <code>_</code>) is kept as-is; a blank or missing price becomes <code>*</code>.</td></tr>
+              <tr><td>Edition</td><td>Parsed from <code>Edition of N</code> or <code>Edition of N at &pound;Y</code>. ${editionRuleText} <span class="muted">Configurable below.</span></td></tr>
+              <tr><td>Honorifics</td><td>Recognised tokens (below) are split from the end of the artist name into a separate field.</td></tr>
+              <tr><td>Whitespace</td><td>Leading/trailing whitespace trimmed from every field (flagged on the work).</td></tr>
+              <tr><td>Artwork</td><td>Parsed to an integer number of pieces.</td></tr>
+              <tr><td>Title, Medium</td><td>Trimmed; otherwise preserved verbatim (plus any text substitutions below).</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <section class="panel">
+        <h4 class="panel-subheading">Honorific Tokens</h4>
+        <div class="form-row form-row--wide">
+          <label>Recognised tokens</label>
+          <input id="cfg-honorific-tokens" type="text" value="${esc(honorificTokensValue)}"${canAdmin() ? '' : ' readonly'}>
+          <span class="form-hint">Comma-separated abbreviations stripped from the end of artist names, e.g. &ldquo;RA, HON, PRA&rdquo;</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h4 class="panel-subheading">Editions</h4>
+        <p class="form-hint" style="margin:0 0 10px">An &ldquo;edition of 1&rdquo; is the work itself, not a distinct copy &mdash; whether to drop it is an editorial choice, so it&rsquo;s configurable.</p>
+        <div class="form-row">
+          <label>Suppress editions of</label>
+          <input id="cfg-edition-suppress-max" type="number" min="0" max="10" value="${editionSuppressMax}" style="max-width:70px"${canAdmin() ? '' : ' disabled'}>
+          <span class="form-hint">or fewer. <strong>0</strong> drops only &ldquo;Edition of 0&rdquo;; <strong>1</strong> also drops &ldquo;Edition of 1&rdquo;. If suppressing one removes a work&rsquo;s only price, that&rsquo;s flagged for review.</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="subst-toolbar">
+          <h4 class="panel-subheading" style="margin:0">Text substitutions<span class="subst-count" id="subst-count">${substRules.length} rule${substRules.length === 1 ? '' : 's'}</span></h4>
+          ${ifAdmin('<button class="btn btn-sm" onclick="addSubstRule()">+ Add rule</button>')}
+        </div>
+        <p class="form-hint" style="margin:0 0 12px">Literal find &rarr; replace on the chosen fields, applied in order. Spaces count (shown as <span class="ws-hint">&middot;</span>), so <code><span class="ws-hint">&middot;</span>-<span class="ws-hint">&middot;</span></code> changes a spaced hyphen but never the hyphen in &ldquo;double-barrelled&rdquo;. <strong>Whole word only</strong> is the safe default for abbreviations (<code>mdf</code>&rarr;<code>MDF</code> won&rsquo;t touch <code>plaster</code>); turn it off for non-letter rules like <code>...</code>&rarr;<code>&hellip;</code>.</p>
+        <div id="subst-rules">
+          ${substRules.map(r => _substRuleRow(r)).join('')}
+        </div>
+      </section>
+
+      <section class="panel">
+        <h4 class="panel-subheading">Title casing</h4>
+        <p class="form-hint" style="margin:0 0 10px">A &ldquo;Title Case Title&rdquo; is derived for each work (used by outputs like the LPG; the List of Works keeps its house caps). All-caps input is best-effort &mdash; multi-letter Roman numerals are kept uppercase automatically, and the result is correctable per work via the Title Case Title override.</p>
+        <div class="form-row form-row--wide">
+          <label>Preserve casing for</label>
+          <input id="cfg-title-case-exceptions" type="text" value="${esc(titleCaseExceptionsValue)}"${canAdmin() ? '' : ' readonly'}>
+          <span class="form-hint">Comma-separated acronyms / stylised names kept as written, e.g. &ldquo;RA, USA, MoMA&rdquo;. Matched case-insensitively.</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="ka-sticky-toolbar">
+          <h4 class="panel-subheading" style="margin:0">Known Artists<span class="ka-count" id="ka-count">${knownArtists.length} entr${knownArtists.length === 1 ? 'y' : 'ies'}</span></h4>
+          <div class="ka-toolbar-actions">
+            ${ifEditor('<button class="btn btn-sm" onclick="_kaSetAllCollapsed(false)" title="Expand every Known Artist card">Expand all</button>')}
+            ${ifEditor('<button class="btn btn-sm" onclick="_kaSetAllCollapsed(true)" title="Collapse every Known Artist card">Collapse all</button>')}
+            ${ifEditor('<button class="btn btn-sm" onclick="addKnownArtistRow()">+ Add entry</button>')}
+            ${ifAdmin(`<button class="btn btn-sm" onclick="seedKnownArtists()" title="Load built-in known artists (won&rsquo;t overwrite existing entries)">Load defaults</button>`)}
+            ${ifAdmin(`<button class="btn btn-sm" onclick="exportKnownArtists()" title="Download all known artists as a seed-format JSON file">Export JSON</button>`)}
+            <span id="known-artists-action-status" class="status-msg"></span>
+          </div>
+        </div>
+        <p class="form-hint" style="margin:0 0 10px">Map recurring raw spreadsheet values to corrected output. Matched during import.</p>
+        <div class="ka-filter-bar">
+          <input type="search" id="ka-filter-q" placeholder="Search match or resolved name&hellip;" oninput="_kaApplyFilter()" autocomplete="off">
+          <div class="ka-segment" role="tablist">
+            <button type="button" class="is-on" data-ka-seg="all" onclick="_kaSetSegment('all')">All</button>
+            <button type="button" data-ka-seg="builtin" onclick="_kaSetSegment('builtin')">Built-in</button>
+            <button type="button" data-ka-seg="custom" onclick="_kaSetSegment('custom')">Custom</button>
+          </div>
+          <span class="ka-count" id="ka-filter-count" style="margin-left:auto"></span>
+        </div>
+        <div id="known-artists-list">
+          ${knownArtists.map(ka => _knownArtistCard(ka)).join('')}
+        </div>
+        <span id="known-artists-status" class="status-msg" style="display:block;margin-top:8px"></span>
+      </section>
+
+      ${ifAdmin(`<div class="norm-save-bar">
+        <button class="btn btn-primary btn-sm" onclick="saveNormalisationRules()">Save normalisation rules</button>
+        <span class="norm-dirty-msg" id="norm-dirty-msg"></span>
+        <span id="norm-tab-status" class="status-msg"></span>
+      </div>`)}
+    </div>`;
+
+  // --- Reconciliation pane (read-only) ---
+  const reconcilePane = `
+    <div class="settings-tab-pane" data-settings-tab="reconciliation"${activeTab === 'reconciliation' ? '' : ' hidden'}>
+      ${_reconcileRulesPanel(reconcileCfg)}
+    </div>`;
+
   app.innerHTML = `
     <h2 class="page-heading">Settings</h2>
-
-    ${canAdmin() && _authMode === 'cognito' ? `
-    <h3 class="settings-group-heading">Users</h3>
-    <p class="settings-group-desc">Manage who can access the Catalogue Tool and their permission level.</p>
-    <section class="panel" id="users-panel">
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
-        <h4 class="panel-subheading" style="margin:0">User Accounts</h4>
-        <button class="btn btn-sm btn-primary" onclick="_showCreateUserForm()">+ New User</button>
-      </div>
-      <div id="create-user-form-slot"></div>
-      <table class="data-table" id="users-table">
-        <thead><tr><th>Email</th><th>Role</th><th>Status</th><th style="width:180px">Actions</th></tr></thead>
-        <tbody><tr><td colspan="4" class="muted">Loading&hellip;</td></tr></tbody>
-      </table>
-    </section>
-    ` : ''}
-
-    <h3 class="settings-group-heading">Preview</h3>
-    <p class="settings-group-desc">Controls how values appear in this browser view only &mdash; stored locally, never sent to the server.</p>
-    <section class="panel">
-      <h4 class="panel-subheading">HTML Preview Formatting</h4>
-      <div class="settings-form">
-        <div class="form-row">
-          <label>Currency symbol</label>
-          <input id="disp-currency" type="text" value="${esc(dispCurr)}" style="max-width:80px">
-        </div>
-        <div class="form-row">
-          <label>Thousands separator</label>
-          <select id="disp-thousands-sep">${sepOpts(dispSep)}</select>
-        </div>
-        <div class="form-row">
-          <label>Decimal places</label>
-          <select id="disp-decimal-places">${dpOpts(dispDp)}</select>
-        </div>
-      </div>
-      <hr style="border:none;border-top:1px solid var(--border);margin:14px 0">
-      <div class="settings-form">
-        <div class="form-row">
-          <label>Edition prefix</label>
-          <input id="disp-edition-prefix" type="text" value="${esc(dispEdPrefix)}" style="max-width:200px">
-          <span class="form-hint">e.g. &ldquo;edition of&rdquo; &rarr; &ldquo;edition of 10 at &pound;500&rdquo;</span>
-        </div>
-        <div class="form-row">
-          <label>Edition brackets</label>
-          <label class="inline-check" style="text-transform:none;font-weight:normal">
-            <input type="checkbox" id="disp-edition-brackets"${dispEdBrackets ? ' checked' : ''}>
-            Wrap edition info in brackets
-          </label>
-        </div>
-      </div>
-      <hr style="border:none;border-top:1px solid var(--border);margin:14px 0">
-      <div class="settings-form">
-        <div class="form-row">
-          <label>Artwork column</label>
-          <label class="inline-check" style="text-transform:none;font-weight:normal">
-            <input type="checkbox" id="disp-show-artwork"${dispCfg.show_artwork_column ? ' checked' : ''}>
-            Show &ldquo;Artwork&rdquo; column in the List of Works
-          </label>
-          <span class="form-hint">The field remains editable in the override form regardless of this setting.</span>
-        </div>
-        <div class="form-row">
-          <label>Title case under title</label>
-          <label class="inline-check" style="text-transform:none;font-weight:normal">
-            <input type="checkbox" id="disp-show-title-cased"${dispCfg.show_title_cased ? ' checked' : ''}>
-            Show the title-cased title beneath each title in the List of Works
-          </label>
-          <span class="form-hint">A quick-scan aid for spotting title-casing mistakes. The all-caps title sits above its title-cased form.</span>
-        </div>
-      </div>
-      <div class="form-actions" style="margin-top:12px">
-        <button class="btn btn-primary btn-sm" onclick="savePreviewSettings()">Save Preview Settings</button>
-        <span id="preview-settings-status" class="status-msg"></span>
-      </div>
-    </section>
-
-    <h3 class="settings-group-heading">Normalisation</h3>
-    <p class="settings-group-desc">Applied when an Excel file is imported. Changes here take effect on the <em>next</em> import.</p>
-    <section class="panel">
-      <h4 class="panel-subheading">Honorific Tokens</h4>
-      <div class="form-row">
-        <label>Recognised tokens</label>
-        <input id="cfg-honorific-tokens" type="text" value="${esc(honorificTokensValue)}"${canAdmin() ? '' : ' readonly'}>
-        <span class="form-hint">Comma-separated abbreviations stripped from the end of artist names, e.g. &ldquo;RA, HON, PRA&rdquo;</span>
-      </div>
-      <div class="form-actions" style="margin-top:12px">
-        ${ifAdmin('<button class="btn btn-primary btn-sm" onclick="saveHonorificTokens()">Save Tokens</button>')}
-        <span id="honorific-status" class="status-msg"></span>
-      </div>
-    </section>
-
-    <section class="panel">
-      <h4 class="panel-subheading">What&rsquo;s normalised automatically</h4>
-      <p class="form-hint" style="margin:0 0 10px">Deterministic rules applied to every imported value. The raw spreadsheet value is always preserved alongside the normalised one.</p>
-      <table class="data-table">
-        <thead><tr><th>Field</th><th>Rule</th></tr></thead>
-        <tbody>
-          <tr><td>Price</td><td>Currency symbols and separators stripped to a number. A value with no parseable number (e.g. <code>NFS</code>, <code>_</code>) is kept as-is; a blank or missing price becomes <code>*</code>.</td></tr>
-          <tr><td>Edition</td><td>Parsed from <code>Edition of N</code> or <code>Edition of N at &pound;Y</code>. ${editionRuleText} <span class="muted">Configurable below.</span></td></tr>
-          <tr><td>Honorifics</td><td>Recognised tokens (above) are split from the end of the artist name into a separate field.</td></tr>
-          <tr><td>Whitespace</td><td>Leading/trailing whitespace trimmed from every field (flagged on the work).</td></tr>
-          <tr><td>Artwork</td><td>Parsed to an integer number of pieces.</td></tr>
-          <tr><td>Title, Medium</td><td>Trimmed; otherwise preserved verbatim (plus any text substitutions below).</td></tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section class="panel">
-      <h4 class="panel-subheading">Editions</h4>
-      <p class="form-hint" style="margin:0 0 10px">An &ldquo;edition of 1&rdquo; is the work itself, not a distinct copy &mdash; whether to drop it is an editorial choice, so it&rsquo;s configurable.</p>
-      <div class="form-row">
-        <label>Suppress editions of</label>
-        <input id="cfg-edition-suppress-max" type="number" min="0" max="10" value="${editionSuppressMax}" style="max-width:70px"${canAdmin() ? '' : ' disabled'}>
-        <span class="form-hint">or fewer. <strong>0</strong> drops only &ldquo;Edition of 0&rdquo;; <strong>1</strong> also drops &ldquo;Edition of 1&rdquo;. If suppressing one removes a work&rsquo;s only price, that&rsquo;s flagged for review.</span>
-      </div>
-      ${ifAdmin(`<div class="form-actions" style="margin-top:12px">
-        <button class="btn btn-primary btn-sm" onclick="saveNormalisationRules()">Save normalisation rules</button>
-        <span id="norm-rules-status" class="status-msg"></span>
-      </div>`)}
-    </section>
-
-    <section class="panel">
-      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:6px;margin-bottom:8px">
-        <h4 class="panel-subheading" style="margin:0">Text substitutions</h4>
-        ${ifAdmin('<button class="btn btn-sm" onclick="addSubstRule()">+ Add rule</button>')}
-      </div>
-      <p class="form-hint" style="margin:0 0 12px">Literal find &rarr; replace on the chosen fields, applied in order. Spaces count (shown as <span class="ws-hint">&middot;</span>), so <code><span class="ws-hint">&middot;</span>-<span class="ws-hint">&middot;</span></code> changes a spaced hyphen but never the hyphen in &ldquo;double-barrelled&rdquo;. <strong>Whole word only</strong> is the safe default for abbreviations (<code>mdf</code>&rarr;<code>MDF</code> won&rsquo;t touch <code>plaster</code>); turn it off for non-letter rules like <code>...</code>&rarr;<code>&hellip;</code>.</p>
-      <div id="subst-rules">
-        ${substRules.map(r => _substRuleRow(r)).join('')}
-      </div>
-      ${ifAdmin(`<div class="form-actions" style="margin-top:12px">
-        <button class="btn btn-primary btn-sm" onclick="saveNormalisationRules()">Save normalisation rules</button>
-        <span id="subst-status" class="status-msg"></span>
-      </div>`)}
-    </section>
-
-    <section class="panel">
-      <h4 class="panel-subheading">Title casing</h4>
-      <p class="form-hint" style="margin:0 0 10px">A &ldquo;Title Case Title&rdquo; is derived for each work (used by outputs like the LPG; the List of Works keeps its house caps). All-caps input is best-effort &mdash; multi-letter Roman numerals are kept uppercase automatically, and the result is correctable per work via the Title Case Title override.</p>
-      <div class="form-row">
-        <label>Preserve casing for</label>
-        <input id="cfg-title-case-exceptions" type="text" value="${esc(titleCaseExceptionsValue)}"${canAdmin() ? '' : ' readonly'}>
-        <span class="form-hint">Comma-separated acronyms / stylised names kept as written, e.g. &ldquo;RA, USA, MoMA&rdquo;. Matched case-insensitively.</span>
-      </div>
-      ${ifAdmin(`<div class="form-actions" style="margin-top:12px">
-        <button class="btn btn-primary btn-sm" onclick="saveNormalisationRules()">Save normalisation rules</button>
-        <span id="title-case-status" class="status-msg"></span>
-      </div>`)}
-    </section>
-
-    <section class="panel">
-      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:6px;margin-bottom:12px">
-        <h4 class="panel-subheading" style="margin:0">Known Artists</h4>
-        <div style="display:flex;align-items:center;gap:6px">
-          ${ifEditor('<button class="btn btn-sm" onclick="addKnownArtistRow()">+ Add entry</button>')}
-          ${ifAdmin(`<button class="btn btn-sm" onclick="seedKnownArtists()" title="Load built-in known artists (won&rsquo;t overwrite existing entries)">Load defaults</button>`)}
-          ${ifAdmin(`<button class="btn btn-sm" onclick="exportKnownArtists()" title="Download all known artists as a seed-format JSON file">Export JSON</button>`)}
-          <span id="known-artists-action-status" class="status-msg"></span>
-        </div>
-      </div>
-      <p class="form-hint" style="margin:0 0 16px">Map recurring raw spreadsheet values to corrected output. Matched during import.</p>
-      <div id="known-artists-list">
-        ${knownArtists.map(ka => _knownArtistCard(ka)).join('')}
-      </div>
-      <span id="known-artists-status" class="status-msg" style="display:block;margin-top:8px"></span>
-    </section>
-    ${_reconcileRulesPanel(reconcileCfg)}`;
+    ${tabBar}
+    ${usersPane}
+    ${previewPane}
+    ${normPane}
+    ${reconcilePane}`;
 
   // Populate Index Name previews now that the DOM is ready
   _refreshAllKaPreviews();
   // Initialise tri-state checkboxes (must set .indeterminate via JS)
   _initTriStateCheckboxes(document.getElementById('known-artists-list'));
+  // Wire dirty-flag tracking on the editable panes
+  _settingsWireDirty();
 
-  // Load users table (admin + Cognito only)
-  if (canAdmin() && _authMode === 'cognito') _loadUsersTable();
+  // Load users table when the Users tab is the active one on mount.
+  if (isAdminCognito && activeTab === 'users') _loadUsersTable();
+}
+
+// ===========================================================================
+// Settings tab navigation, dirty-flag tracking, leave guard
+// (2026-05-29 redesign)
+// ===========================================================================
+
+/** Track which Settings tabs hold unsaved edits. Cleared on every Settings mount. */
+const _settingsDirty = new Set();
+
+function _settingsHasDirty(tab) {
+  if (_settingsDirty.has(tab)) return true;
+  // Per-card Known Artists edits use their own dirty mechanism (saves go via
+  // dedicated /known-artists routes, not PUT /config). For tab-switch guard
+  // purposes, count any dirty KA card as Normalisation-tab dirty.
+  if (tab === 'normalisation' && document.querySelector('.ka-card[data-ka-dirty="true"]')) return true;
+  return false;
+}
+
+function _settingsMarkDirty(tab) {
+  if (!tab) return;
+  _settingsDirty.add(tab);
+  _settingsUpdateDirtyUI();
+}
+
+function _settingsMarkClean(tab) {
+  if (!tab) return;
+  _settingsDirty.delete(tab);
+  _settingsUpdateDirtyUI();
+}
+
+function _settingsUpdateDirtyUI() {
+  document.querySelectorAll('.settings-tab').forEach(btn => {
+    const tab = btn.dataset.settingsTab;
+    const dot = btn.querySelector('.tab-dirty-dot');
+    const isDirty = _settingsDirty.has(tab);
+    if (isDirty && !dot) {
+      btn.insertAdjacentHTML('beforeend', '<span class="tab-dirty-dot" title="Unsaved changes"></span>');
+    } else if (!isDirty && dot) {
+      dot.remove();
+    }
+  });
+  const msg = document.getElementById('norm-dirty-msg');
+  if (msg) msg.textContent = _settingsDirty.has('normalisation') ? '● Unsaved changes' : '';
+}
+
+/** Attach delegated input/change listeners to each editable Settings pane. */
+function _settingsWireDirty() {
+  const wireTab = (tab) => {
+    const pane = document.querySelector(`.settings-tab-pane[data-settings-tab="${tab}"]`);
+    if (!pane) return;
+    const onEdit = (e) => {
+      // Exclude view-only controls: filter bar, explainer disclosure.
+      if (e.target.closest('.ka-filter-bar')) return;
+      if (e.target.closest('.settings-explainer > summary')) return;
+      // KA card edits track via _markKaDirty per-card, not tab-level.
+      if (e.target.closest('.ka-card')) return;
+      _settingsMarkDirty(tab);
+    };
+    pane.addEventListener('input', onEdit);
+    pane.addEventListener('change', onEdit);
+  };
+  wireTab('preview');
+  wireTab('normalisation');
+}
+
+/** Show one Settings tab and hide the others. Guards tab switch when dirty. */
+function _settingsActivateTab(tabName, opts) {
+  const currentBtn = document.querySelector('.settings-tab.is-on');
+  const fromTab = currentBtn?.dataset.settingsTab;
+  if (fromTab && fromTab !== tabName && !opts?.skipDirtyCheck) {
+    if (_settingsHasDirty(fromTab)) {
+      const niceName = fromTab.charAt(0).toUpperCase() + fromTab.slice(1);
+      if (!window.confirm(`Discard unsaved changes on the ${niceName} tab?`)) return;
+      _settingsMarkClean(fromTab);
+      // Also reset per-card KA dirty state when discarding Normalisation.
+      if (fromTab === 'normalisation') {
+        document.querySelectorAll('.ka-card[data-ka-dirty="true"]').forEach(c => {
+          if (typeof _markKaClean === 'function') _markKaClean(c);
+          delete c.dataset.kaDirty;
+        });
+      }
+    }
+  }
+  document.querySelectorAll('.settings-tab').forEach(btn => {
+    btn.classList.toggle('is-on', btn.dataset.settingsTab === tabName);
+  });
+  document.querySelectorAll('.settings-tab-pane').forEach(pane => {
+    pane.hidden = pane.dataset.settingsTab !== tabName;
+  });
+  // Update hash without retriggering router.
+  const newHash = `#/settings/${tabName}`;
+  if (location.hash !== newHash) history.replaceState(null, '', newHash);
+  // Lazy-load Users table on first activation of that tab.
+  if (tabName === 'users' && canAdmin() && _authMode === 'cognito') {
+    const tbody = document.querySelector('#users-table tbody');
+    if (tbody && tbody.querySelector('td.muted, td.loading')) _loadUsersTable();
+  }
+}
+
+// Beforeunload guard — warn before losing unsaved Settings edits.
+window.addEventListener('beforeunload', (e) => {
+  if (!document.querySelector('.settings-tabs')) return;  // only on Settings
+  if (_settingsHasDirty('normalisation') || _settingsHasDirty('preview')) {
+    e.preventDefault();
+    e.returnValue = '';
+  }
+});
+
+// ===========================================================================
+// Known Artists: collapse/expand + filter (Parts 3, 4.5, 4.6)
+// ===========================================================================
+
+/**
+ * Toggle a Known Artist card's expanded state. Ignores clicks inside the
+ * .ka-card-actions group so Duplicate / Save / Delete don't double as toggles.
+ */
+function _toggleKaCard(headerEl, ev) {
+  if (ev && ev.target.closest('.ka-card-actions')) return;
+  headerEl.closest('.ka-card').classList.toggle('is-open');
+}
+
+function _kaSetAllCollapsed(collapsed) {
+  document.querySelectorAll('#known-artists-list .ka-card').forEach(c => {
+    c.classList.toggle('is-open', !collapsed);
+  });
+}
+
+function _kaSetSegment(seg) {
+  document.querySelectorAll('.ka-segment button').forEach(b => {
+    b.classList.toggle('is-on', b.dataset.kaSeg === seg);
+  });
+  _kaApplyFilter();
+}
+
+/**
+ * Filter the Known Artists list by segment (All / Built-in / Custom) plus
+ * a free-text search that matches BOTH the match-text (header title) AND
+ * the resolved name (the styled preview span). Matching the resolved name
+ * surfaces every match-text variant for the same group at once — the
+ * editorial reconciling task.
+ */
+function _kaApplyFilter() {
+  const q = (document.getElementById('ka-filter-q')?.value || '').trim().toLowerCase();
+  const seg = document.querySelector('.ka-segment button.is-on')?.dataset.kaSeg || 'all';
+  const cards = document.querySelectorAll('#known-artists-list .ka-card');
+  let shown = 0;
+  cards.forEach(card => {
+    const seeded = card.dataset.kaSeeded === 'true';
+    let segOk = true;
+    if (seg === 'builtin') segOk = seeded;
+    else if (seg === 'custom') segOk = !seeded;
+    let qOk = true;
+    if (q) {
+      const matchTxt = (card.querySelector('.ka-card-title')?.textContent || '').toLowerCase();
+      const previewTxt = (card.querySelector('.ka-preview')?.textContent || '').toLowerCase();
+      qOk = matchTxt.includes(q) || previewTxt.includes(q);
+    }
+    const show = segOk && qOk;
+    card.hidden = !show;
+    if (show) shown++;
+  });
+  const countEl = document.getElementById('ka-filter-count');
+  if (countEl) {
+    countEl.textContent = (q || seg !== 'all') ? `${shown} shown` : '';
+  }
 }
 
 async function saveSettings() {
@@ -1338,6 +1559,7 @@ function savePreviewSettings() {
       document.getElementById('disp-show-title-cased')?.checked ?? false,
     );
     if (statusEl) { statusEl.textContent = '\u2713 Saved'; statusEl.className = 'status-msg success'; }
+    if (typeof _settingsMarkClean === 'function') _settingsMarkClean('preview');
   } catch (e) {
     if (statusEl) { statusEl.textContent = `Error: ${esc(e.message)}`; statusEl.className = 'status-msg error'; }
   }
@@ -1365,23 +1587,29 @@ function _substRuleRow(rule) {
   const wholeWord = isNew ? true : Boolean(r.whole_word);
   const disabled = canAdmin() ? '' : ' disabled';
   const checks = _SUBST_FIELDS.map(([key, label]) =>
-    `<label class="inline-check" style="text-transform:none;font-weight:normal;margin-right:10px">
+    `<label class="inline-check" style="text-transform:none;font-weight:normal">
        <input type="checkbox" class="subst-field" data-field="${key}"${(r.fields || []).includes(key) ? ' checked' : ''}${disabled}> ${label}
      </label>`).join('');
+  // Two-line layout: inputs on line 1, field checks + whole-word + preview on line 2.
+  // Field checks use the `.subst-fields .inline-check { display: inline-flex }`
+  // override so the four labels sit on one row instead of stacking.
   return `<div class="subst-row">
-    <div class="subst-inputs">
+    <div class="subst-line1">
       <input type="text" class="subst-find" value="${esc(r.find)}" placeholder="find" oninput="_updateSubstPreview(this)"${disabled}>
       <span class="subst-arrow">&rarr;</span>
       <input type="text" class="subst-replace" value="${esc(r.replace)}" placeholder="replace" oninput="_updateSubstPreview(this)"${disabled}>
       ${ifAdmin('<button type="button" class="btn btn-sm subst-remove" onclick="removeSubstRule(this)" title="Remove rule">&times;</button>')}
     </div>
-    <div class="subst-fields">
-      ${checks}
-      <label class="inline-check" style="text-transform:none;font-weight:normal;margin-left:14px" title="Match only when find is a standalone word (no surrounding letters/digits). Leave OFF for non-letter rules like &ldquo;...&rdquo; &rarr; &ldquo;…&rdquo;.">
-        <input type="checkbox" class="subst-whole-word"${wholeWord ? ' checked' : ''}${disabled}> Whole word only
-      </label>
+    <div class="subst-line2">
+      <div class="subst-fields">
+        ${checks}
+        <span class="subst-sep"></span>
+        <label class="inline-check" style="text-transform:none;font-weight:normal" title="Match only when find is a standalone word (no surrounding letters/digits). Leave OFF for non-letter rules like &ldquo;...&rdquo; &rarr; &ldquo;…&rdquo;.">
+          <input type="checkbox" class="subst-whole-word"${wholeWord ? ' checked' : ''}${disabled}> Whole word only
+        </label>
+      </div>
+      <div class="subst-preview"><code>${_visSpaces(r.find)}</code> &rarr; <code>${_visSpaces(r.replace)}</code></div>
     </div>
-    <div class="subst-preview"><code>${_visSpaces(r.find)}</code> &rarr; <code>${_visSpaces(r.replace)}</code></div>
   </div>`;
 }
 
@@ -1396,11 +1624,31 @@ function _updateSubstPreview(inputEl) {
 
 function addSubstRule() {
   const list = document.getElementById('subst-rules');
-  if (list) list.insertAdjacentHTML('beforeend', _substRuleRow(null));
+  if (!list) return;
+  list.insertAdjacentHTML('beforeend', _substRuleRow(null));
+  // Focus the new row's find field and scroll it into view — matches the
+  // pattern used by addKnownArtistRow.
+  const newRow = list.lastElementChild;
+  if (newRow) {
+    const find = newRow.querySelector('.subst-find');
+    if (find) find.focus();
+    newRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+  _refreshSubstCount();
+  if (typeof _settingsMarkDirty === 'function') _settingsMarkDirty('normalisation');
+}
+
+function _refreshSubstCount() {
+  const el = document.getElementById('subst-count');
+  if (!el) return;
+  const n = document.querySelectorAll('#subst-rules .subst-row').length;
+  el.textContent = `${n} rule${n === 1 ? '' : 's'}`;
 }
 
 function removeSubstRule(btn) {
   btn.closest('.subst-row')?.remove();
+  _refreshSubstCount();
+  if (typeof _settingsMarkDirty === 'function') _settingsMarkDirty('normalisation');
 }
 
 function _gatherSubstitutions() {
@@ -1437,14 +1685,19 @@ async function _saveNormalisationConfig(statusIds, okMsg) {
 }
 
 function saveHonorificTokens() {
-  return _saveNormalisationConfig(['honorific-status'], '\u2713 Saved');
+  // Legacy entry point \u2014 the four per-panel save buttons were consolidated
+  // into a single Normalisation-tab save bar (2026-05-29 redesign). Kept as a
+  // shim in case any external link/test still calls it; routes through the
+  // same gather + status target as saveNormalisationRules.
+  return saveNormalisationRules();
 }
 
-function saveNormalisationRules() {
-  return _saveNormalisationConfig(
-    ['norm-rules-status', 'subst-status', 'title-case-status'],
+async function saveNormalisationRules() {
+  await _saveNormalisationConfig(
+    ['norm-tab-status'],
     '\u2713 Saved \u2014 applies to the next import',
   );
+  if (typeof _settingsMarkClean === 'function') _settingsMarkClean('normalisation');
 }
 
 // ---------------------------------------------------------------------------
@@ -1928,20 +2181,28 @@ function _knownArtistCard(ka) {
   const matchDisplay = [ka.match_first_name, ka.match_last_name].filter(Boolean).join(' ') || 'New Entry';
   const seededCls = seeded ? ' ka-card-seeded' : '';
 
-  // Header actions differ for seeded vs editable cards
+  // Header actions differ for seeded vs editable cards. The built-in/custom
+  // pill lives in the header (not in actions) so the distinction stays visible
+  // while the card is collapsed.
   let actions = '';
   if (seeded && canEdit()) {
-    actions = `<span class="badge badge-builtin">built-in</span>
-      <button class="btn btn-sm" onclick="duplicateKnownArtist(this)" title="Create an editable copy of this entry">Duplicate</button>`;
+    actions = `<button class="btn btn-sm" onclick="duplicateKnownArtist(this)" title="Create an editable copy of this entry">Duplicate</button>`;
   } else if (!seeded) {
     actions = ifEditor(`<button class="btn btn-sm ka-save-btn" onclick="saveKnownArtistRow(this)" title="Save" disabled>&#10003; Save</button>
         <button class="btn btn-sm btn-danger" onclick="deleteKnownArtist(this)" title="Delete">&times; Delete</button>
         <span class="ka-card-status status-msg"></span>`);
   }
+  const pill = seeded
+    ? '<span class="badge badge-builtin">built-in</span>'
+    : '<span class="badge badge-custom">custom</span>';
 
+  // Cards start collapsed by default (Part 3). Click anywhere on the header
+  // outside .ka-card-actions to toggle; the chevron rotates via CSS.
   return `<div class="ka-card${seededCls}" data-ka-id="${esc(id)}" data-ka-seeded="${seeded}">
-    <div class="ka-card-header">
+    <div class="ka-card-header" onclick="_toggleKaCard(this, event)">
+      <span class="ka-chev">&rsaquo;</span>
       <span class="ka-card-title">${esc(matchDisplay)}</span>
+      ${pill}
       <span class="ka-card-actions">
         ${actions}
       </span>
@@ -2053,7 +2314,23 @@ function addKnownArtistRow() {
   _initTriStateCheckboxes(newest);
   _updateKaPreview(newest);
   _markKaDirty(newest);  // new entry is always unsaved
+  // New cards open expanded so the editor is immediately visible (Part 3).
+  newest.classList.add('is-open');
+  // Clear any active filter so the new card can't land hidden (Part 4.6).
+  const filterInput = document.getElementById('ka-filter-q');
+  if (filterInput && filterInput.value) { filterInput.value = ''; }
+  if (typeof _kaSetSegment === 'function') _kaSetSegment('all');  // also re-runs the filter
   newest.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  // Focus the first match-pattern field so the user can start typing.
+  newest.querySelector('.ka-match-first')?.focus();
+  _refreshKaCount();
+}
+
+function _refreshKaCount() {
+  const el = document.getElementById('ka-count');
+  if (!el) return;
+  const n = document.querySelectorAll('#known-artists-list .ka-card').length;
+  el.textContent = `${n} entr${n === 1 ? 'y' : 'ies'}`;
 }
 
 function _readKaRow(tr) {
@@ -2137,11 +2414,12 @@ async function deleteKnownArtist(btn) {
   const tr = btn.closest('.ka-card');
   const id = tr.dataset.kaId;
   const statusEl = tr.querySelector('.ka-card-status');
-  if (!id) { tr.remove(); return; }
+  if (!id) { tr.remove(); _refreshKaCount(); return; }
   if (!confirm('Delete this known artist entry?')) return;
   try {
     await api('DELETE', `/known-artists/${id}`);
     tr.remove();
+    _refreshKaCount();
   } catch (e) {
     if (statusEl) { statusEl.textContent = `Error: ${e.message}`; statusEl.className = 'ka-card-status status-msg error'; }
   }
@@ -2159,7 +2437,9 @@ async function duplicateKnownArtist(btn) {
     _initTriStateCheckboxes(newCard);
     _updateKaPreview(newCard);
     _updateKaCompanyState(newCard);
+    newCard.classList.add('is-open');  // open the editable copy for immediate editing
     newCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    _refreshKaCount();
     const newStatusEl = newCard.querySelector('.ka-card-status');
     if (newStatusEl) { newStatusEl.textContent = '\u2713 Editable copy created'; newStatusEl.className = 'ka-card-status status-msg success'; }
   } catch (e) {
@@ -2182,6 +2462,8 @@ async function seedKnownArtists() {
     list.innerHTML = knownArtists.map(ka => _knownArtistCard(ka)).join('');
     _refreshAllKaPreviews();
     _initTriStateCheckboxes(list);
+    _refreshKaCount();
+    if (typeof _kaApplyFilter === 'function') _kaApplyFilter();
   } catch (e) {
     if (statusEl) { statusEl.textContent = `Error: ${e.message}`; statusEl.className = 'status-msg error'; }
   }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2189,40 +2189,76 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .cmp-diffs-cell { max-width: 260px; }
 .cmp-diffs-cell .badge { margin: 1px 2px; }
 
-/* --- Text-substitution rule editor (Settings → Normalisation) --- */
+/* --- Text-substitution rule editor (Settings → Normalisation) ---
+ * Compacted 2026-05-29 per Settings page redesign handoff:
+ *   - Two lines per rule (was four), via .subst-line1/.subst-line2
+ *   - Field checkboxes laid out horizontally; scoped override of the global
+ *     `.inline-check { display: flex }` rule via `.subst-fields .inline-check`
+ *   - Sticky `+ Add rule` toolbar (.subst-toolbar) so Add stays reachable
+ *     however far you've scrolled. `top: var(--settings-tab-h)` pins below
+ *     the Settings tab bar.
+ *   - Pixel values applied as briefed (9px row, 4px first-child top) — see
+ *     deviations note in the handoff report.
+ */
 .subst-row {
-  padding: 10px 0;
+  padding: 9px 0;
   border-bottom: 1px solid var(--border, #e5e5e5);
 }
-.subst-row:first-child { padding-top: 0; }
-.subst-row:last-child { border-bottom: none; }
-.subst-inputs {
+.subst-row:first-child { padding-top: 4px; }
+.subst-row:last-child  { border-bottom: none; }
+
+.subst-line1 {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
 }
-.subst-inputs input[type="text"] {
+.subst-line1 input[type="text"] {
   flex: 1 1 180px;
-  min-width: 120px;
+  min-width: 110px;
   padding: 5px 8px;
   border: 1px solid var(--border, #ccc);
   border-radius: 4px;
   font-family: inherit;
+  font-size: 13px;
 }
-.subst-arrow { color: var(--muted, #888); font-weight: bold; }
-.subst-remove { color: #b00; }
-.subst-fields { margin-top: 6px; font-size: 0.85rem; }
-.subst-preview {
+.subst-arrow  { color: var(--muted, #888); font-weight: bold; flex: 0 0 auto; }
+.subst-remove { flex: 0 0 auto; color: #b00; line-height: 1; padding: 4px 9px; }
+
+.subst-line2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 18px;
+  flex-wrap: wrap;
   margin-top: 6px;
-  font-size: 0.85rem;
+}
+.subst-fields {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px 16px;
+}
+/* Key line: keeps the four field labels on one row by scoping the override
+ * to inside .subst-fields — the global .inline-check rule stays untouched. */
+.subst-fields .inline-check { display: inline-flex; }
+.subst-sep {
+  width: 1px;
+  align-self: stretch;
+  min-height: 14px;
+  background: var(--border);
+  margin: 0 2px;
+}
+.subst-preview {
+  font-size: 12px;
   color: var(--muted, #777);
+  margin-left: auto;
+  white-space: nowrap;
 }
 .subst-preview code {
   background: #f5f5f5;
   padding: 1px 5px;
   border-radius: 3px;
-  white-space: pre-wrap;
+  white-space: nowrap;
 }
 
 /* ==================================================================== */
@@ -2527,3 +2563,265 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .fld__lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
 .fld input, .fld select { padding: 5px 8px; border: 1px solid var(--border); border-radius: var(--radius); background: #fff; font-size: 13px; }
 .fld input:disabled, .fld select:disabled { background: var(--bg-alt); color: var(--muted); }
+
+
+/* ============================================================================
+ * Settings page redesign (2026-05-29 — design handoff)
+ *   Part 2: top tab bar
+ *   Part 4.3: scope badges on each tab
+ *   Part 4.4: collapsible "What's normalised automatically" panel
+ *   Part 1.C: sticky `+ Add rule` toolbar (.subst-toolbar)
+ *   Part 3 + 4.6: Known Artists collapsible cards, sticky KA toolbar,
+ *                 filter bar, custom-badge, expand/collapse-all
+ *   Part 4.1: single sticky save bar per tab (.norm-save-bar)
+ *   Part 4.2: dirty-flag indicator (.tab-dirty-dot)
+ *   Part 4.7: wide form-row modifier for honorific/title-case lists
+ * Settings is a closed surface — all new selectors are Settings-only.
+ * ============================================================================ */
+
+:root { --settings-tab-h: 44px; }
+
+/* --- Part 2: top tab bar (underline idiom, mock default) --- */
+.settings-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 22px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--bg);
+  padding-top: 4px;
+}
+.settings-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 10px 16px 11px;
+  font: 500 13px var(--font);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: -1px;
+}
+.settings-tab:hover:not(.is-on) { color: var(--ra-dark); }
+.settings-tab.is-on {
+  color: var(--ra-dark);
+  font-weight: 600;
+  border-bottom-color: var(--ra-red);
+}
+
+/* --- Part 4.3: scope badge chips inside each tab label --- */
+.settings-tab-scope {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border-radius: 10px;
+  background: var(--bg-alt);
+  color: var(--muted-2);
+  border: 1px solid var(--border);
+  line-height: 1.2;
+}
+.settings-tab.is-on .settings-tab-scope {
+  background: #fff;
+  color: var(--ra-dark);
+  border-color: var(--border-strong);
+}
+
+/* --- Part 4.2: amber dot on tab when its content has unsaved changes --- */
+.tab-dirty-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--warning);
+  display: inline-block;
+  flex: 0 0 auto;
+}
+
+/* --- Settings group containers (one per tab) --- */
+.settings-tab-pane[hidden] { display: none; }
+/* The H3 group-heading inside each pane gives the tab content a clear
+ * top-of-section label (helps screen readers; visually redundant with the
+ * tab label but harmless). The first-of-type margin tweak below preserves
+ * the original look. */
+
+/* --- Part 4.4: collapsible "What's normalised automatically" reference panel --- */
+.settings-explainer { /* the <details> wrapper around the read-only reference */
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-alt);
+  padding: 0;
+  margin: 0 0 16px;
+}
+.settings-explainer > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 9px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ra-dark);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.settings-explainer > summary::-webkit-details-marker { display: none; }
+.settings-explainer > summary::before {
+  content: "\203A";   /* › — rotates 90deg when open */
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1;
+  transition: transform .15s;
+  display: inline-block;
+}
+.settings-explainer[open] > summary::before { transform: rotate(90deg); }
+.settings-explainer > .settings-explainer-body { padding: 0 14px 12px; }
+.settings-explainer > .settings-explainer-body > p:first-child { margin-top: 0; }
+
+/* --- Part 1.C: sticky toolbar pinning `+ Add rule` to the viewport --- */
+.subst-toolbar {
+  position: sticky;
+  top: var(--settings-tab-h);
+  z-index: 10;
+  background: var(--card);
+  padding: 10px 0;
+  margin: -4px 0 8px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.subst-count, .ka-count {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  margin-left: 8px;
+}
+
+/* --- Part 3: Known Artists collapsible cards --- */
+.ka-card-header { cursor: pointer; gap: 10px; }
+/* Title takes leftover space so the trailing pill + actions sit at the right edge. */
+.ka-card-header .ka-card-title { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ka-card-header .ka-chev {
+  flex: 0 0 auto;
+  color: #8a93a0;
+  font-size: 16px;
+  line-height: 1;
+  transition: transform .15s;
+  user-select: none;
+  margin-right: 4px;
+}
+.ka-card.is-open > .ka-card-header .ka-chev { transform: rotate(90deg); }
+.ka-card:not(.is-open) .ka-card-header { border-bottom: none; }
+.ka-card:not(.is-open) .ka-preview-bar {
+  border-bottom: none;
+  border-radius: 0 0 var(--radius) var(--radius);
+}
+.ka-card:not(.is-open) .ka-card-body { display: none; }
+
+/* Custom (user-defined) badge — green mirror of the existing blue built-in. */
+.badge-custom {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 3px 8px;
+  border-radius: 10px;
+  background: #edf6f0;
+  color: #2e7d4f;
+  border: 1px solid #bbdcc6;
+}
+
+/* --- Part 4.6: sticky KA toolbar (parallel to .subst-toolbar) --- */
+.ka-sticky-toolbar {
+  position: sticky;
+  top: var(--settings-tab-h);
+  z-index: 9;            /* below substitutions toolbar (same tab they don't co-exist, but kept ordered defensively) */
+  background: var(--card);
+  padding: 10px 0;
+  margin: -4px 0 12px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ka-sticky-toolbar .ka-toolbar-actions { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+
+/* --- Part 4.5: filter / search on Known Artists --- */
+.ka-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.ka-filter-bar input[type="search"] {
+  flex: 1 1 220px;
+  min-width: 160px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font: 13px var(--font);
+  background: #fff;
+}
+.ka-segment {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: #fff;
+}
+.ka-segment button {
+  background: transparent;
+  border: none;
+  padding: 5px 10px;
+  font: 500 12px var(--font);
+  color: var(--muted-2);
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+}
+.ka-segment button:last-child { border-right: none; }
+.ka-segment button.is-on {
+  background: var(--ra-dark);
+  color: #fff;
+}
+.ka-card[hidden] { display: none; }   /* filter hides via [hidden] attr */
+
+/* --- Part 4.1: single sticky save footer for the Normalisation tab --- */
+.norm-save-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 15;
+  margin: 20px -16px -16px;
+  padding: 12px 16px;
+  background: rgba(255,255,255,0.96);
+  backdrop-filter: blur(2px);
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.norm-save-bar .norm-dirty-msg {
+  font-size: 12px;
+  color: var(--warning);
+  font-weight: 500;
+}
+.norm-save-bar .norm-dirty-msg:empty { display: none; }
+
+/* --- Part 4.7: wide form-row modifier (honorifics + title-case) --- */
+.form-row--wide { flex-direction: row; flex-wrap: wrap; align-items: baseline; gap: 4px 14px; }
+.form-row--wide > label { flex: 0 0 100%; }
+.form-row--wide > input { flex: 1 1 280px; width: auto; min-width: 200px; }
+.form-row--wide > .form-hint { flex: 0 1 36ch; margin-top: 0; }


### PR DESCRIPTION
Implements all four parts of the 2026-05-29 Claude Design handoff for
the Settings page. Frontend only — no backend, alembic, config-schema,
or test changes. Saved `text_substitutions` shape unchanged and
`_gatherSubstitutions` selectors still resolve, so existing configs
round-trip cleanly. Settings is a closed surface (LoW + Index don't
render here), so blast-radius from the shared-class primitives
(`.data-table`, `.section-block`, `.warning-filter-bar`) was confirmed
nil — these were not touched.

### Part 1 — Compact the Text-substitutions editor

- Two-line rule layout via new `.subst-line1` / `.subst-line2` /
  `.subst-sep` classes; the four field checkboxes sit on one
  horizontal row.
- Scoped override `.subst-fields .inline-check { display: inline-flex }`
  — the global `.inline-check` rule stays untouched.
- Sticky `+ Add rule` toolbar (`.subst-toolbar`) pinned at
  `top: var(--settings-tab-h)` so it stays below the tab bar.
- `addSubstRule` now focuses the new row's `.subst-find` and
  `scrollIntoView`s it (matches `addKnownArtistRow` pattern).
- Live rule count next to the heading; preview kept always-on (the
  spec's "only when spaces" alternative was declined).
- `.subst-row` padding values (9px / 4px first-child) applied per the
  spec verbatim — flagged in the deviations note that they go in
  opposite directions and the real density win is structural.

### Part 2 — Settings sections as tabs

- New `.settings-tabs` / `.settings-tab` underline idiom (lighter than
  reusing `.tabbtn`; mock default).
- `renderSettings` now emits each group inside `<div
  class="settings-tab-pane" data-settings-tab="...">` and toggles
  display via the `[hidden]` attribute. The four panes all stay in
  the DOM so `document.getElementById(...)` status wiring keeps
  working.
- Hash router extended: `#/settings/<users|preview|normalisation|reconciliation>`
  deep-links; bare `#/settings` defaults to `users` for admin+Cognito,
  otherwise `preview`.
- `_loadUsersTable` now lazy-fires on first activation of the Users
  tab instead of on every Settings mount.
- Users tab still gated on `canAdmin() && _authMode === 'cognito'`.

### Part 3 — Collapse the Known Artists list by default

- `.ka-card-header` gains a chevron and click-to-toggle; clicks inside
  `.ka-card-actions` are ignored so Duplicate / Save / Delete don't
  double as toggles. New cards (`addKnownArtistRow`,
  `duplicateKnownArtist`) open expanded.
- `badge-builtin` moved out of `.ka-card-actions` into the header
  proper so the seeded/custom distinction stays visible while
  collapsed.
- New `.badge-custom` pill (green mirror of the blue `.badge-builtin`)
  for user-defined entries.
- `.ka-card-header` gets a `flex: 1 1 auto; text-overflow: ellipsis`
  rule on `.ka-card-title` so the new chevron+title+pill+actions row
  resolves to `[chev title … pill actions]` instead of even
  `space-between`.
- Index Preview bar stays outside the collapsed body so the styled
  preview (`.idx-ra-styled`, `.honorifics-pill`) remains the one-line
  summary while the card is closed — `_updateKaPreview` untouched.

### Part 4 — Further refinements

- **4.1** Single sticky `.norm-save-bar` at the bottom of the
  Normalisation pane replaces the four per-panel `Save normalisation
  rules` buttons. `saveNormalisationRules` now writes to one
  `norm-tab-status` element. Same `_gatherNormalisationConfig`
  payload, byte-identical `PUT /config`. `saveHonorificTokens` kept
  as a shim that delegates to `saveNormalisationRules` for any caller
  (no longer wired to a button).
- **4.2** Dirty-flag tracking per tab via `_settingsDirty` Set; amber
  `.tab-dirty-dot` on the tab, `● Unsaved changes` text in the save
  bar. Tab-switch confirms before discarding; `beforeunload` guards
  page navigation. Filter bar and explainer disclosure are excluded;
  per-card KA dirty (existing `_markKaDirty`) is folded in for
  Normalisation only.
- **4.3** Scope chips on each tab label (`.settings-tab-scope`):
  *access* / *this device* / *next import* / *read-only*.
- **4.4** "What's normalised automatically" wrapped in `<details
  class="settings-explainer">` — collapsed by default and moved to
  the top of the Normalisation tab (was position 2).
- **4.5** Known Artists filter bar: search box matches both
  `.ka-card-title` AND `.ka-preview` `textContent` (so "Caruso"
  surfaces every match-text variant); All/Built-in/Custom segment
  toggles via `[data-ka-seg]`. Filter is presentational —
  gather/save logic unaffected.
- **4.6** `.ka-sticky-toolbar` with Expand all / Collapse all /
  + Add entry / Load defaults / Export JSON. New cards clear any
  active filter so they can't land hidden.
- **4.7** `.form-row--wide` modifier added to the Honorifics and
  Title casing rows so the long comma-lists fill the row with the
  helper note to the right.

### Behaviour preservation

- All save endpoints, payloads, and gather functions unchanged.
- All form field IDs preserved (`cfg-honorific-tokens`,
  `cfg-edition-suppress-max`, `cfg-title-case-exceptions`, `disp-*`).
- Substitution rule defaults preserved (`whole_word: true`,
  `fields: ['title', 'medium']`).
- Admin/editor guards (`canAdmin`, `canEdit`, `ifAdmin`, `ifEditor`)
  preserved on every save button, readonly/disabled attribute, and KA
  action.
- 4 old per-panel status IDs (`norm-rules-status`, `honorific-status`,
  `subst-status`, `title-case-status`) cleanly removed; replaced by
  the single `norm-tab-status` target.

959 tests pass. Frontend is baked into the Docker image — rebuild to
see changes locally (`docker compose up -d --build app`).
