### PR TITLE
Add Ruff lint baseline + pre-commit hooks + CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,30 @@ env:
   TASK_DEF_PROD: .aws/task-definition-prod.json
 
 jobs:
-  # ── 1. Unit tests (all branches + PRs) ─────────────────────────────
+  # ── 1. Lint (all branches + PRs) ───────────────────────────────────
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install Ruff
+        run: pip install ruff==0.15.15
+
+      - name: Ruff check
+        run: ruff check backend/ tests/
+
+  # ── 2. Unit tests (all branches + PRs) ─────────────────────────────
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -39,12 +62,14 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Run tests
-        run: python -m pytest tests/ -x -q --tb=short
+        # Note: no -x flag — we want the full failure list in CI for triage,
+        # even if it costs a few extra seconds when something is broken.
+        run: python -m pytest tests/ -q --tb=short
 
-  # ── 2. Build Docker image + smoke test (all branches) ──────────────
+  # ── 3. Build Docker image + smoke test (all branches) ──────────────
   docker:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [lint, test]
     timeout-minutes: 10
 
     steps:
@@ -85,7 +110,7 @@ jobs:
           path: /tmp/catalogue-app.tar.gz
           retention-days: 1
 
-  # ── 3. Push to ECR (main branch only) ──────────────────────────────
+  # ── 4. Push to ECR (main branch only) ──────────────────────────────
   push-ecr:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -127,7 +152,7 @@ jobs:
           docker push "$IMAGE:latest"
           echo "image=$IMAGE:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
-  # ── 4. Deploy to PRODUCTION (main branch only, automatic) ─────────
+  # ── 5. Deploy to PRODUCTION (main branch only, automatic) ─────────
   deploy-prod:
 
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# Run on commit: ruff lint + format, and a handful of generic hygiene hooks.
+# Install once with:  pre-commit install
+# Run manually with:  pre-commit run --all-files
+#
+# Ruff version is pinned to match requirements-dev.txt and CI.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.15
+    hooks:
+      - id: ruff
+        args: [--fix]
+      # `ruff-format` is intentionally NOT enabled yet — running it once would
+      # produce a sweeping diff across the whole codebase. Enable in a
+      # dedicated PR when ready.
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=2000]

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,32 +1,30 @@
 import sys
-from pathlib import Path
 from logging.config import fileConfig
-
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from pathlib import Path
 
 from alembic import context
+from sqlalchemy import engine_from_config, pool
 
 # Ensure the project root is on sys.path so "backend.app..." imports work
 # when running `alembic` from the repo root.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from backend.app.config import DATABASE_URL  # noqa: E402
-from backend.app.db import Base  # noqa: E402
+import backend.app.models.audit_log_model  # noqa: F401, E402
+import backend.app.models.export_snapshot_model  # noqa: F401, E402
 
 # Import every model so Base.metadata is fully populated
 import backend.app.models.import_model  # noqa: F401, E402
-import backend.app.models.section_model  # noqa: F401, E402
-import backend.app.models.work_model  # noqa: F401, E402
-import backend.app.models.override_model  # noqa: F401, E402
-import backend.app.models.ruleset_model  # noqa: F401, E402
-import backend.app.models.validation_warning_model  # noqa: F401, E402
-import backend.app.models.audit_log_model  # noqa: F401, E402
-import backend.app.models.export_snapshot_model  # noqa: F401, E402
 import backend.app.models.index_artist_model  # noqa: F401, E402
 import backend.app.models.index_cat_number_model  # noqa: F401, E402
 import backend.app.models.index_override_model  # noqa: F401, E402
 import backend.app.models.known_artist_model  # noqa: F401, E402
+import backend.app.models.override_model  # noqa: F401, E402
+import backend.app.models.ruleset_model  # noqa: F401, E402
+import backend.app.models.section_model  # noqa: F401, E402
+import backend.app.models.validation_warning_model  # noqa: F401, E402
+import backend.app.models.work_model  # noqa: F401, E402
+from backend.app.config import DATABASE_URL  # noqa: E402
+from backend.app.db import Base  # noqa: E402
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -2,19 +2,20 @@
 Audit log routes: per-import and global audit trail.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.orm import Session
-from sqlalchemy import desc
 from typing import List
 from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
 
 from backend.app.api.deps import get_db
 from backend.app.api.schemas import AuditLogOut
 from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.import_model import Import
-from backend.app.models.work_model import Work
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.ruleset_model import Ruleset
+from backend.app.models.work_model import Work
 
 router = APIRouter(tags=["audit"])
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -31,15 +31,15 @@ from enum import IntEnum
 from functools import lru_cache
 from typing import Optional
 
-from fastapi import Header, HTTPException, Request, status, Depends
 import jwt
+from fastapi import Depends, Header, HTTPException, Request, status
 from jwt.exceptions import InvalidTokenError as JWTError
 
 from backend.app.config import (
     API_KEY,
-    COGNITO_USER_POOL_ID,
     COGNITO_CLIENT_ID,
     COGNITO_REGION,
+    COGNITO_USER_POOL_ID,
 )
 
 logger = logging.getLogger(__name__)

--- a/backend/app/api/compare.py
+++ b/backend/app/api/compare.py
@@ -6,9 +6,10 @@ Artists' Index import by catalogue number.  The comparison is purely
 read-only and uses resolved (post-override) values.
 """
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from uuid import UUID
 
 from backend.app.api.deps import get_db
 from backend.app.api.schemas import (

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -2,7 +2,6 @@
 Shared FastAPI dependencies used by all route modules.
 """
 
-from sqlalchemy.orm import Session
 from backend.app.db import SessionLocal
 
 

--- a/backend/app/api/import_routes.py
+++ b/backend/app/api/import_routes.py
@@ -8,22 +8,22 @@ in dedicated modules under ``backend/app/api/``.
 
 from fastapi import APIRouter, Depends
 
-from backend.app.api.auth import require_api_key
-from backend.app.api.deps import get_db  # noqa: F401  re-exported for tests
 from backend.app.api import (
-    low_imports,
-    low_overrides,
-    low_exports,
-    low_reconcile,
-    low_templates,
-    normalisation_config,
     audit,
+    compare,
     index,
     index_templates,
     known_artists,
+    low_exports,
+    low_imports,
+    low_overrides,
+    low_reconcile,
+    low_templates,
+    normalisation_config,
     users,
-    compare,
 )
+from backend.app.api.auth import require_api_key
+from backend.app.api.deps import get_db  # noqa: F401  re-exported for tests
 
 router = APIRouter(dependencies=[Depends(require_api_key)])
 

--- a/backend/app/api/index.py
+++ b/backend/app/api/index.py
@@ -3,54 +3,55 @@ Artists' Index routes: upload, list, artists, export, delete, exclude toggle.
 """
 
 import logging
-from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, Query, status
-from fastapi.responses import Response
-from sqlalchemy.orm import Session
-from sqlalchemy import func
 import os
 import uuid
 from typing import List
 from uuid import UUID
 
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi.responses import Response
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
 from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
-from backend.app.services.storage import storage
-from backend.app.services.export_renderer import escape_for_mac_roman
 from backend.app.api.schemas import (
     AutoResolvedFields,
-    IndexImportOut,
     IndexArtistOut,
-    IndexCatNumberOut,
     IndexArtistOverrideIn,
     IndexArtistOverrideOut,
+    IndexCatNumberOut,
+    IndexImportOut,
     ReimportOut,
 )
+from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.import_model import Import
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.index_override_model import IndexArtistOverride
-from backend.app.models.audit_log_model import AuditLog
+from backend.app.services.export_diff_service import (
+    compute_index_diff,
+    save_index_export_snapshot,
+)
+from backend.app.services.export_renderer import escape_for_mac_roman
 from backend.app.services.index_importer import (
+    IndexImportError,
     import_index_excel,
     reimport_index_excel,
-    IndexImportError,
 )
 from backend.app.services.index_override_service import (
-    resolve_index_artist,
     build_known_artist_cache,
     lookup_known_artist,
+    resolve_index_artist,
 )
 from backend.app.services.index_renderer import (
+    DEFAULT_INDEX_CONFIG,
+    IndexExportConfig,
+    _letter_key,
     collect_index_entries,
     render_index_tagged_text,
-    IndexExportConfig,
-    DEFAULT_INDEX_CONFIG,
-    _letter_key,
 )
-from backend.app.services.export_diff_service import (
-    save_index_export_snapshot,
-    compute_index_diff,
-)
+from backend.app.services.storage import storage
 
 logger = logging.getLogger("catalogue")
 
@@ -776,12 +777,6 @@ def unmerge_artist(
     The original artist record keeps the cat numbers from its own row_number.
     New artist records are created for each additional source row.
     """
-    from backend.app.services.index_importer import (
-        is_ra_member,
-        detect_company,
-        build_sort_key,
-        parse_multi_artist,
-    )
 
     artist = _get_artist_or_404(import_id, artist_id, db)
 

--- a/backend/app/api/index_templates.py
+++ b/backend/app/api/index_templates.py
@@ -4,20 +4,21 @@ Artists' Index export template CRUD routes.
 Mirrors the List of Works template routes but uses config_type='index_template'.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import Response
-from sqlalchemy.orm import Session
 import hashlib
 import json
 import re
 from typing import List
 from uuid import UUID
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
 from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
 from backend.app.api.schemas import IndexTemplateBodyIn, TemplateOut
-from backend.app.models.ruleset_model import Ruleset
 from backend.app.models.audit_log_model import AuditLog
+from backend.app.models.ruleset_model import Ruleset
 
 CONFIG_TYPE = "index_template"
 

--- a/backend/app/api/known_artists.py
+++ b/backend/app/api/known_artists.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
-from backend.app.api.schemas import KnownArtistOut, KnownArtistCreate, KnownArtistUpdate
+from backend.app.api.schemas import KnownArtistCreate, KnownArtistOut, KnownArtistUpdate
 from backend.app.models.known_artist_model import KnownArtist
 
 logger = logging.getLogger(__name__)

--- a/backend/app/api/low_exports.py
+++ b/backend/app/api/low_exports.py
@@ -6,29 +6,29 @@ into an ExportConfig dataclass.
 """
 
 import re
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
-from uuid import UUID
 
 from backend.app.api.deps import get_db
 from backend.app.models.section_model import Section
-from backend.app.services.export_renderer import (
-    render_import_as_tagged_text,
-    render_import_as_json,
-    render_import_as_xml,
-    render_import_as_csv,
-    ExportConfig,
-    DEFAULT_CONFIG,
-    DEFAULT_COMPONENTS,
-    ComponentConfig,
-    resolve_export_config,
-    escape_for_mac_roman,
-)
 from backend.app.services.export_diff_service import (
-    save_export_snapshot,
     compute_diff,
+    save_export_snapshot,
+)
+from backend.app.services.export_renderer import (
+    DEFAULT_COMPONENTS,
+    DEFAULT_CONFIG,
+    ComponentConfig,
+    ExportConfig,
+    escape_for_mac_roman,
+    render_import_as_csv,
+    render_import_as_json,
+    render_import_as_tagged_text,
+    render_import_as_xml,
+    resolve_export_config,
 )
 
 router = APIRouter(tags=["exports"])

--- a/backend/app/api/low_imports.py
+++ b/backend/app/api/low_imports.py
@@ -2,41 +2,42 @@
 Import management routes: upload, list, sections, preview, warnings, delete.
 """
 
-from dataclasses import asdict
-from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, status, Query
-from fastapi.responses import Response
-from sqlalchemy.orm import Session
-
-from backend.app.api.auth import require_role
-from sqlalchemy import func
 import os
 import uuid
+from dataclasses import asdict
 from typing import List
 from uuid import UUID
 
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
-from backend.app.services.storage import storage
+from backend.app.api.normalisation_config import load_normalisation_settings
 from backend.app.api.schemas import (
     ImportOut,
-    ReimportOut,
-    SectionOut,
-    WorkOut,
-    WorkOverrideOut,
     PreviewSectionOut,
     PreviewWorkOut,
+    ReimportOut,
+    SectionOut,
     ValidationWarningOut,
+    WorkOut,
+    WorkOverrideOut,
 )
 from backend.app.models.import_model import Import
-from backend.app.models.section_model import Section
-from backend.app.models.work_model import Work
 from backend.app.models.override_model import WorkOverride
+from backend.app.models.section_model import Section
 from backend.app.models.validation_warning_model import ValidationWarning
+from backend.app.models.work_model import Work
+from backend.app.services.excel_importer import (
+    ImportError as ExcelImportError,
+)
 from backend.app.services.excel_importer import (
     import_excel,
     reimport_excel,
-    ImportError as ExcelImportError,
 )
-from backend.app.api.normalisation_config import load_normalisation_settings
+from backend.app.services.storage import storage
 
 router = APIRouter(tags=["imports"])
 
@@ -374,7 +375,6 @@ def preview_import(import_id: UUID, db: Session = Depends(get_db)):
 
 @router.get("/imports/{import_id}/warnings", response_model=List[ValidationWarningOut])
 def list_warnings(import_id: UUID, db: Session = Depends(get_db)):
-    from sqlalchemy.orm import outerjoin
 
     rows = (
         db.query(ValidationWarning, Work)

--- a/backend/app/api/low_overrides.py
+++ b/backend/app/api/low_overrides.py
@@ -2,16 +2,17 @@
 Override and exclude/include routes for individual works.
 """
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from uuid import UUID
 
 from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
 from backend.app.api.schemas import OverrideIn, OverrideOut
-from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
 from backend.app.models.audit_log_model import AuditLog
+from backend.app.models.override_model import WorkOverride
+from backend.app.models.work_model import Work
 
 router = APIRouter(tags=["overrides"])
 

--- a/backend/app/api/low_reconcile.py
+++ b/backend/app/api/low_reconcile.py
@@ -23,8 +23,8 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from sqlalchemy.orm import Session
 
-from backend.app.api.deps import get_db
 from backend.app.api.auth import require_role
+from backend.app.api.deps import get_db
 from backend.app.api.low_exports import _ruleset_to_export_config
 from backend.app.models.import_model import Import
 from backend.app.models.low_tag_snapshot_model import LowTagSnapshot
@@ -32,8 +32,8 @@ from backend.app.services.export_renderer import (
     _collect_export_data,
     resolve_export_config,
 )
+from backend.app.services.low_diff import LowDiffConfig, diff_low
 from backend.app.services.low_tag_parser import parse_low_tags
-from backend.app.services.low_diff import diff_low, LowDiffConfig
 
 router = APIRouter(tags=["reconcile"])
 

--- a/backend/app/api/low_templates.py
+++ b/backend/app/api/low_templates.py
@@ -2,20 +2,21 @@
 Export template CRUD routes.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import Response
-from sqlalchemy.orm import Session
 import hashlib
 import json
 import re
 from typing import List
 from uuid import UUID
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
 from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
 from backend.app.api.schemas import TemplateBodyIn, TemplateOut
-from backend.app.models.ruleset_model import Ruleset
 from backend.app.models.audit_log_model import AuditLog
+from backend.app.models.ruleset_model import Ruleset
 
 router = APIRouter(tags=["templates"])
 

--- a/backend/app/api/normalisation_config.py
+++ b/backend/app/api/normalisation_config.py
@@ -2,10 +2,11 @@
 Global normalisation config routes (honorific tokens).
 """
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
 import hashlib
 import json
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
 
 from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -2,9 +2,9 @@
 Pydantic request/response schemas shared across API route modules.
 """
 
-from pydantic import BaseModel, field_validator
 from typing import List
 
+from pydantic import BaseModel, field_validator
 
 # ---------------------------------------------------------------------------
 # Import

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -13,8 +13,8 @@ from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr
 
-from backend.app.api.auth import require_role, Role
-from backend.app.config import COGNITO_USER_POOL_ID, COGNITO_REGION
+from backend.app.api.auth import require_role
+from backend.app.config import COGNITO_REGION, COGNITO_USER_POOL_ID
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+
 from dotenv import load_dotenv
 
 # Load .env from the project root (two levels above this file)

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from backend.app.config import DATABASE_URL, LOG_LEVEL
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,43 +1,28 @@
+import json
 import logging
 import os
 import platform
 import shutil
 import time
-import json
-import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import FastAPI, Request, Depends
-from fastapi.exceptions import ResponseValidationError
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import JSONResponse, RedirectResponse
-from sqlalchemy import text
-
-from backend.app.config import LOG_LEVEL, CORS_ORIGINS, API_KEY
-from backend.app.db import engine, Base
-from backend.app.api.auth import get_current_role, Role
-
-from backend.app.models import import_model
-from backend.app.models import section_model
-from backend.app.models import work_model
-from backend.app.models import override_model
-from backend.app.models import ruleset_model
-from backend.app.models import validation_warning_model
-from backend.app.models import audit_log_model
-from backend.app.models import export_snapshot_model
-from backend.app.models import index_artist_model
-from backend.app.models import index_cat_number_model
-from backend.app.models import index_override_model
-from backend.app.models import known_artist_model
+from alembic import command as alembic_command
 
 # ---------------------------------------------------------------------------
 # Run Alembic migrations on startup (replaces Base.metadata.create_all)
 # ---------------------------------------------------------------------------
-
 from alembic.config import Config as AlembicConfig
-from alembic import command as alembic_command
+from fastapi import Depends, FastAPI, Request
+from fastapi.exceptions import ResponseValidationError
+from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import text
+
+from backend.app.api.auth import Role, get_current_role
+from backend.app.config import API_KEY, CORS_ORIGINS, LOG_LEVEL
+from backend.app.db import engine
 
 _alembic_cfg = AlembicConfig(
     str(Path(__file__).resolve().parent.parent.parent / "alembic.ini")
@@ -54,7 +39,6 @@ if _has_tables and not _has_alembic:
 alembic_command.upgrade(_alembic_cfg, "head")
 
 from backend.app.api import import_routes
-
 
 # ---------------------------------------------------------------------------
 # Structured JSON logging
@@ -293,8 +277,8 @@ async def _log_requests(request: Request, call_next):
 # automatically attributed to the authenticated user.
 # ---------------------------------------------------------------------------
 
-from backend.app.api.user_context import current_user_email
 from backend.app.api.auth import get_current_user as _resolve_user
+from backend.app.api.user_context import current_user_email
 
 
 @app.middleware("http")
@@ -473,9 +457,9 @@ def auth_config():
     """
     from backend.app.api.auth import _USE_COGNITO
     from backend.app.config import (
-        COGNITO_USER_POOL_ID,
         COGNITO_CLIENT_ID,
         COGNITO_REGION,
+        COGNITO_USER_POOL_ID,
     )
 
     if _USE_COGNITO:

--- a/backend/app/models/audit_log_model.py
+++ b/backend/app/models/audit_log_model.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Text, TIMESTAMP, ForeignKey, Index, event
+import uuid
+
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Index, Text, event
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/models/export_snapshot_model.py
+++ b/backend/app/models/export_snapshot_model.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Text, TIMESTAMP, ForeignKey, Index
-from sqlalchemy.dialects.postgresql import UUID, JSONB
-from sqlalchemy.sql import func
 import uuid
+
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Index
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import func
 
 from backend.app.db import Base
 

--- a/backend/app/models/import_model.py
+++ b/backend/app/models/import_model.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Text, TIMESTAMP
+import uuid
+
+from sqlalchemy import TIMESTAMP, Column, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/models/index_artist_model.py
+++ b/backend/app/models/index_artist_model.py
@@ -1,17 +1,17 @@
+import uuid
+
 from sqlalchemy import (
-    Column,
-    Text,
-    Integer,
-    Boolean,
-    ForeignKey,
     TIMESTAMP,
-    UniqueConstraint,
+    Boolean,
+    Column,
+    ForeignKey,
     Index,
+    Integer,
+    Text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/models/index_cat_number_model.py
+++ b/backend/app/models/index_cat_number_model.py
@@ -1,13 +1,14 @@
+import uuid
+
 from sqlalchemy import (
     Column,
-    Text,
-    Integer,
     ForeignKey,
     Index,
+    Integer,
+    Text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/models/index_override_model.py
+++ b/backend/app/models/index_override_model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Boolean, Text, ForeignKey, TIMESTAMP
+from sqlalchemy import TIMESTAMP, Boolean, Column, ForeignKey, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 

--- a/backend/app/models/known_artist_model.py
+++ b/backend/app/models/known_artist_model.py
@@ -1,13 +1,14 @@
+import uuid
+
 from sqlalchemy import (
+    TIMESTAMP,
+    Boolean,
     Column,
     Text,
-    Boolean,
-    TIMESTAMP,
     UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/models/low_tag_snapshot_model.py
+++ b/backend/app/models/low_tag_snapshot_model.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Text, TIMESTAMP, ForeignKey, Index
+import uuid
+
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Index, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/models/override_model.py
+++ b/backend/app/models/override_model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Text, Integer, Numeric, TIMESTAMP, ForeignKey
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Integer, Numeric, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 

--- a/backend/app/models/ruleset_model.py
+++ b/backend/app/models/ruleset_model.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Text, Integer, Boolean, TIMESTAMP, Index
-from sqlalchemy.dialects.postgresql import UUID, JSONB
-from sqlalchemy.sql import func
 import uuid
+
+from sqlalchemy import TIMESTAMP, Boolean, Column, Index, Integer, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import func
 
 from backend.app.db import Base
 

--- a/backend/app/models/section_model.py
+++ b/backend/app/models/section_model.py
@@ -1,7 +1,7 @@
-from sqlalchemy import Column, Text, Integer, ForeignKey, UniqueConstraint, Index
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.sql import func
 import uuid
+
+from sqlalchemy import Column, ForeignKey, Index, Integer, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
 
 from backend.app.db import Base
 

--- a/backend/app/models/validation_warning_model.py
+++ b/backend/app/models/validation_warning_model.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Text, TIMESTAMP, ForeignKey, Index
+import uuid
+
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Index, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/models/work_model.py
+++ b/backend/app/models/work_model.py
@@ -1,17 +1,18 @@
+import uuid
+
 from sqlalchemy import (
-    Column,
-    Text,
-    Integer,
-    Boolean,
-    Numeric,
-    ForeignKey,
     TIMESTAMP,
-    UniqueConstraint,
+    Boolean,
+    Column,
+    ForeignKey,
     Index,
+    Integer,
+    Numeric,
+    Text,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
-import uuid
 
 from backend.app.db import Base
 

--- a/backend/app/services/comparison_service.py
+++ b/backend/app/services/comparison_service.py
@@ -202,7 +202,6 @@ def _extract_index_name_parts(
     fn = (first_name or "").strip()
     ln = (last_name or "").strip()
     q = (quals or "").strip()
-    t = (title or "").strip()
 
     # For companies, the "last_name" is the company name
     if is_company:

--- a/backend/app/services/comparison_service.py
+++ b/backend/app/services/comparison_service.py
@@ -18,19 +18,17 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from backend.app.models.import_model import Import
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.index_override_model import IndexArtistOverride
-from backend.app.models.work_model import Work
 from backend.app.models.override_model import WorkOverride
-from backend.app.services.override_service import resolve_effective_work
+from backend.app.models.work_model import Work
 from backend.app.services.index_override_service import (
     build_known_artist_cache,
     lookup_known_artist,
     resolve_index_artist,
 )
-
+from backend.app.services.override_service import resolve_effective_work
 
 # ---------------------------------------------------------------------------
 # Match classification

--- a/backend/app/services/excel_importer.py
+++ b/backend/app/services/excel_importer.py
@@ -1,20 +1,20 @@
+import uuid as _uuid
+from difflib import get_close_matches
+from typing import Dict, List, Optional, Tuple
+
 from openpyxl import load_workbook
 from openpyxl.utils.exceptions import InvalidFileException
 from sqlalchemy.orm import Session
-from difflib import get_close_matches
-import uuid as _uuid
 
-from backend.app.models.import_model import Import
-from backend.app.models.section_model import Section
-from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
 from backend.app.models.audit_log_model import AuditLog
+from backend.app.models.import_model import Import
+from backend.app.models.override_model import WorkOverride
+from backend.app.models.section_model import Section
 from backend.app.models.validation_warning_model import ValidationWarning
-from typing import Dict, List, Optional, Tuple
-
+from backend.app.models.work_model import Work
 from backend.app.services.normalisation_service import (
-    normalise_work,
     collect_work_warnings,
+    normalise_work,
 )
 from backend.app.services.reimport_matcher import (
     MatchPlan,
@@ -23,7 +23,6 @@ from backend.app.services.reimport_matcher import (
     compute_fingerprint,
     match_overrides,
 )
-
 
 # ---------------------------------------------------------------------------
 # Expected column headers

--- a/backend/app/services/export_diff_service.py
+++ b/backend/app/services/export_diff_service.py
@@ -8,14 +8,14 @@ Covers both List of Works (LoW) and Artists' Index pipelines.
 """
 
 from dataclasses import asdict
-from sqlalchemy.orm import Session
-from sqlalchemy import desc
-from uuid import UUID
 from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
 
 from backend.app.models.export_snapshot_model import ExportSnapshot
 from backend.app.services.export_renderer import _collect_export_data
-
 
 # ---------------------------------------------------------------------------
 # Snapshot

--- a/backend/app/services/export_renderer.py
+++ b/backend/app/services/export_renderer.py
@@ -1,16 +1,16 @@
-from dataclasses import dataclass, field
-from typing import List, Optional
 import csv
 import io
 import json
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import List, Optional
+
 from sqlalchemy.orm import Session
 
+from backend.app.models.override_model import WorkOverride
 from backend.app.models.section_model import Section
 from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
 from backend.app.services.override_service import resolve_effective_work
-
 
 # ---------------------------------------------------------------------------
 # Component / separator model
@@ -114,8 +114,9 @@ class ExportConfig:
 
 DEFAULT_CONFIG = ExportConfig()
 
-from backend.app.models.ruleset_model import Ruleset
 from uuid import UUID
+
+from backend.app.models.ruleset_model import Ruleset
 
 
 def resolve_export_config(

--- a/backend/app/services/index_importer.py
+++ b/backend/app/services/index_importer.py
@@ -3,23 +3,23 @@
 Expected columns: Title, First Name, Last Name, Quals, Company, Address 1, Cat Nos
 """
 
-from collections import defaultdict
-from openpyxl import load_workbook
-from openpyxl.utils.exceptions import InvalidFileException
-from sqlalchemy.orm import Session
-from difflib import get_close_matches
-from typing import Dict, List, Optional, Tuple
 import re
 import unicodedata
 import uuid as _uuid
+from collections import defaultdict
+from difflib import get_close_matches
+from typing import Dict, List, Optional, Tuple
 
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+from sqlalchemy.orm import Session
+
+from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.import_model import Import
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.index_override_model import IndexArtistOverride
-from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.validation_warning_model import ValidationWarning
-
 
 # ---------------------------------------------------------------------------
 # RA member detection

--- a/backend/app/services/index_importer.py
+++ b/backend/app/services/index_importer.py
@@ -144,8 +144,6 @@ def parse_multi_artist(
         m = _QUAL_IN_NAME_PATTERN.search(remaining)
         if not m:
             break
-        # Only strip if it's at the end (after trimming)
-        suffix = remaining[m.start() :].strip()
         # Check the match is at the end of the remaining string
         after_match = remaining[m.end() :].strip()
         if _QUAL_IN_NAME_PATTERN.sub("", after_match).strip() == "":
@@ -177,7 +175,6 @@ def parse_multi_artist(
 
     # Parse the second artist: strip "and "/"& " prefix, then extract quals
     a2_raw = _SECOND_ARTIST_PREFIX.sub("", second_artist_raw).strip()
-    a2_words = a2_raw.split()
     a2_extracted_quals: list[str] = []
     a2_remaining = a2_raw
     while True:

--- a/backend/app/services/index_override_service.py
+++ b/backend/app/services/index_override_service.py
@@ -23,7 +23,6 @@ from sqlalchemy.orm import Session
 from backend.app.models.known_artist_model import KnownArtist
 from backend.app.services.index_importer import build_sort_key
 
-
 # ---------------------------------------------------------------------------
 # Known artist cache
 # ---------------------------------------------------------------------------

--- a/backend/app/services/index_renderer.py
+++ b/backend/app/services/index_renderer.py
@@ -4,23 +4,22 @@ Produces InDesign Tagged Text (primary format), with the same multi-format
 support pattern as the List of Works renderer.
 """
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
 from collections import defaultdict
-from sqlalchemy.orm import Session
+from dataclasses import dataclass
+from typing import Dict, List, Optional
 from uuid import UUID
+
+from sqlalchemy.orm import Session
 
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.index_override_model import IndexArtistOverride
+from backend.app.services.export_renderer import escape_tagged_text_chars
 from backend.app.services.index_override_service import (
-    resolve_index_artist,
     build_known_artist_cache,
     lookup_known_artist,
+    resolve_index_artist,
 )
-from backend.app.services.index_importer import is_ra_member
-from backend.app.services.export_renderer import escape_tagged_text_chars
-
 
 # ---------------------------------------------------------------------------
 # Config

--- a/backend/app/services/low_diff.py
+++ b/backend/app/services/low_diff.py
@@ -28,12 +28,11 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 
 from backend.app.services.export_renderer import (
-    ExportConfig,
     DEFAULT_CONFIG,
+    ExportConfig,
     _fmt_price,
 )
 from backend.app.services.low_tag_parser import ParsedEntry, recoverable_fields
-
 
 # ---------------------------------------------------------------------------
 # DB side: render a resolved work to display strings

--- a/backend/app/services/low_tag_parser.py
+++ b/backend/app/services/low_tag_parser.py
@@ -43,7 +43,7 @@ import re
 import unicodedata
 from dataclasses import dataclass
 
-from backend.app.services.export_renderer import ExportConfig, DEFAULT_CONFIG
+from backend.app.services.export_renderer import DEFAULT_CONFIG, ExportConfig
 
 # Match both the verbose (our renderer) and short (InDesign) tag dialects.
 _PARA_RE = re.compile(r"^\s*<(?:ParaStyle|pstyle):([^>]*)>")

--- a/backend/app/services/normalisation_service.py
+++ b/backend/app/services/normalisation_service.py
@@ -2,7 +2,6 @@ import re
 from decimal import Decimal
 from typing import List, Optional, Set, Tuple
 
-
 # -----------------------------
 # Configurable-rule defaults
 # -----------------------------

--- a/backend/app/services/reimport_matcher.py
+++ b/backend/app/services/reimport_matcher.py
@@ -50,7 +50,6 @@ import unicodedata
 from dataclasses import dataclass, field
 from typing import Optional
 
-
 # ---------------------------------------------------------------------------
 # Fingerprint
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.ruff]
+# Match the runtime Python (CI + Docker run 3.12; local devs may run newer).
+target-version = "py312"
+line-length = 100
+extend-exclude = [
+    "venv",
+    "backend/alembic/versions",  # auto-generated migration scaffolding
+]
+
+[tool.ruff.lint]
+# Default selection (F + E + W) plus isort (I) for stable import ordering.
+# Add more rule families (B, SIM, UP) later once the baseline is clean.
+select = ["F", "E", "W", "I"]
+ignore = [
+    # SQLAlchemy filter clauses require `Column == False` / `== True` to build
+    # SQL expressions; Ruff's suggested rewrite (`not Column`) would evaluate
+    # the column eagerly and break the query. Disable globally.
+    "E712",
+    # Line-length warning — Ruff format handles wrapping; warning is noise.
+    "E501",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# `main.py` deliberately imports route modules after `alembic upgrade` so
+# migrations apply before models are touched. `export_renderer.py` has a
+# late import to avoid a circular dependency. `alembic/env.py` sets
+# sys.path before importing app modules.
+"backend/app/main.py" = ["E402"]
+"backend/app/services/export_renderer.py" = ["E402"]
+"backend/alembic/env.py" = ["E402"]
+"tests/conftest.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["backend"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 httpx==0.28.1
 pytest==9.0.3
+ruff==0.15.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ python-multipart==0.0.27
 openpyxl==3.1.5
 titlecase==2.4.1
 aiofiles==25.1.0
-boto3>=1.35.0
+boto3==1.42.57
 python-dotenv==1.2.2
 PyJWT[crypto]==2.12.0
-email-validator>=2.0
+email-validator==2.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,25 +21,25 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-# Import Base *after* the patch so create_all uses the patched column types
-from backend.app.db import Base  # noqa: E402
-
-# Ensure every model table is registered on Base.metadata
-import backend.app.models.ruleset_model  # noqa: F401
-import backend.app.models.import_model  # noqa: F401
-import backend.app.models.section_model  # noqa: F401
-import backend.app.models.work_model  # noqa: F401
-import backend.app.models.override_model  # noqa: F401
-import backend.app.models.validation_warning_model  # noqa: F401
 import backend.app.models.audit_log_model  # noqa: F401
 import backend.app.models.export_snapshot_model  # noqa: F401
+import backend.app.models.import_model  # noqa: F401
 import backend.app.models.index_artist_model  # noqa: F401
 import backend.app.models.index_cat_number_model  # noqa: F401
 import backend.app.models.index_override_model  # noqa: F401
 import backend.app.models.known_artist_model  # noqa: F401
 import backend.app.models.low_tag_snapshot_model  # noqa: F401
+import backend.app.models.override_model  # noqa: F401
 
-from backend.app.api.import_routes import router, get_db
+# Ensure every model table is registered on Base.metadata
+import backend.app.models.ruleset_model  # noqa: F401
+import backend.app.models.section_model  # noqa: F401
+import backend.app.models.validation_warning_model  # noqa: F401
+import backend.app.models.work_model  # noqa: F401
+from backend.app.api.import_routes import get_db, router
+
+# Import Base *after* the patch so create_all uses the patched column types
+from backend.app.db import Base  # noqa: E402
 
 SQLITE_URL = "sqlite:///:memory:"
 

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -7,22 +7,19 @@ Tests for audit log API endpoints:
 import uuid as _uuid
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
+from backend.app.api.import_routes import get_db, router
 from backend.app.db import Base
-from backend.app.api.import_routes import router, get_db
+from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.import_model import Import
+from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.section_model import Section
 from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
-from backend.app.models.audit_log_model import AuditLog
-from backend.app.models.ruleset_model import Ruleset
-from backend.app.models.index_artist_model import IndexArtist
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_auth_and_context.py
+++ b/tests/test_auth_and_context.py
@@ -10,19 +10,15 @@ Covers:
 
 from unittest.mock import patch
 
-import pytest
-from fastapi import FastAPI, Depends, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 
 from backend.app.api.auth import (
     Role,
-    get_current_role,
     get_current_user,
-    require_api_key,
     require_role,
 )
 from backend.app.api.user_context import current_user_email
-
 
 # ---------------------------------------------------------------------------
 # /auth/config endpoint
@@ -187,8 +183,9 @@ class TestAuditLogUserAttribution:
     """Test that AuditLog.user_email is auto-populated from the context var."""
 
     def test_default_email_is_anonymous(self):
-        from backend.app.models.audit_log_model import AuditLog
         import uuid
+
+        from backend.app.models.audit_log_model import AuditLog
 
         entry = AuditLog(
             import_id=uuid.uuid4(),
@@ -197,8 +194,9 @@ class TestAuditLogUserAttribution:
         assert entry.user_email == "anonymous"
 
     def test_email_set_from_context(self):
-        from backend.app.models.audit_log_model import AuditLog
         import uuid
+
+        from backend.app.models.audit_log_model import AuditLog
 
         tok = current_user_email.set("bob@example.com")
         try:
@@ -211,8 +209,9 @@ class TestAuditLogUserAttribution:
             current_user_email.reset(tok)
 
     def test_explicit_email_not_overridden(self):
-        from backend.app.models.audit_log_model import AuditLog
         import uuid
+
+        from backend.app.models.audit_log_model import AuditLog
 
         tok = current_user_email.set("context@example.com")
         try:

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -4,25 +4,22 @@ Tests for the cross-dataset comparison service and API endpoint.
 
 import uuid
 
-import pytest
-
 from backend.app.models.import_model import Import
-from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.index_override_model import IndexArtistOverride
 from backend.app.models.known_artist_model import KnownArtist
+from backend.app.models.override_model import WorkOverride
 from backend.app.models.section_model import Section
+from backend.app.models.work_model import Work
 from backend.app.services.comparison_service import (
-    MatchLevel,
     PARTIAL_LEVELS,
+    MatchLevel,
     _compare_names,
     _extract_low_name_parts,
     _normalise_words,
     compare_datasets,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_configurable_normalisation.py
+++ b/tests/test_configurable_normalisation.py
@@ -12,7 +12,6 @@ import io
 import uuid
 from types import SimpleNamespace
 
-import pytest
 from openpyxl import Workbook
 
 from backend.app.models.work_model import Work
@@ -22,7 +21,6 @@ from backend.app.services.normalisation_service import (
     normalise_work,
     parse_edition,
 )
-
 
 # ---------------------------------------------------------------------------
 # Edition-suppression threshold

--- a/tests/test_export_diff.py
+++ b/tests/test_export_diff.py
@@ -250,7 +250,7 @@ class TestComputeDiff:
     def test_removed_work(self, db_session):
         imp = _seed_import(db_session)
         sec = _seed_section(db_session, imp)
-        w1 = _seed_work(db_session, imp, sec, raw_cat_no="1")
+        _seed_work(db_session, imp, sec, raw_cat_no="1")
         w2 = _seed_work(db_session, imp, sec, raw_cat_no="2", position=2)
 
         save_export_snapshot(imp.id, None, db_session)
@@ -293,7 +293,7 @@ class TestComputeDiff:
     def test_combined_added_removed_changed(self, db_session):
         imp = _seed_import(db_session)
         sec = _seed_section(db_session, imp)
-        w_stay = _seed_work(db_session, imp, sec, raw_cat_no="1", title="Stays Same")
+        _seed_work(db_session, imp, sec, raw_cat_no="1", title="Stays Same")
         w_change = _seed_work(
             db_session, imp, sec, raw_cat_no="2", position=2, title="Will Change"
         )

--- a/tests/test_export_diff.py
+++ b/tests/test_export_diff.py
@@ -8,22 +8,19 @@ Covers:
 """
 
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
-import pytest
 from sqlalchemy.orm import Session
 
 from backend.app.models.import_model import Import
 from backend.app.models.section_model import Section
 from backend.app.models.work_model import Work
-from backend.app.models.export_snapshot_model import ExportSnapshot
 from backend.app.services.export_diff_service import (
-    save_export_snapshot,
-    get_last_snapshot,
-    compute_diff,
     _flatten_works,
+    compute_diff,
+    get_last_snapshot,
+    save_export_snapshot,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -12,9 +12,7 @@ from backend.app.services.export_renderer import (
     render_import_as_csv,
     render_import_as_json,
     render_import_as_xml,
-    render_import_as_tagged_text,
 )
-
 
 # ---------------------------------------------------------------------------
 # Shared test fixtures helpers

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -16,8 +16,10 @@ from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
+from fastapi.exceptions import ResponseValidationError
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 from sqlalchemy import text
 
 # ---------------------------------------------------------------------------
@@ -229,9 +231,6 @@ class TestVersionEndpoint:
 # ---------------------------------------------------------------------------
 # ResponseValidationError handler
 # ---------------------------------------------------------------------------
-
-from fastapi.exceptions import ResponseValidationError
-from pydantic import BaseModel
 
 
 class TestResponseValidationErrorHandler:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -12,7 +12,6 @@ import platform
 import shutil
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -20,9 +19,6 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from sqlalchemy import text
-
-from backend.app.db import Base
-
 
 # ---------------------------------------------------------------------------
 # Build a minimal app that embeds the same health logic as main.py
@@ -234,8 +230,8 @@ class TestVersionEndpoint:
 # ResponseValidationError handler
 # ---------------------------------------------------------------------------
 
-from pydantic import BaseModel
 from fastapi.exceptions import ResponseValidationError
+from pydantic import BaseModel
 
 
 class TestResponseValidationErrorHandler:

--- a/tests/test_import_override_export_routes.py
+++ b/tests/test_import_override_export_routes.py
@@ -434,7 +434,7 @@ class TestOverrideCRUD:
         logs = db_session.query(AuditLog).filter(AuditLog.work_id == w.id).all()
         assert len(logs) >= 1
         assert any(
-            l.action == "override_set" and l.field == "title_override" for l in logs
+            log.action == "override_set" and log.field == "title_override" for log in logs
         )
 
     # --- PUT override (update) ---

--- a/tests/test_import_override_export_routes.py
+++ b/tests/test_import_override_export_routes.py
@@ -7,16 +7,14 @@ unit-level tests for rendering, normalisation, etc.
 
 import uuid as _uuid
 
-import pytest
 from sqlalchemy.orm import Session
 
-from backend.app.models.import_model import Import
-from backend.app.models.section_model import Section
-from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
-from backend.app.models.validation_warning_model import ValidationWarning
 from backend.app.models.audit_log_model import AuditLog
-
+from backend.app.models.import_model import Import
+from backend.app.models.override_model import WorkOverride
+from backend.app.models.section_model import Section
+from backend.app.models.validation_warning_model import ValidationWarning
+from backend.app.models.work_model import Work
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_index_export_diff.py
+++ b/tests/test_index_export_diff.py
@@ -10,23 +10,20 @@ Covers:
 import uuid
 from datetime import datetime, timezone
 
-import pytest
 from sqlalchemy.orm import Session
 
 from backend.app.models.import_model import Import
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
-from backend.app.models.export_snapshot_model import ExportSnapshot
 from backend.app.services.export_diff_service import (
-    save_index_export_snapshot,
-    get_last_snapshot,
-    compute_index_diff,
     _collect_index_export_data,
-    _flatten_index_entries,
-    _entry_key,
     _entry_display_name,
+    _entry_key,
+    _flatten_index_entries,
+    compute_index_diff,
+    get_last_snapshot,
+    save_index_export_snapshot,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_index_importer.py
+++ b/tests/test_index_importer.py
@@ -1,23 +1,23 @@
 """Tests for the Artists' Index importer."""
 
-import pytest
-from openpyxl import Workbook
 from pathlib import Path
 
-from backend.app.services.index_importer import (
-    import_index_excel,
-    IndexImportError,
-    is_ra_member,
-    build_sort_key,
-    parse_cat_nos,
-    detect_company,
-    detect_multi_name,
-    detect_quals_in_name,
-)
+import pytest
+from openpyxl import Workbook
+
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.validation_warning_model import ValidationWarning
-
+from backend.app.services.index_importer import (
+    IndexImportError,
+    build_sort_key,
+    detect_company,
+    detect_multi_name,
+    detect_quals_in_name,
+    import_index_excel,
+    is_ra_member,
+    parse_cat_nos,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_index_override_service.py
+++ b/tests/test_index_override_service.py
@@ -1,13 +1,10 @@
 """Tests for the index override resolution service."""
 
-import pytest
 
 from backend.app.services.index_override_service import (
-    resolve_index_artist,
     build_index_name,
-    EffectiveIndexArtist,
+    resolve_index_artist,
 )
-
 
 # ---------------------------------------------------------------------------
 # Minimal stub classes to avoid needing real ORM objects

--- a/tests/test_index_reimport.py
+++ b/tests/test_index_reimport.py
@@ -18,16 +18,11 @@ Covers:
 import io
 import uuid
 
-import pytest
 from openpyxl import Workbook
 
-from backend.app.models.import_model import Import
-from backend.app.models.index_artist_model import IndexArtist
-from backend.app.models.index_cat_number_model import IndexCatNumber
-from backend.app.models.index_override_model import IndexArtistOverride
-from backend.app.models.validation_warning_model import ValidationWarning
 from backend.app.models.audit_log_model import AuditLog
-
+from backend.app.models.import_model import Import
+from backend.app.models.validation_warning_model import ValidationWarning
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_index_reimport.py
+++ b/tests/test_index_reimport.py
@@ -321,22 +321,21 @@ class TestIndexReimportAuditAndWarnings:
     def test_warnings_regenerated(self, client, db_session):
         _, import_id = _upload_index(client)
         iid = uuid.UUID(import_id)
-        warnings_before = (
-            db_session.query(ValidationWarning)
-            .filter(ValidationWarning.import_id == iid)
-            .count()
-        )
 
         # Reimport — warnings should be regenerated (old ones deleted)
         _reimport_index(client, import_id)
         db_session.expire_all()
 
+        # TODO: this assertion is weaker than the test name promises. Original
+        # author dropped a before/after count comparison ("count may differ
+        # based on new data") but left the dead snapshot in. Strengthen later:
+        # e.g. assert the rows have higher created_at than before, or check
+        # that the warning records carry the new import's id only.
         warnings_after = (
             db_session.query(ValidationWarning)
             .filter(ValidationWarning.import_id == iid)
             .all()
         )
-        # We just check they exist — count may differ based on new data
         assert isinstance(warnings_after, list)
 
     def test_filename_updated(self, client, db_session):

--- a/tests/test_index_renderer.py
+++ b/tests/test_index_renderer.py
@@ -1,20 +1,18 @@
 """Tests for the Artists' Index renderer."""
 
-import pytest
 
 from backend.app.services.index_renderer import (
     ArtistExportEntry,
     IndexExportConfig,
-    render_index_tagged_text,
-    _render_name_part,
-    _render_quals,
-    _render_courtesy,
-    _render_cat_nos,
     _cstyle,
     _letter_key,
+    _render_cat_nos,
+    _render_courtesy,
+    _render_name_part,
+    _render_quals,
     _section_sep,
+    render_index_tagged_text,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_index_routes.py
+++ b/tests/test_index_routes.py
@@ -166,7 +166,7 @@ class TestListIndexImports:
         assert data[0]["product_type"] == "artists_index"
 
     def test_includes_artist_count(self, client, db_session):
-        resp = _upload_index(client)
+        _upload_index(client)
         r = client.get("/index/imports")
         data = r.json()
         assert len(data) == 1

--- a/tests/test_index_routes.py
+++ b/tests/test_index_routes.py
@@ -3,16 +3,14 @@
 import io
 import uuid
 
-import pytest
 from openpyxl import Workbook
 
+from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.import_model import Import
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.index_override_model import IndexArtistOverride
-from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.known_artist_model import KnownArtist
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_index_templates.py
+++ b/tests/test_index_templates.py
@@ -4,10 +4,7 @@ import hashlib
 import json
 import uuid
 
-import pytest
-
 from backend.app.models.ruleset_model import Ruleset
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_known_artists.py
+++ b/tests/test_known_artists.py
@@ -1,10 +1,8 @@
 """Tests for the Known Artists API routes."""
 
 import uuid
-import pytest
 
 from backend.app.models.known_artist_model import KnownArtist
-
 
 # ---------------------------------------------------------------------------
 # CRUD

--- a/tests/test_low_diff.py
+++ b/tests/test_low_diff.py
@@ -9,13 +9,12 @@ disparity correctly — including suppressing cosmetic noise.
 from types import SimpleNamespace
 
 from backend.app.services.export_renderer import (
-    render_import_as_tagged_text,
-    _collect_export_data,
     ExportConfig,
+    _collect_export_data,
+    render_import_as_tagged_text,
 )
-from backend.app.services.low_tag_parser import parse_low_tags, ParsedEntry
-from backend.app.services.low_diff import diff_low, LowDiffConfig
-
+from backend.app.services.low_diff import LowDiffConfig, diff_low
+from backend.app.services.low_tag_parser import ParsedEntry, parse_low_tags
 
 # --- minimal in-memory session -------------------------------------------------
 

--- a/tests/test_low_real_sample.py
+++ b/tests/test_low_real_sample.py
@@ -17,8 +17,8 @@ import pytest
 from backend.app.api.low_exports import _ruleset_to_export_config
 from backend.app.services.excel_importer import import_excel
 from backend.app.services.export_renderer import _collect_export_data
-from backend.app.services.low_tag_parser import parse_low_tags
 from backend.app.services.low_diff import diff_low
+from backend.app.services.low_tag_parser import parse_low_tags
 
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Git-tracked fixtures required by the test suite live here; the rest of

--- a/tests/test_low_reconcile_routes.py
+++ b/tests/test_low_reconcile_routes.py
@@ -5,9 +5,9 @@ export real tags, post them back, and assert the diff."""
 import uuid
 
 from backend.app.models.import_model import Import
+from backend.app.models.override_model import WorkOverride
 from backend.app.models.section_model import Section
 from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
 
 
 def _seed(db):

--- a/tests/test_low_tag_parser.py
+++ b/tests/test_low_tag_parser.py
@@ -9,18 +9,17 @@ back to the values it was rendered from, every later diff is false positives.
 from types import SimpleNamespace
 
 from backend.app.services.export_renderer import (
-    render_import_as_tagged_text,
-    _collect_export_data,
-    ExportConfig,
     ComponentConfig,
-)
-from backend.app.services.low_tag_parser import (
-    parse_low_tags,
-    recoverable_fields,
-    _FIELD_STYLE_ATTRS,
+    ExportConfig,
+    _collect_export_data,
+    render_import_as_tagged_text,
 )
 from backend.app.services.low_diff import work_display_fields
-
+from backend.app.services.low_tag_parser import (
+    _FIELD_STYLE_ATTRS,
+    parse_low_tags,
+    recoverable_fields,
+)
 
 # ---------------------------------------------------------------------------
 # Regression: a template with an enabled "title_cased" component must parse

--- a/tests/test_lpg_render.py
+++ b/tests/test_lpg_render.py
@@ -23,8 +23,6 @@ import re
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 from backend.app.api.low_exports import _ruleset_to_export_config
 from backend.app.models.import_model import Import
 from backend.app.models.section_model import Section

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -1,13 +1,11 @@
-import pytest
 from types import SimpleNamespace
 
 from backend.app.services.normalisation_service import (
     collect_work_warnings,
     normalise_artist,
-    parse_price,
     parse_edition,
+    parse_price,
 )
-
 
 # -----------------------------
 # Artist Normalisation Tests

--- a/tests/test_normalise_work.py
+++ b/tests/test_normalise_work.py
@@ -1,9 +1,7 @@
 """Unit tests for normalise_work — the orchestrator that ties all normalisation together."""
 
-import pytest
 
 from backend.app.services.normalisation_service import normalise_work
-
 
 # ---------------------------------------------------------------------------
 # Lightweight stand-in for a Work model row (avoids needing a DB session)

--- a/tests/test_override_service.py
+++ b/tests/test_override_service.py
@@ -2,12 +2,10 @@
 Tests for override resolution service.
 """
 
-from types import SimpleNamespace
 from decimal import Decimal
+from types import SimpleNamespace
 
-import pytest
-
-from backend.app.services.override_service import resolve_effective_work, EffectiveWork
+from backend.app.services.override_service import resolve_effective_work
 
 
 def _make_work(**kwargs):

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -21,12 +21,8 @@ import uuid as _uuid
 import pytest
 from openpyxl import Workbook
 
-from backend.app.models.import_model import Import
-from backend.app.models.section_model import Section
-from backend.app.models.work_model import Work
-from backend.app.models.override_model import WorkOverride
-from backend.app.models.validation_warning_model import ValidationWarning
 from backend.app.models.audit_log_model import AuditLog
+from backend.app.models.work_model import Work
 
 # Re-import uses raise_server_exceptions=False so we can assert on 4xx/5xx
 # status codes directly.  The ``client_lenient`` fixture from conftest

--- a/tests/test_reimport_matcher.py
+++ b/tests/test_reimport_matcher.py
@@ -18,7 +18,6 @@ from backend.app.services.reimport_matcher import (
     match_overrides,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fingerprint normalisation
 # ---------------------------------------------------------------------------

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,8 +1,9 @@
 from types import SimpleNamespace
+
 from backend.app.services.export_renderer import (
-    render_import_as_tagged_text,
-    ExportConfig,
     ComponentConfig,
+    ExportConfig,
+    render_import_as_tagged_text,
 )
 
 

--- a/tests/test_role_guards.py
+++ b/tests/test_role_guards.py
@@ -9,21 +9,18 @@ and asserts that the endpoint either allows or rejects the request with 403.
 
 import hashlib
 import json
-import uuid
-from io import BytesIO
 
 import pytest
+from fastapi import Depends
 
-from backend.app.api.auth import get_current_role, Role
-from backend.app.models.ruleset_model import Ruleset
+from backend.app.api.auth import Role, get_current_role
 from backend.app.models.import_model import Import
-from backend.app.models.section_model import Section
-from backend.app.models.work_model import Work
 from backend.app.models.index_artist_model import IndexArtist
 from backend.app.models.index_cat_number_model import IndexCatNumber
 from backend.app.models.known_artist_model import KnownArtist
-from fastapi import Depends
-
+from backend.app.models.ruleset_model import Ruleset
+from backend.app.models.section_model import Section
+from backend.app.models.work_model import Work
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,11 +10,8 @@ import hashlib
 import json
 import uuid
 
-import pytest
-
 from backend.app.models.ruleset_model import Ruleset
 from backend.app.services.export_renderer import resolve_export_config
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_seed_templates.py
+++ b/tests/test_seed_templates.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from backend.app.models.ruleset_model import Ruleset
+
 SEED_DIR = Path(__file__).resolve().parent.parent / "backend" / "seed_templates"
 
 # ---------------------------------------------------------------------------
@@ -193,8 +195,6 @@ class TestTemplateSeedFiles:
 # ---------------------------------------------------------------------------
 # Template seeding process
 # ---------------------------------------------------------------------------
-
-from backend.app.models.ruleset_model import Ruleset
 
 
 def test_seed_templates_deletes_orphaned_builtins(db_session):

--- a/tests/test_spreadsheet_validation.py
+++ b/tests/test_spreadsheet_validation.py
@@ -10,23 +10,25 @@ Tests for spreadsheet validation during import:
 
 import io
 import uuid
+
 import pytest
-from openpyxl import Workbook
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from openpyxl import Workbook
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from backend.app.api.import_routes import get_db, router
 from backend.app.db import Base
-from backend.app.api.import_routes import router, get_db
 from backend.app.services.excel_importer import (
-    _validate_headers,
-    ImportError as ExcelImportError,
-    REQUIRED_COLUMNS,
     KNOWN_COLUMNS,
+    REQUIRED_COLUMNS,
+    _validate_headers,
 )
-
+from backend.app.services.excel_importer import (
+    ImportError as ExcelImportError,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_tagged_text_escape.py
+++ b/tests/test_tagged_text_escape.py
@@ -36,7 +36,6 @@ from backend.app.services.low_tag_parser import (
     parse_low_tags,
 )
 
-
 # ---------------------------------------------------------------------------
 # Minimal fakes (mirrors tests/test_renderer.py)
 # ---------------------------------------------------------------------------

--- a/tests/test_title_case.py
+++ b/tests/test_title_case.py
@@ -7,8 +7,6 @@ Roman numerals); the result is corrected per work via the title-case override.
 
 from types import SimpleNamespace
 
-import pytest
-
 from backend.app.services.normalisation_service import (
     DEFAULT_TITLE_CASE_EXCEPTIONS,
     normalise_work,
@@ -16,7 +14,6 @@ from backend.app.services.normalisation_service import (
     to_title_case,
 )
 from backend.app.services.override_service import resolve_effective_work
-
 
 # ---------------------------------------------------------------------------
 # to_title_case

--- a/tests/test_upload_cleanup.py
+++ b/tests/test_upload_cleanup.py
@@ -3,15 +3,12 @@ Tests for upload file management: disk_filename tracking, file cleanup on
 delete, and the orphan cleanup endpoint.
 """
 
-import os
 import uuid as _uuid
 
-import pytest
 from sqlalchemy.orm import Session
 
-from backend.app.services.storage import storage
 from backend.app.models.import_model import Import
-
+from backend.app.services.storage import storage
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -12,9 +12,7 @@ from botocore.exceptions import ClientError
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
-from backend.app.api.auth import require_role, Role
 from backend.app.api import users as users_module
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -81,7 +79,7 @@ def role_client(db_session):
     Reuses the shared ``db_session`` fixture from conftest so that FK
     enforcement and isolation are consistent across the whole test suite.
     """
-    from backend.app.api.import_routes import router, get_db
+    from backend.app.api.import_routes import get_db, router
 
     app = FastAPI()
     app.include_router(router)

--- a/tests/test_validation_warnings.py
+++ b/tests/test_validation_warnings.py
@@ -1,9 +1,6 @@
 from types import SimpleNamespace
 
-import pytest
-
 from backend.app.services.normalisation_service import collect_work_warnings
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_wrap_and_layout.py
+++ b/tests/test_wrap_and_layout.py
@@ -120,7 +120,7 @@ def test_wrap_multiple_breaks():
     # 10 chars per line; text has natural spaces
     text = "one two three four five"
     lines = _wrap_lines(text, 10)
-    assert all(len(l) <= 11 for l in lines)  # <=11 because trailing space allowed
+    assert all(len(line) <= 11 for line in lines)  # <=11 because trailing space allowed
     reassembled = "".join(lines)
     assert reassembled == text
 

--- a/tests/test_wrap_and_layout.py
+++ b/tests/test_wrap_and_layout.py
@@ -4,8 +4,6 @@ Tests for title wrapping, component enabled flag, and final_sep_from_last_compon
 
 from types import SimpleNamespace
 
-import pytest
-
 from backend.app.services.export_renderer import (
     ComponentConfig,
     ExportConfig,
@@ -13,7 +11,6 @@ from backend.app.services.export_renderer import (
     _wrap_lines,
     render_import_as_tagged_text,
 )
-
 
 # ---------------------------------------------------------------------------
 # Shared helpers


### PR DESCRIPTION
## Summary

First tooling-hygiene pass from the code review. Three commits, all low-risk.

1. **`f5b6eb9` Add Ruff lint baseline: config + dependency pins**
   New `pyproject.toml` with Ruff config, new `.pre-commit-config.yaml`, and exact-version pins for `boto3` and `email-validator` (which were the only two unpinned deps).

2. **`72065c8` Apply Ruff autofixes: remove 74 unused imports, sort 91 import blocks**
   Pure mechanical sweep. 80 files touched, nothing semantic changed. Every diff is either F401 (remove unused import) or I001 (re-sort import block stdlib/third-party/first-party).

3. **`f26b18e` Manual lint fixes + add lint job to CI**
   12 issues Ruff couldn't auto-fix:
   - 4 truly unused local variables removed (3 in services, 1 in test)
   - 2 ambiguous `l` iteration vars renamed to `log` / `line`
   - 3 imports moved to top of file in two test files
   - 1 dead `warnings_before` snapshot removed in `test_index_reimport.py` — left a TODO because that test's only remaining assertion (`isinstance(x, list)`) passes vacuously and deserves a real check later
   - CI: added `lint` job (Ruff), made `docker` depend on both lint+test, removed `pytest -x` so CI surfaces the whole failure list rather than stopping at the first

## Ruff config choices

- **`E712` (`== False`) disabled globally.** SQLAlchemy filter clauses *need* `Column == False` to build SQL; Ruff's suggested rewrite `not Column` would evaluate the column eagerly and break the query. Long-term cleaner is `Column.is_(False)` but that's a sweep for another PR.
- **`E402` (import-not-at-top) exempted for 4 files** that have legitimate late-binding reasons: `main.py` imports route modules after `alembic upgrade`, `export_renderer.py` dodges a circular import, `alembic/env.py` and `tests/conftest.py` set `sys.path` first.
- **`E501` (line length) disabled.** Format hook will handle wrapping when we enable it; until then, warnings are noise.
- **`I` (isort) enabled** with `backend` as the first-party package. Already auto-applied across the codebase.
- **`ruff format` deliberately NOT enabled yet.** Would produce a sweeping diff — worth doing, but as its own PR.

## Verification

- `ruff check backend/ tests/`: clean
- `pytest tests/`: **959 passed in 17s** (README says 900, but the suite has actually grown)

## Out of scope for this PR

Held for follow-ups:
- `ruff format` sweep
- Day-2 list from review: `pool_pre_ping=True` on the engine, `WorkOverride.updated_at onupdate`, two alembic env.py gaps, file upload `max_size`, `secrets.compare_digest` for API key, Dockerfile USER + HEALTHCHECK
- The `warnings_regenerated` test deserves a real assertion (TODO left in place)
