### PR TITLE
Document Ruff lint baseline + refresh stale counts in README and dev-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ frontend/
   index.html
   app.js
   style.css
-tests/            # pytest suite (900 tests across 37 test files)
+tests/            # pytest suite (~960 tests across 38 test files)
 .github/workflows/
   ci.yml          # GitHub Actions CI/CD pipeline
 .aws/
@@ -186,6 +186,33 @@ docs/
 ```bash
 python -m pytest tests/ -q
 ```
+
+---
+
+## Linting
+
+Ruff is used for linting (and, eventually, formatting). Configuration lives
+in [`pyproject.toml`](pyproject.toml); Ruff itself is pinned in
+[`requirements-dev.txt`](requirements-dev.txt).
+
+```bash
+# Check
+ruff check backend/ tests/
+
+# Auto-fix what's safe (unused imports, import order)
+ruff check backend/ tests/ --fix
+```
+
+Optional but recommended: install the pre-commit hooks so lint runs on every
+commit and trailing whitespace etc. is fixed automatically.
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+CI runs `ruff check` as a separate job (parallel to the test job) and the
+deploy pipeline blocks on both.
 
 ---
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -19,7 +19,7 @@ Academy Summer Exhibition catalogue. It handles two products:
 | -------- | -------------------------------------------------- |
 | Backend  | Python 3.12, FastAPI, SQLAlchemy, Alembic          |
 | Database | PostgreSQL 16 (Docker), SQLite (tests)             |
-| Frontend | Vanilla JS SPA (`frontend/app.js`, ~5700 lines)    |
+| Frontend | Vanilla JS SPA (`frontend/app.js`, ~7400 lines)    |
 | Infra    | Docker Compose (local), ECS Fargate (staging/prod) |
 
 ### Key directories
@@ -32,7 +32,7 @@ Academy Summer Exhibition catalogue. It handles two products:
 | `backend/alembic/versions/` | Database migrations (auto-run on startup)             |
 | `backend/seed_templates/`   | Default templates and known artist seed data          |
 | `frontend/`                 | Single-page app (`app.js`, `style.css`, `index.html`) |
-| `tests/`                    | Pytest suite (~900 tests, SQLite in-memory)           |
+| `tests/`                    | Pytest suite (~960 tests, SQLite in-memory)           |
 
 ### Data flow
 
@@ -164,7 +164,7 @@ Tests run against an **in-memory SQLite database** — no Docker required.
 python -m venv venv && source venv/bin/activate
 pip install -r requirements-dev.txt
 
-# Run all tests (~775)
+# Run all tests (~960)
 python -m pytest tests/ -q
 
 # Run a single test file
@@ -182,6 +182,58 @@ If you see `ModuleNotFoundError` when running tests, re-run:
 ```bash
 pip install -r requirements-dev.txt
 ```
+
+---
+
+## Linting (Ruff)
+
+Lint config lives in [`pyproject.toml`](../pyproject.toml). Ruff is pinned to
+the same exact version in three places (`requirements-dev.txt`,
+`.pre-commit-config.yaml`, and the CI workflow) — bump them together.
+
+### Commands
+
+| Task                                 | Command                                  |
+| ------------------------------------ | ---------------------------------------- |
+| Check (read-only)                    | `ruff check backend/ tests/`             |
+| Auto-fix what's safe                 | `ruff check backend/ tests/ --fix`       |
+| Show statistics per rule             | `ruff check backend/ tests/ --statistics` |
+| Show one rule only                   | `ruff check --select E402 --no-fix .`    |
+
+Auto-fix safely handles unused imports (`F401`) and import ordering (`I001`).
+It will *not* touch judgement-call issues like unused locals (`F841`),
+ambiguous variable names (`E741`), or mid-file imports (`E402`).
+
+### Config choices worth knowing
+
+- **`E712` (`Column == False`) is disabled globally** because SQLAlchemy filter
+  clauses need `Column == False` to build SQL expressions. Ruff's suggested
+  rewrite (`not Column`) would evaluate the column eagerly and break the
+  query. `Column.is_(False)` is cleaner long-term but hasn't been swept.
+- **`E402` (import not at top) is exempted in four files** that have
+  legitimate late-binding reasons: `main.py` imports route modules after
+  `alembic upgrade`, `services/export_renderer.py` dodges a circular import,
+  and `alembic/env.py` + `tests/conftest.py` set `sys.path` before importing
+  app modules. Don't add new files to this list — fix the import order
+  instead.
+- **`E501` (line length) is disabled.** Once `ruff format` is enabled it will
+  wrap lines; until then warnings are noise.
+- **`I` (isort) is enabled** with `backend` as the first-party package.
+- **`ruff format` is intentionally NOT enabled** in the pre-commit config.
+  Switching it on will produce a sweeping diff; do that in a dedicated PR
+  with no other content so the diff is reviewable.
+
+### Pre-commit hook
+
+Optional but recommended for local use:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The first commit after installing may produce a wave of auto-fixed files
+(trailing whitespace, end-of-file newlines). Re-stage and commit again.
 
 ---
 
@@ -279,10 +331,13 @@ ls backend/alembic/versions/ | sort
 
 Every push triggers:
 
-1. **Test** — runs `pytest` against the full test suite
-2. **Build** — builds Docker image, pushes to ECR
-3. **Deploy staging** — updates ECS service `catalogue-staging` (non-main branches)
-4. **Deploy production** — updates ECS service `catalogue-prod` (main branch only)
+1. **Lint** — runs `ruff check backend/ tests/` (parallel to Test)
+2. **Test** — runs `pytest` against the full test suite (parallel to Lint)
+3. **Build** — builds Docker image, smoke-tests, pushes to ECR (depends on both)
+4. **Deploy staging** — updates ECS service `catalogue-staging` (non-main branches)
+5. **Deploy production** — updates ECS service `catalogue-prod` (main branch only)
+
+A lint failure blocks Build (and therefore Deploy), same as a test failure.
 
 AWS resources use **per-environment secrets** in AWS Secrets Manager:
 


### PR DESCRIPTION
Docs follow-on to PR #77. Targets `tooling-baseline` (not main) so the diff shown here is just the docs work; once #77 merges this PR auto-retargets to main.

## Changes

### README.md
- Fixed stale test count ("900 tests across 37 test files" → "~960 tests across 38 test files").
- New **Linting** section: how to run `ruff check`/`--fix` locally, where the config lives, and the optional pre-commit install.

### docs/dev-guide.md
- Three stale numbers refreshed: frontend `~5700` → `~7400` lines (file has grown), test count `~900` / `~775` → `~960` (the doc had two different stale counts in two places).
- New **Linting (Ruff)** section between "Running tests" and "Database migrations". Covers:
  - Common commands (check, fix, statistics, single-rule).
  - The three places the Ruff version is pinned and must move together (`requirements-dev.txt`, `.pre-commit-config.yaml`, CI workflow).
  - Config choices with real rationale (E712 globally off for SQLAlchemy compat; E402 per-file exemptions for legit late imports; E501 deferred to format; isort enabled with `backend` as first-party).
  - That `ruff format` is **not** yet enabled and should ship in its own PR.
  - Pre-commit install + the first-commit auto-fix surprise.
- **CI/CD pipeline** section updated to show the new five-step flow: Lint and Test in parallel, Build depends on both, then staging/prod deploy. Notes that a lint failure blocks deploy.

No code changes.