### PR TITLE
Fix WorkOverride.updated_at: stamp the column on UPDATE

### DIFF
--- a/backend/app/models/override_model.py
+++ b/backend/app/models/override_model.py
@@ -33,5 +33,6 @@ class WorkOverride(Base):
     updated_at = Column(
         TIMESTAMP(timezone=True),
         server_default=func.now(),
+        onupdate=func.now(),
         nullable=False,
     )

--- a/tests/test_import_override_export_routes.py
+++ b/tests/test_import_override_export_routes.py
@@ -453,6 +453,83 @@ class TestOverrideCRUD:
         assert r2.status_code == 200
         assert r2.json()["title_override"] == "Second"
 
+    def test_put_advances_updated_at_and_audits_update(self, client, db_session):
+        """Regression + coverage for the update path.
+
+        Two side-effects an update PUT must produce:
+
+        1. ``WorkOverride.updated_at`` must move forward. Before
+           backend/app/models/override_model.py gained ``onupdate=func.now()``,
+           the column was stamped on INSERT and then never moved, so it
+           lied about when the row was last touched.
+        2. An ``AuditLog`` row must be appended for each changed field.
+           The existing test_put_creates_audit_log only covers the CREATE
+           branch of the PUT handler; the UPDATE branch (which goes through
+           a separate code path in low_overrides.py) had no test.
+        """
+        from datetime import timedelta
+
+        imp, w = self._make_work(db_session)
+
+        # Create the override.
+        client.put(
+            f"/imports/{imp.id}/works/{w.id}/override",
+            json={"title_override": "First"},
+        )
+
+        # Read the initial timestamp, then backdate it so the post-update
+        # value is unambiguously newer. (SQLite's CURRENT_TIMESTAMP only has
+        # second resolution, and a back-to-back PUT can otherwise land in
+        # the same second.)
+        ovr = (
+            db_session.query(WorkOverride)
+            .filter(WorkOverride.work_id == w.id)
+            .one()
+        )
+        original_updated_at = ovr.updated_at
+        ovr.updated_at = original_updated_at - timedelta(hours=1)
+        db_session.commit()
+        backdated_value = ovr.updated_at
+
+        audit_count_before = (
+            db_session.query(AuditLog).filter(AuditLog.work_id == w.id).count()
+        )
+
+        # Update the override (changes title_override "First" → "Second").
+        client.put(
+            f"/imports/{imp.id}/works/{w.id}/override",
+            json={"title_override": "Second"},
+        )
+        db_session.expire_all()
+
+        # Assertion 1: updated_at moved forward.
+        ovr2 = (
+            db_session.query(WorkOverride)
+            .filter(WorkOverride.work_id == w.id)
+            .one()
+        )
+        assert ovr2.updated_at > backdated_value, (
+            f"updated_at should have moved forward after PUT; "
+            f"backdated to {backdated_value}, still {ovr2.updated_at}"
+        )
+
+        # Assertion 2: exactly one new audit row, capturing old → new.
+        new_logs = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.work_id == w.id)
+            .order_by(AuditLog.id.desc())
+            .all()
+        )
+        assert len(new_logs) == audit_count_before + 1, (
+            f"expected exactly one new audit row for the changed field; "
+            f"had {audit_count_before}, now {len(new_logs)}"
+        )
+        latest = new_logs[0]
+        assert latest.action == "override_set"
+        assert latest.field == "title_override"
+        assert latest.old_value == "First"
+        assert latest.new_value == "Second"
+
     def test_put_partial_fields(self, client, db_session):
         imp, w = self._make_work(db_session)
         r = client.put(

--- a/tests/test_import_override_export_routes.py
+++ b/tests/test_import_override_export_routes.py
@@ -514,21 +514,28 @@ class TestOverrideCRUD:
         )
 
         # Assertion 2: exactly one new audit row, capturing old → new.
-        new_logs = (
-            db_session.query(AuditLog)
-            .filter(AuditLog.work_id == w.id)
-            .order_by(AuditLog.id.desc())
-            .all()
+        # Audit rows can't be ordered by id (UUID, random) or reliably by
+        # created_at (SQLite has only second resolution and the two PUTs may
+        # land in the same second). Query specifically for the update row
+        # by its distinguishing values instead.
+        total_logs = (
+            db_session.query(AuditLog).filter(AuditLog.work_id == w.id).count()
         )
-        assert len(new_logs) == audit_count_before + 1, (
+        assert total_logs == audit_count_before + 1, (
             f"expected exactly one new audit row for the changed field; "
-            f"had {audit_count_before}, now {len(new_logs)}"
+            f"had {audit_count_before}, now {total_logs}"
         )
-        latest = new_logs[0]
-        assert latest.action == "override_set"
-        assert latest.field == "title_override"
-        assert latest.old_value == "First"
-        assert latest.new_value == "Second"
+        update_log = (
+            db_session.query(AuditLog)
+            .filter(
+                AuditLog.work_id == w.id,
+                AuditLog.action == "override_set",
+                AuditLog.field == "title_override",
+                AuditLog.new_value == "Second",
+            )
+            .one()
+        )
+        assert update_log.old_value == "First"
 
     def test_put_partial_fields(self, client, db_session):
         imp, w = self._make_work(db_session)


### PR DESCRIPTION
## Bug

`WorkOverride.updated_at` was set on INSERT and then never moved. The model had `server_default=func.now()` but no `onupdate=func.now()`, so every override's `updated_at` reflected creation time, not last-modification time.

Inconsistent with `KnownArtist` ([known_artist_model.py:73-78](backend/app/models/known_artist_model.py#L73-L78)) and `IndexArtistOverride` ([index_override_model.py:57-62](backend/app/models/index_override_model.py#L57-L62)), which both already set `onupdate` correctly. This one-line change brings `WorkOverride` into line with the convention.

## No migration needed

The schema column already exists with the right nullability and INSERT default. This is purely an ORM-emission change: SQLAlchemy will now include `updated_at = now()` in the UPDATE statement it generates.

Verified in real Postgres locally via `docker compose exec`:
```
after INSERT:  updated_at = 2026-05-29T13:18:48.693606+00:00
after UPDATE:  updated_at = 2026-05-29T13:18:48.698216+00:00
delta: 0.005s  (moved forward ✓)
```

**Existing rows note:** rows already in `work_overrides` keep their (creation-time) `updated_at` until the next time someone edits them. The fix is forward-only because we can't reliably backfill "when was this row really last modified."

## Test

`test_put_advances_updated_at_and_audits_update` covers the update PUT's two side-effects:

1. **`updated_at` moves forward** after a real API-driven PUT. Test backdates the row by an hour, performs the PUT, asserts the timestamp is newer than the backdated value (works on both SQLite and Postgres).
2. **An `AuditLog` row is appended** for the changed field, with correct `old_value` / `new_value` / `field`. This half closes a pre-existing coverage gap: `test_put_creates_audit_log` only covered the CREATE branch of `low_overrides.py`'s PUT handler; the UPDATE branch had no audit-log assertion anywhere in the suite until now.

## Branch context

Branches off `main`, independent of #77 (lint baseline) and #78 (docs). Item #2 from the code-review followups.