### PR TITLE
Dockerfile: non-root user + HEALTHCHECK; .dockerignore: exclude tests/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,6 @@ docs/
 
 # Test sample files
 test_sample_files/
+
+# Tests — not needed at runtime; the production image only needs the app.
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,43 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install curl for ECS container health checks
+# Install curl for the in-container HEALTHCHECK below and for ECS's check.
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies first (layer-cached unless requirements change)
+# Create a non-root user to run the app under. UID 1000 is the conventional
+# first non-system user; matching it makes mounted-volume permissions
+# predictable on Linux hosts.
+RUN useradd --create-home --uid 1000 appuser
+
+# Install dependencies first (layer-cached unless requirements change).
+# Done as root so packages install system-wide under /usr/local.
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy source
-COPY . .
+# Copy source with appuser ownership in a single layer.
+COPY --chown=appuser:appuser . .
 
-# Build metadata — set at build time, readable at runtime
+# Build metadata — set at build time, readable at runtime.
 ARG BUILD_COMMIT=unknown
 ENV BUILD_COMMIT=$BUILD_COMMIT
 
-# Create uploads directory
-RUN mkdir -p /app/uploads
+# Create the uploads directory owned by appuser so the running app can
+# write to it. Note: when a Docker volume is mounted over this path, the
+# volume's existing ownership wins. Local-dev volumes created before this
+# change will be root-owned — recreate them once with
+#     docker compose down -v && docker compose up -d --build
+# In ECS prod, file storage is S3 so this path is unused.
+RUN mkdir -p /app/uploads && chown appuser:appuser /app/uploads
+
+USER appuser
+
+# Docker's own healthcheck. Independent of ECS's (which is defined in the
+# task definition); mostly valuable for `docker compose up` so the
+# container auto-marks unhealthy if the app dies. start-period covers
+# Alembic upgrade + seed loader on first boot.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -sf http://localhost:8000/health || exit 1
 
 EXPOSE 8000
 


### PR DESCRIPTION
Two small hardening / hygiene fixes from the [code-review followups](https://github.com/hoyla/RA-SummerExhibition-ListOfWorks/pull/81).

## Changes

### Dockerfile

- **Create `appuser` (uid 1000) and switch to it before CMD.** Limits the blast radius if the app process is ever compromised. UID 1000 is the conventional first non-system user — makes mounted-volume permissions predictable on Linux hosts.
- **`COPY --chown=appuser:appuser . .`** shifts source ownership in the same layer (no separate slow `chown -R`).
- **chown the `/app/uploads` dir explicitly** so a fresh Docker volume mount inherits writable-by-appuser ownership.
- **Native `HEALTHCHECK`** hits `/health` every 10s after a 20s start-period (covers Alembic upgrade + seed loader on first boot). Independent of ECS's check, which is defined in the task definition. Mostly valuable for `docker compose up` so the container auto-marks unhealthy if the app dies.

### .dockerignore

- **Add `tests/`.** They shipped into every production image until now. Dead weight, not a security issue.

## Migration note for local dev

Existing uploads volumes were created with root ownership. After pulling this change, run once:

```bash
docker compose down -v && docker compose up -d --build
```

In ECS prod the uploads path is unused (file storage is S3), so no impact there.

## Verified locally

```
=== App responds to /health ===
status=ok, db.connected=True

=== Container is running as appuser (uid 1000) ===
appuser
uid=1000(appuser) gid=1000(appuser) groups=1000(appuser)

=== tests/ directory is NOT in the image ===
absent (good)

=== uploads/ is writable by appuser ===
writable (good)

=== Healthcheck status ===
Status: healthy, FailingStreak: 0
Last probe: exit=0
```

The existing `docker` CI job builds the image and smoke-tests `/health` — same verification path I just ran locally.