### PR TITLE
Apply ruff format across backend/ and tests/

### DIFF
--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -93,9 +93,7 @@ def get_import_audit_log(
     """Return audit log entries for a single import, newest first."""
     imp = db.query(Import).filter(Import.id == import_id).first()
     if not imp:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Import not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Import not found")
 
     logs = (
         db.query(AuditLog)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -125,9 +125,7 @@ def _decode_cognito_token(token: str) -> dict:
     # PyJWT requires a key object rather than a raw JWK dict
     key = jwt.algorithms.RSAAlgorithm.from_jwk(jwk_dict)
 
-    issuer = (
-        f"https://cognito-idp.{COGNITO_REGION}.amazonaws.com/" f"{COGNITO_USER_POOL_ID}"
-    )
+    issuer = f"https://cognito-idp.{COGNITO_REGION}.amazonaws.com/{COGNITO_USER_POOL_ID}"
 
     try:
         claims = jwt.decode(

--- a/backend/app/api/index.py
+++ b/backend/app/api/index.py
@@ -182,24 +182,18 @@ def list_index_artists(import_id: UUID, db: Session = Depends(get_db)):
 
     # Batch-fetch overrides
     overrides = (
-        db.query(IndexArtistOverride)
-        .filter(IndexArtistOverride.artist_id.in_(artist_ids))
-        .all()
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id.in_(artist_ids)).all()
         if artist_ids
         else []
     )
-    override_map: dict[str, IndexArtistOverride] = {
-        str(o.artist_id): o for o in overrides
-    }
+    override_map: dict[str, IndexArtistOverride] = {str(o.artist_id): o for o in overrides}
 
     # Build known artist cache
     known_cache = build_known_artist_cache(db)
 
     result = []
     for a in artists:
-        known = lookup_known_artist(
-            known_cache, a.raw_first_name, a.raw_last_name, a.raw_quals
-        )
+        known = lookup_known_artist(known_cache, a.raw_first_name, a.raw_last_name, a.raw_quals)
         ovr = override_map.get(str(a.id))
         eff = resolve_index_artist(a, ovr, known)
 
@@ -311,9 +305,7 @@ def list_index_artists(import_id: UUID, db: Session = Depends(get_db)):
 # ---------------------------------------------------------------------------
 
 
-def _resolve_index_template(
-    db: Session, template_id: UUID | None
-) -> "IndexExportConfig":
+def _resolve_index_template(db: Session, template_id: UUID | None) -> "IndexExportConfig":
     """Load an index template by ID and convert to IndexExportConfig."""
     if not template_id:
         return DEFAULT_INDEX_CONFIG
@@ -335,32 +327,22 @@ def _resolve_index_template(
     cfg = r.config
     return IndexExportConfig(
         entry_style=cfg.get("entry_style", DEFAULT_INDEX_CONFIG.entry_style),
-        ra_surname_style=cfg.get(
-            "ra_surname_style", DEFAULT_INDEX_CONFIG.ra_surname_style
-        ),
+        ra_surname_style=cfg.get("ra_surname_style", DEFAULT_INDEX_CONFIG.ra_surname_style),
         ra_caps_style=cfg.get("ra_caps_style", DEFAULT_INDEX_CONFIG.ra_caps_style),
         cat_no_style=cfg.get("cat_no_style", DEFAULT_INDEX_CONFIG.cat_no_style),
-        honorifics_style=cfg.get(
-            "honorifics_style", DEFAULT_INDEX_CONFIG.honorifics_style
-        ),
+        honorifics_style=cfg.get("honorifics_style", DEFAULT_INDEX_CONFIG.honorifics_style),
         expert_numbers_style=cfg.get(
             "expert_numbers_style", DEFAULT_INDEX_CONFIG.expert_numbers_style
         ),
-        quals_lowercase=cfg.get(
-            "quals_lowercase", DEFAULT_INDEX_CONFIG.quals_lowercase
-        ),
+        quals_lowercase=cfg.get("quals_lowercase", DEFAULT_INDEX_CONFIG.quals_lowercase),
         expert_numbers_enabled=cfg.get(
             "expert_numbers_enabled", DEFAULT_INDEX_CONFIG.expert_numbers_enabled
         ),
-        cat_no_separator=cfg.get(
-            "cat_no_separator", DEFAULT_INDEX_CONFIG.cat_no_separator
-        ),
+        cat_no_separator=cfg.get("cat_no_separator", DEFAULT_INDEX_CONFIG.cat_no_separator),
         cat_no_separator_style=cfg.get(
             "cat_no_separator_style", DEFAULT_INDEX_CONFIG.cat_no_separator_style
         ),
-        section_separator=cfg.get(
-            "section_separator", DEFAULT_INDEX_CONFIG.section_separator
-        ),
+        section_separator=cfg.get("section_separator", DEFAULT_INDEX_CONFIG.section_separator),
         section_separator_style=cfg.get(
             "section_separator_style", DEFAULT_INDEX_CONFIG.section_separator_style
         ),
@@ -450,9 +432,7 @@ def reimport_index_upload(
             )
         except IndexImportError as exc:
             storage.delete(disk_name)
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
-            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
     # Remove the previous upload file if it exists
     storage.delete(import_record.disk_filename or "")
@@ -544,9 +524,7 @@ def _override_to_out(override: IndexArtistOverride) -> IndexArtistOverrideOut:
 def get_index_override(import_id: UUID, artist_id: UUID, db: Session = Depends(get_db)):
     _get_artist_or_404(import_id, artist_id, db)
     override = (
-        db.query(IndexArtistOverride)
-        .filter(IndexArtistOverride.artist_id == artist_id)
-        .first()
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id == artist_id).first()
     )
     if not override:
         raise HTTPException(
@@ -569,9 +547,7 @@ def set_index_override(
 ):
     artist = _get_artist_or_404(import_id, artist_id, db)
     override = (
-        db.query(IndexArtistOverride)
-        .filter(IndexArtistOverride.artist_id == artist_id)
-        .first()
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id == artist_id).first()
     )
 
     fields = body.model_dump()
@@ -621,14 +597,10 @@ def set_index_override(
     status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_role("editor"))],
 )
-def delete_index_override(
-    import_id: UUID, artist_id: UUID, db: Session = Depends(get_db)
-):
+def delete_index_override(import_id: UUID, artist_id: UUID, db: Session = Depends(get_db)):
     _get_artist_or_404(import_id, artist_id, db)
     override = (
-        db.query(IndexArtistOverride)
-        .filter(IndexArtistOverride.artist_id == artist_id)
-        .first()
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id == artist_id).first()
     )
     if not override:
         raise HTTPException(
@@ -678,9 +650,7 @@ def set_artist_excluded(
             AuditLog(
                 import_id=import_id,
                 artist_id=artist_id,
-                action=(
-                    "index_artist_excluded" if new_excluded else "index_artist_included"
-                ),
+                action=("index_artist_excluded" if new_excluded else "index_artist_included"),
                 field="include_in_export",
                 old_value=str(not old_excluded),
                 new_value=str(not new_excluded),
@@ -714,9 +684,7 @@ def set_artist_company(
     artist = _get_artist_or_404(import_id, artist_id, db)
 
     override = (
-        db.query(IndexArtistOverride)
-        .filter(IndexArtistOverride.artist_id == artist_id)
-        .first()
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id == artist_id).first()
     )
 
     # Determine old effective value
@@ -738,11 +706,7 @@ def set_artist_company(
             AuditLog(
                 import_id=import_id,
                 artist_id=artist_id,
-                action=(
-                    "index_artist_company_set"
-                    if is_company
-                    else "index_artist_company_unset"
-                ),
+                action=("index_artist_company_set" if is_company else "index_artist_company_unset"),
                 field="is_company_override",
                 old_value=str(old_effective),
                 new_value=str(is_company),

--- a/backend/app/api/index_templates.py
+++ b/backend/app/api/index_templates.py
@@ -114,9 +114,7 @@ def get_index_template(template_id: UUID, db: Session = Depends(get_db)):
 def create_index_template(body: IndexTemplateBodyIn, db: Session = Depends(get_db)):
     """Create a new index export template."""
     config_dict = body.model_dump(exclude={"name"})
-    config_hash = hashlib.sha256(
-        json.dumps(config_dict, sort_keys=True).encode()
-    ).hexdigest()
+    config_hash = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
     r = Ruleset(
         name=body.name,
         config=config_dict,
@@ -170,9 +168,7 @@ def update_index_template(
     config_dict = body.model_dump(exclude={"name"})
     r.config = config_dict
     r.name = body.name
-    r.config_hash = hashlib.sha256(
-        json.dumps(config_dict, sort_keys=True).encode()
-    ).hexdigest()
+    r.config_hash = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
     db.add(
         AuditLog(
             template_id=r.id,

--- a/backend/app/api/known_artists.py
+++ b/backend/app/api/known_artists.py
@@ -204,11 +204,7 @@ def update_known_artist(
     db: Session = Depends(get_db),
 ):
     """Update an existing known artist entry."""
-    ka = (
-        db.query(KnownArtist)
-        .filter(KnownArtist.id == uuid.UUID(known_artist_id))
-        .first()
-    )
+    ka = db.query(KnownArtist).filter(KnownArtist.id == uuid.UUID(known_artist_id)).first()
     if not ka:
         raise HTTPException(status_code=404, detail="Known artist not found")
     if ka.is_seeded:
@@ -248,11 +244,7 @@ def delete_known_artist(
     db: Session = Depends(get_db),
 ):
     """Remove a known artist entry."""
-    ka = (
-        db.query(KnownArtist)
-        .filter(KnownArtist.id == uuid.UUID(known_artist_id))
-        .first()
-    )
+    ka = db.query(KnownArtist).filter(KnownArtist.id == uuid.UUID(known_artist_id)).first()
     if not ka:
         raise HTTPException(status_code=404, detail="Known artist not found")
     if ka.is_seeded:
@@ -285,11 +277,7 @@ def duplicate_known_artist(
     preserving the original.  The copy has ``is_seeded=False`` and can
     be freely edited or deleted.
     """
-    source = (
-        db.query(KnownArtist)
-        .filter(KnownArtist.id == uuid.UUID(known_artist_id))
-        .first()
-    )
+    source = db.query(KnownArtist).filter(KnownArtist.id == uuid.UUID(known_artist_id)).first()
     if not source:
         raise HTTPException(status_code=404, detail="Known artist not found")
 
@@ -344,9 +332,7 @@ def duplicate_known_artist(
 # ---------------------------------------------------------------------------
 
 
-@router.post(
-    "/seed", response_model=dict, dependencies=[Depends(require_role("admin"))]
-)
+@router.post("/seed", response_model=dict, dependencies=[Depends(require_role("admin"))])
 def seed_known_artists(db: Session = Depends(get_db)):
     """Load known artists from the seed file (known-artists.json).
 
@@ -354,9 +340,7 @@ def seed_known_artists(db: Session = Depends(get_db)):
     Returns a count of added/skipped entries.
     """
     seed_path = (
-        Path(__file__).resolve().parent.parent.parent
-        / "seed_templates"
-        / "known-artists.json"
+        Path(__file__).resolve().parent.parent.parent / "seed_templates" / "known-artists.json"
     )
     if not seed_path.exists():
         raise HTTPException(status_code=404, detail="Seed file not found")

--- a/backend/app/api/low_exports.py
+++ b/backend/app/api/low_exports.py
@@ -94,28 +94,20 @@ def _ruleset_to_export_config(ruleset) -> ExportConfig:
         ComponentConfig(
             field=c["field"] if isinstance(c, dict) else c.field,
             separator_after=(
-                c.get("separator_after", "tab")
-                if isinstance(c, dict)
-                else c.separator_after
+                c.get("separator_after", "tab") if isinstance(c, dict) else c.separator_after
             ),
             omit_sep_when_empty=(
-                c.get("omit_sep_when_empty", True)
-                if isinstance(c, dict)
-                else c.omit_sep_when_empty
+                c.get("omit_sep_when_empty", True) if isinstance(c, dict) else c.omit_sep_when_empty
             ),
             enabled=c.get("enabled", True) if isinstance(c, dict) else c.enabled,
-            max_line_chars=(
-                c.get("max_line_chars") if isinstance(c, dict) else c.max_line_chars
-            ),
+            max_line_chars=(c.get("max_line_chars") if isinstance(c, dict) else c.max_line_chars),
             next_component_position=(
                 c.get("next_component_position", "end_of_text")
                 if isinstance(c, dict)
                 else c.next_component_position
             ),
             balance_lines=(
-                c.get("balance_lines", False)
-                if isinstance(c, dict)
-                else c.balance_lines
+                c.get("balance_lines", False) if isinstance(c, dict) else c.balance_lines
             ),
             paragraph_style=(
                 c.get("paragraph_style") if isinstance(c, dict) else c.paragraph_style
@@ -133,32 +125,22 @@ def _ruleset_to_export_config(ruleset) -> ExportConfig:
         cat_no_style=cfg.get("cat_no_style", DEFAULT_CONFIG.cat_no_style),
         artist_style=cfg.get("artist_style", DEFAULT_CONFIG.artist_style),
         honorifics_style=cfg.get("honorifics_style", DEFAULT_CONFIG.honorifics_style),
-        honorifics_lowercase=cfg.get(
-            "honorifics_lowercase", DEFAULT_CONFIG.honorifics_lowercase
-        ),
+        honorifics_lowercase=cfg.get("honorifics_lowercase", DEFAULT_CONFIG.honorifics_lowercase),
         title_style=cfg.get("title_style", DEFAULT_CONFIG.title_style),
         title_cased_style=cfg.get("title_cased_style", DEFAULT_CONFIG.title_cased_style),
         price_style=cfg.get("price_style", DEFAULT_CONFIG.price_style),
         medium_style=cfg.get("medium_style", DEFAULT_CONFIG.medium_style),
         artwork_style=cfg.get("artwork_style", DEFAULT_CONFIG.artwork_style),
         edition_style=cfg.get("edition_style", DEFAULT_CONFIG.edition_style),
-        thousands_separator=cfg.get(
-            "thousands_separator", DEFAULT_CONFIG.thousands_separator
-        ),
+        thousands_separator=cfg.get("thousands_separator", DEFAULT_CONFIG.thousands_separator),
         decimal_places=cfg.get("decimal_places", DEFAULT_CONFIG.decimal_places),
-        leading_separator=cfg.get(
-            "leading_separator", DEFAULT_CONFIG.leading_separator
-        ),
-        trailing_separator=cfg.get(
-            "trailing_separator", DEFAULT_CONFIG.trailing_separator
-        ),
+        leading_separator=cfg.get("leading_separator", DEFAULT_CONFIG.leading_separator),
+        trailing_separator=cfg.get("trailing_separator", DEFAULT_CONFIG.trailing_separator),
         final_sep_from_last_component=cfg.get(
             "final_sep_from_last_component",
             DEFAULT_CONFIG.final_sep_from_last_component,
         ),
-        section_separator=cfg.get(
-            "section_separator", DEFAULT_CONFIG.section_separator
-        ),
+        section_separator=cfg.get("section_separator", DEFAULT_CONFIG.section_separator),
         section_separator_style=cfg.get(
             "section_separator_style", DEFAULT_CONFIG.section_separator_style
         ),
@@ -201,9 +183,7 @@ def export_section_indesign_tags(
     config = _ruleset_to_export_config(ruleset)
     output = render_import_as_tagged_text(import_id, db, config, section_id=section_id)
     section = (
-        db.query(Section)
-        .filter(Section.id == section_id, Section.import_id == import_id)
-        .first()
+        db.query(Section).filter(Section.id == section_id, Section.import_id == import_id).first()
     )
     # Section-level exports don't snapshot (full-import only)
     return _attachment(

--- a/backend/app/api/low_imports.py
+++ b/backend/app/api/low_imports.py
@@ -64,9 +64,7 @@ def upload_excel(file: UploadFile = File(...), db: Session = Depends(get_db)):
         except ExcelImportError as exc:
             # Clean up the saved file on validation failure
             storage.delete(disk_name)
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
-            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
     # Persist the storage key so we can clean up later
     import_record.disk_filename = disk_name
@@ -145,9 +143,7 @@ def reimport_upload(
             )
         except ExcelImportError as exc:
             storage.delete(disk_name)
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
-            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
     if dry_run:
         # Don't persist the uploaded file — caller will re-upload on commit.
@@ -224,9 +220,7 @@ def list_imports(db: Session = Depends(get_db)):
                 "works": work_counts.get(iid, 0),
                 "override_count": ovr.override_count if ovr else 0,
                 "last_override_at": (
-                    ovr.last_override_at.isoformat()
-                    if ovr and ovr.last_override_at
-                    else None
+                    ovr.last_override_at.isoformat() if ovr and ovr.last_override_at else None
                 ),
             }
         )
@@ -254,9 +248,7 @@ def list_sections(import_id: UUID, db: Session = Depends(get_db)):
     # Batch-fetch all overrides in one query and build a lookup map
     work_ids = [w.id for w in all_works]
     overrides_raw = (
-        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all()
-        if work_ids
-        else []
+        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all() if work_ids else []
     )
     override_map = {str(o.work_id): o for o in overrides_raw}
 
@@ -293,14 +285,10 @@ def list_sections(import_id: UUID, db: Session = Depends(get_db)):
                 artist_name=w.artist_name,
                 artist_honorifics=w.artist_honorifics,
                 price_text=w.price_text,
-                price_numeric=(
-                    float(w.price_numeric) if w.price_numeric is not None else None
-                ),
+                price_numeric=(float(w.price_numeric) if w.price_numeric is not None else None),
                 edition_total=w.edition_total,
                 edition_price_numeric=(
-                    float(w.edition_price_numeric)
-                    if w.edition_price_numeric is not None
-                    else None
+                    float(w.edition_price_numeric) if w.edition_price_numeric is not None else None
                 ),
                 artwork=w.artwork,
                 medium=w.medium,
@@ -346,9 +334,7 @@ def preview_import(import_id: UUID, db: Session = Depends(get_db)):
         for w in works:
             edition_display = None
             if w.edition_total and w.edition_price_numeric:
-                edition_display = (
-                    f"(edition of {w.edition_total} at £{w.edition_price_numeric})"
-                )
+                edition_display = f"(edition of {w.edition_total} at £{w.edition_price_numeric})"
             elif w.edition_total:
                 edition_display = f"(edition of {w.edition_total})"
 
@@ -437,9 +423,7 @@ def cleanup_uploads(db: Session = Depends(get_db)):
     # Collect all disk_filenames that are still referenced
     referenced = {
         row.disk_filename
-        for row in db.query(Import.disk_filename)
-        .filter(Import.disk_filename.isnot(None))
-        .all()
+        for row in db.query(Import.disk_filename).filter(Import.disk_filename.isnot(None)).all()
     }
 
     removed_files: list[str] = []

--- a/backend/app/api/low_overrides.py
+++ b/backend/app/api/low_overrides.py
@@ -18,9 +18,7 @@ router = APIRouter(tags=["overrides"])
 
 
 def _get_work_or_404(import_id: UUID, work_id: UUID, db: Session):
-    work = (
-        db.query(Work).filter(Work.id == work_id, Work.import_id == import_id).first()
-    )
+    work = db.query(Work).filter(Work.id == work_id, Work.import_id == import_id).first()
     if not work:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/api/low_reconcile.py
+++ b/backend/app/api/low_reconcile.py
@@ -55,14 +55,11 @@ def _get_low_import(import_id: UUID, db: Session) -> Import:
     """Fetch a List of Works import or raise 404/400."""
     rec = db.query(Import).filter(Import.id == import_id).first()
     if not rec:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Import not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Import not found")
     if rec.product_type != "list_of_works":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Import {import_id} is not a list_of_works "
-            f"(got {rec.product_type})",
+            detail=f"Import {import_id} is not a list_of_works (got {rec.product_type})",
         )
     return rec
 
@@ -217,9 +214,7 @@ def list_low_tag_snapshots(import_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.get("/imports/{import_id}/low-tag-snapshots/{snapshot_id}")
-def get_low_tag_snapshot_diff(
-    import_id: UUID, snapshot_id: UUID, db: Session = Depends(get_db)
-):
+def get_low_tag_snapshot_diff(import_id: UUID, snapshot_id: UUID, db: Session = Depends(get_db)):
     """Recompute a stored snapshot's diff against the import's *current* data."""
     _get_low_import(import_id, db)
     snap = (
@@ -231,14 +226,10 @@ def get_low_tag_snapshot_diff(
         .first()
     )
     if not snap:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Snapshot not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Snapshot not found")
     return {
         "snapshot": _snapshot_meta(snap),
-        "diff": _diff_payload(
-            import_id, snap.raw_text, snap.template_id, snap.filename, db
-        ),
+        "diff": _diff_payload(import_id, snap.raw_text, snap.template_id, snap.filename, db),
     }
 
 
@@ -246,9 +237,7 @@ def get_low_tag_snapshot_diff(
     "/imports/{import_id}/low-tag-snapshots/{snapshot_id}",
     dependencies=[Depends(require_role("editor"))],
 )
-def delete_low_tag_snapshot(
-    import_id: UUID, snapshot_id: UUID, db: Session = Depends(get_db)
-):
+def delete_low_tag_snapshot(import_id: UUID, snapshot_id: UUID, db: Session = Depends(get_db)):
     """Delete a stored snapshot."""
     _get_low_import(import_id, db)
     snap = (
@@ -260,9 +249,7 @@ def delete_low_tag_snapshot(
         .first()
     )
     if not snap:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Snapshot not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Snapshot not found")
     db.delete(snap)
     db.commit()
     return {"deleted": str(snapshot_id)}

--- a/backend/app/api/low_templates.py
+++ b/backend/app/api/low_templates.py
@@ -61,9 +61,7 @@ def export_template(template_id: UUID, db: Session = Depends(get_db)):
         .first()
     )
     if not r:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
     seed = {"_name": r.name, **r.config}
     body = json.dumps(seed, indent=2, ensure_ascii=False) + "\n"
     slug = r.slug or re.sub(r"[^a-z0-9]+", "-", r.name.lower()).strip("-")
@@ -79,15 +77,9 @@ def export_template(template_id: UUID, db: Session = Depends(get_db)):
 @router.get("/templates/{template_id}")
 def get_template(template_id: UUID, db: Session = Depends(get_db)):
     """Return full config for one template."""
-    r = (
-        db.query(Ruleset)
-        .filter(Ruleset.id == template_id, Ruleset.archived == False)
-        .first()
-    )
+    r = db.query(Ruleset).filter(Ruleset.id == template_id, Ruleset.archived == False).first()
     if not r:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
     return {
         "id": str(r.id),
         "name": r.name,
@@ -105,9 +97,7 @@ def get_template(template_id: UUID, db: Session = Depends(get_db)):
 def create_template(body: TemplateBodyIn, db: Session = Depends(get_db)):
     """Create a new export template."""
     config_dict = body.model_dump(exclude={"name"})
-    config_hash = hashlib.sha256(
-        json.dumps(config_dict, sort_keys=True).encode()
-    ).hexdigest()
+    config_hash = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
     r = Ruleset(
         name=body.name,
         config=config_dict,
@@ -132,19 +122,11 @@ def create_template(body: TemplateBodyIn, db: Session = Depends(get_db)):
 
 
 @router.put("/templates/{template_id}", dependencies=[Depends(require_role("editor"))])
-def update_template(
-    template_id: UUID, body: TemplateBodyIn, db: Session = Depends(get_db)
-):
+def update_template(template_id: UUID, body: TemplateBodyIn, db: Session = Depends(get_db)):
     """Update an existing export template."""
-    r = (
-        db.query(Ruleset)
-        .filter(Ruleset.id == template_id, Ruleset.archived == False)
-        .first()
-    )
+    r = db.query(Ruleset).filter(Ruleset.id == template_id, Ruleset.archived == False).first()
     if not r:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
     if r.is_builtin:
         raise HTTPException(
             status_code=403,
@@ -154,9 +136,7 @@ def update_template(
     config_dict = body.model_dump(exclude={"name"})
     r.config = config_dict
     r.name = body.name
-    r.config_hash = hashlib.sha256(
-        json.dumps(config_dict, sort_keys=True).encode()
-    ).hexdigest()
+    r.config_hash = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
     db.add(
         AuditLog(
             template_id=r.id,
@@ -182,15 +162,9 @@ def update_template(
 )
 def delete_template(template_id: UUID, db: Session = Depends(get_db)):
     """Soft-delete an export template."""
-    r = (
-        db.query(Ruleset)
-        .filter(Ruleset.id == template_id, Ruleset.archived == False)
-        .first()
-    )
+    r = db.query(Ruleset).filter(Ruleset.id == template_id, Ruleset.archived == False).first()
     if not r:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
     if r.is_builtin:
         raise HTTPException(status_code=403, detail="Cannot delete a built-in template")
     r.archived = True
@@ -214,9 +188,7 @@ def duplicate_template(template_id: UUID, db: Session = Depends(get_db)):
     """Clone a template under a new name."""
     r = db.query(Ruleset).filter(Ruleset.id == template_id).first()
     if not r:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
     new_r = Ruleset(
         name=f"Copy of {r.name}",
         config=dict(r.config),

--- a/backend/app/api/normalisation_config.py
+++ b/backend/app/api/normalisation_config.py
@@ -40,15 +40,9 @@ def load_normalisation_settings(db: Session) -> dict:
     cfg = row.config if row else {}
     return {
         "honorific_tokens": cfg.get("honorific_tokens", DEFAULT_HONORIFIC_TOKENS),
-        "edition_suppress_max": cfg.get(
-            "edition_suppress_max", DEFAULT_EDITION_SUPPRESS_MAX
-        ),
-        "text_substitutions": cfg.get(
-            "text_substitutions", DEFAULT_TEXT_SUBSTITUTIONS
-        ),
-        "title_case_exceptions": cfg.get(
-            "title_case_exceptions", DEFAULT_TITLE_CASE_EXCEPTIONS
-        ),
+        "edition_suppress_max": cfg.get("edition_suppress_max", DEFAULT_EDITION_SUPPRESS_MAX),
+        "text_substitutions": cfg.get("text_substitutions", DEFAULT_TEXT_SUBSTITUTIONS),
+        "title_case_exceptions": cfg.get("title_case_exceptions", DEFAULT_TITLE_CASE_EXCEPTIONS),
     }
 
 
@@ -67,9 +61,7 @@ def put_config(body: NormalisationIn, db: Session = Depends(get_db)):
         "text_substitutions": [s.model_dump() for s in body.text_substitutions],
         "title_case_exceptions": body.title_case_exceptions,
     }
-    config_hash = hashlib.sha256(
-        json.dumps(config_dict, sort_keys=True).encode()
-    ).hexdigest()
+    config_hash = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode()).hexdigest()
     row = _get_normalisation_row(db)
     if row:
         row.config = config_dict

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -297,8 +297,7 @@ class TextSubstitutionIn(BaseModel):
         bad = [f for f in v if f not in _SUBSTITUTABLE_FIELDS]
         if bad:
             raise ValueError(
-                f"unknown substitution field(s): {bad}; "
-                f"allowed: {sorted(_SUBSTITUTABLE_FIELDS)}"
+                f"unknown substitution field(s): {bad}; allowed: {sorted(_SUBSTITUTABLE_FIELDS)}"
             )
         return v
 
@@ -321,8 +320,21 @@ class NormalisationIn(BaseModel):
     ]
     # Tokens whose casing is preserved when title-casing (acronyms, stylised names).
     title_case_exceptions: list[str] = [
-        "RA", "PRA", "PPRA", "RWS", "RE", "NEAC", "OBE", "MBE", "CBE",
-        "USA", "UK", "NYC", "LA", "BBC", "MoMA",
+        "RA",
+        "PRA",
+        "PPRA",
+        "RWS",
+        "RE",
+        "NEAC",
+        "OBE",
+        "MBE",
+        "CBE",
+        "USA",
+        "UK",
+        "NYC",
+        "LA",
+        "BBC",
+        "MoMA",
     ]
 
     @field_validator("edition_suppress_max")

--- a/backend/app/api/user_context.py
+++ b/backend/app/api/user_context.py
@@ -12,6 +12,4 @@ from contextvars import ContextVar
 
 # Holds the current user's email for the duration of a request.
 # Default is "anonymous" for local-dev / no-auth mode.
-current_user_email: ContextVar[str] = ContextVar(
-    "current_user_email", default="anonymous"
-)
+current_user_email: ContextVar[str] = ContextVar("current_user_email", default="anonymous")

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -62,7 +62,9 @@ def _user_to_dict(user: dict, groups: list[str] | None = None) -> dict:
         "status": user.get("UserStatus", "UNKNOWN"),
         "enabled": user.get("Enabled", True),
         "role": role,
-        "created_at": user.get("UserCreateDate", "").isoformat() if hasattr(user.get("UserCreateDate", ""), "isoformat") else str(user.get("UserCreateDate", "")),
+        "created_at": user.get("UserCreateDate", "").isoformat()
+        if hasattr(user.get("UserCreateDate", ""), "isoformat")
+        else str(user.get("UserCreateDate", "")),
     }
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,9 +36,7 @@ AWS_REGION: str | None = os.getenv("AWS_REGION")
 
 # Comma-separated list of allowed CORS origins.
 # Leave empty to disallow cross-origin requests (same-origin only).
-CORS_ORIGINS: list[str] = [
-    o.strip() for o in os.getenv("CORS_ORIGINS", "").split(",") if o.strip()
-]
+CORS_ORIGINS: list[str] = [o.strip() for o in os.getenv("CORS_ORIGINS", "").split(",") if o.strip()]
 
 # Maximum request body size in bytes; requests exceeding this are rejected
 # with 413 before parsing. Default 50 MB — comfortably above any realistic

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,9 +24,7 @@ from backend.app.api.auth import Role, get_current_role
 from backend.app.config import API_KEY, CORS_ORIGINS, LOG_LEVEL, MAX_REQUEST_BODY_BYTES
 from backend.app.db import engine
 
-_alembic_cfg = AlembicConfig(
-    str(Path(__file__).resolve().parent.parent.parent / "alembic.ini")
-)
+_alembic_cfg = AlembicConfig(str(Path(__file__).resolve().parent.parent.parent / "alembic.ini"))
 
 # If the DB already has tables but no alembic_version table, stamp it first
 # so that upgrade() doesn't re-create existing tables.
@@ -140,14 +138,10 @@ def _seed_known_artists() -> None:
                     resolved_last_name=entry.get("resolved_last_name"),
                     resolved_quals=entry.get("resolved_quals"),
                     resolved_is_company=entry.get("resolved_is_company"),
-                    resolved_artist2_first_name=entry.get(
-                        "resolved_artist2_first_name"
-                    ),
+                    resolved_artist2_first_name=entry.get("resolved_artist2_first_name"),
                     resolved_artist2_last_name=entry.get("resolved_artist2_last_name"),
                     resolved_artist2_quals=entry.get("resolved_artist2_quals"),
-                    resolved_artist3_first_name=entry.get(
-                        "resolved_artist3_first_name"
-                    ),
+                    resolved_artist3_first_name=entry.get("resolved_artist3_first_name"),
                     resolved_artist3_last_name=entry.get("resolved_artist3_last_name"),
                     resolved_artist3_quals=entry.get("resolved_artist3_quals"),
                     resolved_artist1_ra_styled=entry.get("resolved_artist1_ra_styled"),
@@ -364,10 +358,7 @@ def health():
 
             # Active connections
             row = conn.execute(
-                text(
-                    "SELECT count(*) FROM pg_stat_activity "
-                    "WHERE datname = current_database()"
-                )
+                text("SELECT count(*) FROM pg_stat_activity WHERE datname = current_database()")
             ).fetchone()
             if row:
                 db_info["active_connections"] = row[0]

--- a/backend/app/models/import_model.py
+++ b/backend/app/models/import_model.py
@@ -19,6 +19,4 @@ class Import(Base):
     # 'list_of_works' | 'artists_index'
     product_type = Column(Text, nullable=False, server_default="list_of_works")
 
-    uploaded_at = Column(
-        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
-    )
+    uploaded_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/models/section_model.py
+++ b/backend/app/models/section_model.py
@@ -21,8 +21,6 @@ class Section(Base):
 
     __table_args__ = (
         UniqueConstraint("import_id", "name", name="sections_import_id_name_key"),
-        UniqueConstraint(
-            "import_id", "position", name="sections_import_id_position_key"
-        ),
+        UniqueConstraint("import_id", "position", name="sections_import_id_position_key"),
         Index("idx_sections_import", "import_id"),
     )

--- a/backend/app/models/work_model.py
+++ b/backend/app/models/work_model.py
@@ -65,9 +65,7 @@ class Work(Base):
     # rows inserted via the ORM that don't set the value rely on the DB default,
     # which on SQLite (tests) stores a value that doesn't satisfy
     # `== True` queries. App-level default only — no schema change / migration.
-    include_in_export = Column(
-        Boolean, nullable=False, default=True, server_default="true"
-    )
+    include_in_export = Column(Boolean, nullable=False, default=True, server_default="true")
 
     created_at = Column(
         TIMESTAMP(timezone=True),

--- a/backend/app/services/comparison_service.py
+++ b/backend/app/services/comparison_service.py
@@ -232,9 +232,7 @@ def _compare_names(
     """
     differences: List[str] = []
 
-    low_first, low_last, low_quals = _extract_low_name_parts(
-        low_artist_name, low_artist_honorifics
-    )
+    low_first, low_last, low_quals = _extract_low_name_parts(low_artist_name, low_artist_honorifics)
     idx_first_clean, idx_last_clean, idx_quals_set = _extract_index_name_parts(
         idx_first, idx_last, idx_title, idx_quals, idx_is_company
     )
@@ -253,9 +251,7 @@ def _compare_names(
 
     # Check last name match
     last_match = (
-        low_last.lower() == idx_last_clean.lower()
-        if (low_last and idx_last_clean)
-        else False
+        low_last.lower() == idx_last_clean.lower() if (low_last and idx_last_clean) else False
     )
 
     # Check first name match (ignoring title prefixes in Index)
@@ -317,19 +313,14 @@ def _compare_names(
         extra_other_idx = idx_other - low_other
         extra_other_low = low_other - idx_other
         if extra_other_idx:
-            differences.append(
-                f"extra_quals_in_index:{','.join(sorted(extra_other_idx))}"
-            )
+            differences.append(f"extra_quals_in_index:{','.join(sorted(extra_other_idx))}")
         if extra_other_low:
-            differences.append(
-                f"extra_quals_in_low:{','.join(sorted(extra_other_low))}"
-            )
+            differences.append(f"extra_quals_in_low:{','.join(sorted(extra_other_low))}")
 
     # Title mismatch (already captured in differences above if first_match
     # was resolved by absorbing the title).  Also flag explicit title presence.
     has_title_diff = any(
-        d in ("title_in_index_not_in_low", "title_in_low_not_in_index")
-        for d in differences
+        d in ("title_in_index_not_in_low", "title_in_low_not_in_index") for d in differences
     )
 
     # ----- Classify match level (most → least significant) -----
@@ -359,17 +350,12 @@ def _compare_names(
     else:
         # Check word-set overlap as a fallback (handles companies, unusual name orders)
         low_all_words = _normalise_words(low_artist_name) | low_quals
-        idx_all_words = (
-            _normalise_words(f"{idx_first_clean} {idx_last_clean}") | idx_quals_set
-        )
+        idx_all_words = _normalise_words(f"{idx_first_clean} {idx_last_clean}") | idx_quals_set
         if low_all_words and low_all_words == idx_all_words:
             return (MatchLevel.equivalent, differences)
         if low_all_words and idx_all_words and low_all_words & idx_all_words:
             # Some overlap — classify by most significant difference
-            if (
-                "last_name_different" in differences
-                or "first_name_different" in differences
-            ):
+            if "last_name_different" in differences or "first_name_different" in differences:
                 return (MatchLevel.partial_name, differences)
             if not ra_match:
                 return (MatchLevel.partial_ra, differences)
@@ -414,16 +400,14 @@ def compare_datasets(
     works = db.query(Work).filter(Work.import_id == low_import_id).all()
     work_ids = [w.id for w in works]
     overrides = (
-        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all()
-        if work_ids
-        else []
+        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all() if work_ids else []
     )
     override_map: Dict[str, WorkOverride] = {str(o.work_id): o for o in overrides}
 
     # Build LoW map: cat_no (int) -> resolved values
-    low_map: Dict[int, Tuple[str, str, str, str]] = (
-        {}
-    )  # cat_no -> (artist_name, honorifics, work_id, raw_cat_no)
+    low_map: Dict[
+        int, Tuple[str, str, str, str]
+    ] = {}  # cat_no -> (artist_name, honorifics, work_id, raw_cat_no)
     for w in works:
         eff = resolve_effective_work(w, override_map.get(str(w.id)))
         raw = eff.raw_cat_no or ""
@@ -441,9 +425,7 @@ def compare_datasets(
     # ------------------------------------------------------------------
     # 2. Load Index artists with overrides and known artists
     # ------------------------------------------------------------------
-    artists = (
-        db.query(IndexArtist).filter(IndexArtist.import_id == index_import_id).all()
-    )
+    artists = db.query(IndexArtist).filter(IndexArtist.import_id == index_import_id).all()
     artist_ids = [a.id for a in artists]
 
     # Batch-fetch cat numbers
@@ -458,15 +440,11 @@ def compare_datasets(
 
     # Batch-fetch overrides
     idx_overrides = (
-        db.query(IndexArtistOverride)
-        .filter(IndexArtistOverride.artist_id.in_(artist_ids))
-        .all()
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id.in_(artist_ids)).all()
         if artist_ids
         else []
     )
-    idx_override_map: Dict[str, IndexArtistOverride] = {
-        str(o.artist_id): o for o in idx_overrides
-    }
+    idx_override_map: Dict[str, IndexArtistOverride] = {str(o.artist_id): o for o in idx_overrides}
 
     # Build known artist cache
     known_cache = build_known_artist_cache(db)
@@ -489,9 +467,7 @@ def compare_datasets(
     # Pre-resolve each artist
     artist_resolved: Dict[str, object] = {}
     for a in artists:
-        known = lookup_known_artist(
-            known_cache, a.raw_first_name, a.raw_last_name, a.raw_quals
-        )
+        known = lookup_known_artist(known_cache, a.raw_first_name, a.raw_last_name, a.raw_quals)
         ovr = idx_override_map.get(str(a.id))
         eff = resolve_index_artist(a, ovr, known)
         artist_resolved[str(a.id)] = eff

--- a/backend/app/services/excel_importer.py
+++ b/backend/app/services/excel_importer.py
@@ -73,9 +73,7 @@ def _validate_headers(headers: list[str]) -> list[str]:
         for col in sorted(missing_required):
             matches = get_close_matches(col, list(found), n=1, cutoff=0.6)
             if matches:
-                suggestions.append(
-                    f'  - "{col}" not found (did you mean "{matches[0]}"?)'
-                )
+                suggestions.append(f'  - "{col}" not found (did you mean "{matches[0]}"?)')
             else:
                 suggestions.append(f'  - "{col}" not found')
 
@@ -126,9 +124,7 @@ def import_excel(
     record_name = display_name or file_path
 
     # Duplicate filename detection
-    duplicate_detected = (
-        db.query(Import).filter(Import.filename == record_name).first() is not None
-    )
+    duplicate_detected = db.query(Import).filter(Import.filename == record_name).first() is not None
 
     import_record = Import(filename=record_name)
     db.add(import_record)
@@ -280,10 +276,7 @@ def _open_and_parse_workbook(file_path: str) -> Tuple[List[str], List[dict], Lis
             v = "'" + v
         return v
 
-    rows = [
-        {h: _cell_value(c) for h, c in zip(headers, row)}
-        for row in sheet.iter_rows(min_row=2)
-    ]
+    rows = [{h: _cell_value(c) for h, c in zip(headers, row)} for row in sheet.iter_rows(min_row=2)]
 
     return headers, rows, header_warnings
 
@@ -356,9 +349,7 @@ def reimport_excel(
     if work_ids:
         existing_overrides_by_work = {
             o.work_id: o
-            for o in db.query(WorkOverride)
-            .filter(WorkOverride.work_id.in_(work_ids))
-            .all()
+            for o in db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all()
         }
 
     # Side-table for restoring overrides keyed by old cat_no (the matcher
@@ -369,16 +360,12 @@ def reimport_excel(
     for w in existing_works:
         cat_key = str(w.raw_cat_no).strip() if w.raw_cat_no is not None else ""
         ovr_obj = existing_overrides_by_work.get(w.id)
-        ovr_dict = (
-            {f: getattr(ovr_obj, f) for f in OVERRIDE_FIELDS} if ovr_obj else None
-        )
+        ovr_dict = {f: getattr(ovr_obj, f) for f in OVERRIDE_FIELDS} if ovr_obj else None
         old_snapshots.append(
             OldWorkSnapshot(
                 cat_no=cat_key,
                 gallery=str(w.raw_gallery or ""),
-                fingerprint=compute_fingerprint(
-                    w.raw_title, w.raw_artist, w.raw_medium
-                ),
+                fingerprint=compute_fingerprint(w.raw_title, w.raw_artist, w.raw_medium),
                 include_in_export=w.include_in_export,
                 override=ovr_dict,
                 raw_title=w.raw_title,
@@ -402,9 +389,7 @@ def reimport_excel(
         gallery_name = row_dict.get("Gallery") or "Uncategorised"
         new_rows.append(
             NewWorkRow(
-                cat_no=(
-                    str(raw_cat_no).strip() if raw_cat_no is not None else ""
-                ),
+                cat_no=(str(raw_cat_no).strip() if raw_cat_no is not None else ""),
                 gallery=str(gallery_name),
                 fingerprint=compute_fingerprint(
                     row_dict.get("Title"),
@@ -435,18 +420,14 @@ def reimport_excel(
 
     if gallery_scope is None:
         if work_ids:
-            db.query(WorkOverride).filter(
-                WorkOverride.work_id.in_(work_ids)
-            ).delete(synchronize_session=False)
-        db.query(ValidationWarning).filter(
-            ValidationWarning.import_id == import_id
-        ).delete(synchronize_session=False)
-        db.query(Work).filter(Work.import_id == import_id).delete(
+            db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).delete(
+                synchronize_session=False
+            )
+        db.query(ValidationWarning).filter(ValidationWarning.import_id == import_id).delete(
             synchronize_session=False
         )
-        db.query(Section).filter(Section.import_id == import_id).delete(
-            synchronize_session=False
-        )
+        db.query(Work).filter(Work.import_id == import_id).delete(synchronize_session=False)
+        db.query(Section).filter(Section.import_id == import_id).delete(synchronize_session=False)
         db.flush()
         next_position = 1
     else:
@@ -467,21 +448,21 @@ def reimport_excel(
             w.id for w in existing_works if w.section_id in set(in_scope_section_ids)
         ]
         if in_scope_work_ids:
-            db.query(WorkOverride).filter(
-                WorkOverride.work_id.in_(in_scope_work_ids)
-            ).delete(synchronize_session=False)
+            db.query(WorkOverride).filter(WorkOverride.work_id.in_(in_scope_work_ids)).delete(
+                synchronize_session=False
+            )
             # Per-work validation warnings only (header warnings keyed by
             # work_id=NULL are global and survive a selective re-import).
             db.query(ValidationWarning).filter(
                 ValidationWarning.work_id.in_(in_scope_work_ids)
             ).delete(synchronize_session=False)
         if in_scope_section_ids:
-            db.query(Work).filter(
-                Work.section_id.in_(in_scope_section_ids)
-            ).delete(synchronize_session=False)
-            db.query(Section).filter(
-                Section.id.in_(in_scope_section_ids)
-            ).delete(synchronize_session=False)
+            db.query(Work).filter(Work.section_id.in_(in_scope_section_ids)).delete(
+                synchronize_session=False
+            )
+            db.query(Section).filter(Section.id.in_(in_scope_section_ids)).delete(
+                synchronize_session=False
+            )
         db.flush()
         # New galleries (in scope but no pre-existing section) get
         # positions after the current max.
@@ -511,9 +492,7 @@ def reimport_excel(
 
     # Map (in_scope_row_index → matched item) so we can restore override
     # data as each new Work is created.
-    matched_by_in_scope_idx: Dict[int, object] = {
-        m.new_row_index: m for m in plan.matched
-    }
+    matched_by_in_scope_idx: Dict[int, object] = {m.new_row_index: m for m in plan.matched}
     in_scope_counter = 0
 
     for row_dict in rows:

--- a/backend/app/services/export_diff_service.py
+++ b/backend/app/services/export_diff_service.py
@@ -255,7 +255,7 @@ def _entry_key(entry: dict) -> str:
     groups gets separate keys.
     """
     courtesy = entry.get("courtesy") or ""
-    return f'{entry.get("sort_key", "")}::{courtesy}'
+    return f"{entry.get('sort_key', '')}::{courtesy}"
 
 
 def _entry_display_name(entry: dict) -> str:
@@ -267,7 +267,7 @@ def _entry_display_name(entry: dict) -> str:
         parts.append(entry["first_name"])
     name = ", ".join(parts) if parts else "(unknown)"
     if entry.get("quals"):
-        name += f' {entry["quals"]}'
+        name += f" {entry['quals']}"
     return name
 
 

--- a/backend/app/services/export_renderer.py
+++ b/backend/app/services/export_renderer.py
@@ -33,13 +33,9 @@ class ComponentConfig:
 
     field: str
     separator_after: str = "tab"  # key in SEPARATOR_MAP
-    omit_sep_when_empty: bool = (
-        True  # suppress the separator when this component has no value
-    )
+    omit_sep_when_empty: bool = True  # suppress the separator when this component has no value
     enabled: bool = True  # when False the component is excluded from export entirely
-    max_line_chars: Optional[int] = (
-        None  # wrap at this many chars per line (None = no wrap)
-    )
+    max_line_chars: Optional[int] = None  # wrap at this many chars per line (None = no wrap)
     next_component_position: str = "end_of_text"  # "end_of_text" | "end_of_first_line"
     balance_lines: bool = False  # narrow column to equalise line lengths
     # When set, this component opens a NEW paragraph with this paragraph style
@@ -119,9 +115,7 @@ from uuid import UUID
 from backend.app.models.ruleset_model import Ruleset
 
 
-def resolve_export_config(
-    db: Session, ruleset_id: UUID | None = None
-) -> Ruleset | None:
+def resolve_export_config(db: Session, ruleset_id: UUID | None = None) -> Ruleset | None:
     """
     Resolve an export Ruleset from the database.
 
@@ -194,9 +188,7 @@ def _collect_export_data(import_id, db: Session, section_id=None) -> list[dict]:
     )
     work_ids = [w.id for w in all_works]
     all_overrides = (
-        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all()
-        if work_ids
-        else []
+        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all() if work_ids else []
     )
     override_map = {o.work_id: o for o in all_overrides}
 
@@ -331,9 +323,7 @@ def _wrap_lines(text: str, max_chars: int) -> list:
         # Walk the candidate backwards until we find a clean break point
         for _ in range(max_chars):  # bounded to prevent infinite loop
             char_before = remaining[candidate - 1] if candidate > 0 else ""
-            char_after = (
-                remaining[candidate + 1] if candidate + 1 < len(remaining) else ""
-            )
+            char_after = remaining[candidate + 1] if candidate + 1 < len(remaining) else ""
             bad = (
                 char_before in _OPEN_PUNCT
                 or char_before in _NO_BREAK_AFTER
@@ -495,9 +485,7 @@ def _compute_component_values(w: dict, config: "ExportConfig") -> dict:
     layouts."""
     artist = _cs(config.artist_style, w["artist"])
     if w["honorifics"]:
-        hon_text = (
-            w["honorifics"].lower() if config.honorifics_lowercase else w["honorifics"]
-        )
+        hon_text = w["honorifics"].lower() if config.honorifics_lowercase else w["honorifics"]
         artist += " " + _cs(config.honorifics_style, hon_text)
 
     if w["price_numeric"]:
@@ -525,13 +513,9 @@ def _compute_component_values(w: dict, config: "ExportConfig") -> dict:
         # Fall back to the plain title when the cased form is absent (e.g. data
         # imported before title-casing existed), so a printed guide never shows
         # blank titles — graceful degradation; a re-import populates the casing.
-        "title_cased": _cs(
-            config.title_cased_style, w.get("title_cased") or w.get("title") or ""
-        ),
+        "title_cased": _cs(config.title_cased_style, w.get("title_cased") or w.get("title") or ""),
         "edition": _cs(config.edition_style, edition_display),
-        "artwork": _cs(
-            config.artwork_style, str(w["artwork"]) if w["artwork"] else ""
-        ),
+        "artwork": _cs(config.artwork_style, str(w["artwork"]) if w["artwork"] else ""),
         "price": _cs(config.price_style, raw_price),
         "medium": _cs(config.medium_style, w["medium"] or ""),
     }
@@ -641,13 +625,9 @@ def render_import_as_tagged_text(
                     raw = _raw_text_for_field(comp.field, w)
                     # Manual line breaks (\n in overridden text) bypass auto-wrap
                     if raw and "\n" in raw:
-                        wrapped = [
-                            line.lstrip() for line in raw.split("\n") if line.strip()
-                        ]
+                        wrapped = [line.lstrip() for line in raw.split("\n") if line.strip()]
                     else:
-                        _wrap_fn = (
-                            _balance_wrap_lines if comp.balance_lines else _wrap_lines
-                        )
+                        _wrap_fn = _balance_wrap_lines if comp.balance_lines else _wrap_lines
                         wrapped = _wrap_fn(raw, comp.max_line_chars) if raw else []
                     style = _field_char_style(config, comp.field)
                     eff_sep = (
@@ -665,11 +645,7 @@ def render_import_as_tagged_text(
                             entry += _sep(eff_sep, config.entry_style)
                     elif end_of_first_line:
                         # Multi-line + end_of_first_line: interleave next component
-                        nc = (
-                            enabled_comps[idx + 1]
-                            if idx + 1 < len(enabled_comps)
-                            else None
-                        )
+                        nc = enabled_comps[idx + 1] if idx + 1 < len(enabled_comps) else None
                         if nc:
                             skip_fields.add(nc.field)
                             nc_val = comp_values.get(nc.field, "")
@@ -685,9 +661,7 @@ def render_import_as_tagged_text(
                         # block. Escape per-line so the wrap count math (which
                         # ran on the unescaped raw text) isn't thrown off by
                         # inflated escape sequences.
-                        rest = "\n".join(
-                            escape_tagged_text_chars(line) for line in wrapped[1:]
-                        )
+                        rest = "\n".join(escape_tagged_text_chars(line) for line in wrapped[1:])
                         if style:
                             entry += f"<CharStyle:{style}>\n{rest}<CharStyle:>"
                         else:
@@ -703,9 +677,7 @@ def render_import_as_tagged_text(
                         # Multi-line, normal position: join with soft returns.
                         # Escape per-line — see end_of_first_line branch above
                         # for the wrap-length-vs-escape rationale.
-                        full = "\n".join(
-                            escape_tagged_text_chars(line) for line in wrapped
-                        )
+                        full = "\n".join(escape_tagged_text_chars(line) for line in wrapped)
                         if style:
                             entry += f"<CharStyle:{style}>{full}<CharStyle:>"
                         else:
@@ -867,21 +839,13 @@ def render_import_as_csv(import_id, db: Session) -> str:
                     "artist": w["artist"],
                     "honorifics": w["honorifics"] or "",
                     "title": w["title"],
-                    "price_numeric": (
-                        w["price_numeric"] if w["price_numeric"] is not None else ""
-                    ),
+                    "price_numeric": (w["price_numeric"] if w["price_numeric"] is not None else ""),
                     "price_text": w["price_text"],
-                    "edition_total": (
-                        w["edition_total"] if w["edition_total"] is not None else ""
-                    ),
+                    "edition_total": (w["edition_total"] if w["edition_total"] is not None else ""),
                     "edition_price_numeric": (
-                        w["edition_price_numeric"]
-                        if w["edition_price_numeric"] is not None
-                        else ""
+                        w["edition_price_numeric"] if w["edition_price_numeric"] is not None else ""
                     ),
-                    "artwork": (
-                        w["artwork"] if w["artwork"] is not None else ""
-                    ),
+                    "artwork": (w["artwork"] if w["artwork"] is not None else ""),
                     "medium": w["medium"] or "",
                 }
             )

--- a/backend/app/services/index_importer.py
+++ b/backend/app/services/index_importer.py
@@ -188,9 +188,7 @@ def parse_multi_artist(
             break
         else:
             a2_extracted_quals.insert(0, m2.group(0))
-            a2_remaining = (
-                a2_remaining[: m2.start()] + a2_remaining[m2.end() :]
-            ).strip()
+            a2_remaining = (a2_remaining[: m2.start()] + a2_remaining[m2.end() :]).strip()
 
     a2_name_words = a2_remaining.split()
     a2_last = a2_name_words[-1] if a2_name_words else None
@@ -291,9 +289,7 @@ _QUAL_IN_NAME_PATTERN = re.compile(
 )
 
 
-def detect_quals_in_name(
-    first_name: Optional[str], last_name: Optional[str]
-) -> Optional[str]:
+def detect_quals_in_name(first_name: Optional[str], last_name: Optional[str]) -> Optional[str]:
     """If a known qualification token appears in a name field, return it.
 
     Returns the first matched token or None.
@@ -345,9 +341,7 @@ def _validate_headers(headers: List[str]) -> List[str]:
         for col in sorted(missing_required):
             matches = get_close_matches(col, list(found), n=1, cutoff=0.6)
             if matches:
-                suggestions.append(
-                    f'  - "{col}" not found (did you mean "{matches[0]}"?)'
-                )
+                suggestions.append(f'  - "{col}" not found (did you mean "{matches[0]}"?)')
             else:
                 suggestions.append(f'  - "{col}" not found')
         raise IndexImportError(
@@ -500,9 +494,7 @@ def _create_artists_from_parsed_rows(
     """
     artist_groups: Dict[str, List[dict]] = defaultdict(list)
     for row in raw_rows:
-        key = _artist_merge_key(
-            row["title"], row["first_name"], row["last_name"], row["quals"]
-        )
+        key = _artist_merge_key(row["title"], row["first_name"], row["last_name"], row["quals"])
         artist_groups[key].append(row)
 
     artist_count = 0
@@ -516,9 +508,7 @@ def _create_artists_from_parsed_rows(
             for r in no_courtesy_rows:
                 for cn in r["cat_nos"]:
                     merged_cat_entries.append((cn, r["row_number"]))
-            _create_artist_entry(
-                db, import_record, merged, merged_cat_entries, courtesy=None
-            )
+            _create_artist_entry(db, import_record, merged, merged_cat_entries, courtesy=None)
             artist_count += 1
 
             if len(no_courtesy_rows) > 1:
@@ -536,9 +526,7 @@ def _create_artists_from_parsed_rows(
 
         for r in courtesy_rows:
             cat_entries = [(cn, r["row_number"]) for cn in r["cat_nos"]]
-            _create_artist_entry(
-                db, import_record, r, cat_entries, courtesy=r["address"]
-            )
+            _create_artist_entry(db, import_record, r, cat_entries, courtesy=r["address"])
             artist_count += 1
 
     if artist_count == 0:
@@ -575,9 +563,7 @@ def import_index_excel(
     record_name = display_name or file_path
 
     # Duplicate filename detection
-    duplicate_detected = (
-        db.query(Import).filter(Import.filename == record_name).first() is not None
-    )
+    duplicate_detected = db.query(Import).filter(Import.filename == record_name).first() is not None
 
     import_record = Import(filename=record_name, product_type="artists_index")
     db.add(import_record)
@@ -788,7 +774,7 @@ def _create_artist_entry(
                 import_id=import_record.id,
                 work_id=None,
                 warning_type="possible_company",
-                message=f"Row {row['row_number']}: \"{last_name}\" has no first name — treated as company",
+                message=f'Row {row["row_number"]}: "{last_name}" has no first name — treated as company',
             )
         )
 
@@ -827,7 +813,7 @@ def _create_artist_entry(
                 import_id=import_record.id,
                 work_id=None,
                 warning_type="quals_in_name_field",
-                message=f"Row {row['row_number']}: Qualification \"{embedded_qual}\" found in name field: {first_name or ''} {last_name or ''}".strip(),
+                message=f'Row {row["row_number"]}: Qualification "{embedded_qual}" found in name field: {first_name or ""} {last_name or ""}'.strip(),
             )
         )
 
@@ -932,9 +918,7 @@ def reimport_index_excel(
     raw_rows, header_warnings = _open_and_parse_index_workbook(file_path)
 
     # 2. Snapshot existing overrides + include_in_export, keyed by identity
-    existing_artists = (
-        db.query(IndexArtist).filter(IndexArtist.import_id == import_id).all()
-    )
+    existing_artists = db.query(IndexArtist).filter(IndexArtist.import_id == import_id).all()
     artist_ids = [a.id for a in existing_artists]
 
     # Load overrides
@@ -951,9 +935,7 @@ def reimport_index_excel(
     courtesy_map: Dict[str, str] = {}
     if artist_ids:
         cat_numbers = (
-            db.query(IndexCatNumber)
-            .filter(IndexCatNumber.artist_id.in_(artist_ids))
-            .all()
+            db.query(IndexCatNumber).filter(IndexCatNumber.artist_id.in_(artist_ids)).all()
         )
         for cn in cat_numbers:
             aid = str(cn.artist_id)
@@ -974,12 +956,12 @@ def reimport_index_excel(
     # 3. Delete old data (CASCADE will handle cat_numbers, overrides,
     #    artist-level audit logs)
     if artist_ids:
-        db.query(IndexArtistOverride).filter(
-            IndexArtistOverride.artist_id.in_(artist_ids)
-        ).delete(synchronize_session=False)
-        db.query(IndexCatNumber).filter(
-            IndexCatNumber.artist_id.in_(artist_ids)
-        ).delete(synchronize_session=False)
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id.in_(artist_ids)).delete(
+            synchronize_session=False
+        )
+        db.query(IndexCatNumber).filter(IndexCatNumber.artist_id.in_(artist_ids)).delete(
+            synchronize_session=False
+        )
     db.query(ValidationWarning).filter(ValidationWarning.import_id == import_id).delete(
         synchronize_session=False
     )

--- a/backend/app/services/index_override_service.py
+++ b/backend/app/services/index_override_service.py
@@ -387,11 +387,8 @@ def resolve_index_artist(artist, override, known_artist=None) -> EffectiveIndexA
     raw_company = getattr(artist, "raw_company", None)
     has_raw_company = bool(raw_company and str(raw_company).strip())
     has_explicit_company = (
-        known_artist is not None
-        and getattr(known_artist, "resolved_company", None) is not None
-    ) or (
-        override is not None and getattr(override, "company_override", None) is not None
-    )
+        known_artist is not None and getattr(known_artist, "resolved_company", None) is not None
+    ) or (override is not None and getattr(override, "company_override", None) is not None)
     if effective_company and not has_raw_company and not has_explicit_company:
         company = last_name
 

--- a/backend/app/services/index_renderer.py
+++ b/backend/app/services/index_renderer.py
@@ -54,9 +54,7 @@ class IndexExportConfig:
 
     # Letter headings (e.g. "A", "B", "C" at the start of each group)
     letter_heading_enabled: bool = False
-    letter_heading_style: str = (
-        ""  # paragraph style for the heading (empty = entry_style)
-    )
+    letter_heading_style: str = ""  # paragraph style for the heading (empty = entry_style)
 
 
 DEFAULT_INDEX_CONFIG = IndexExportConfig()
@@ -102,9 +100,7 @@ def collect_index_entries(db: Session, import_id: UUID) -> List[ArtistExportEntr
     """
     artists = (
         db.query(IndexArtist)
-        .filter(
-            IndexArtist.import_id == import_id, IndexArtist.include_in_export.is_(True)
-        )
+        .filter(IndexArtist.import_id == import_id, IndexArtist.include_in_export.is_(True))
         .order_by(IndexArtist.sort_key, IndexArtist.row_number)
         .all()
     )
@@ -112,9 +108,7 @@ def collect_index_entries(db: Session, import_id: UUID) -> List[ArtistExportEntr
     # Batch-fetch overrides
     artist_ids = [a.id for a in artists]
     overrides = (
-        db.query(IndexArtistOverride)
-        .filter(IndexArtistOverride.artist_id.in_(artist_ids))
-        .all()
+        db.query(IndexArtistOverride).filter(IndexArtistOverride.artist_id.in_(artist_ids)).all()
         if artist_ids
         else []
     )

--- a/backend/app/services/low_diff.py
+++ b/backend/app/services/low_diff.py
@@ -61,9 +61,7 @@ def _price_display(w: dict, config: ExportConfig) -> str:
     return ""
 
 
-def work_display_fields(
-    w: dict, config: ExportConfig = DEFAULT_CONFIG
-) -> dict[str, str]:
+def work_display_fields(w: dict, config: ExportConfig = DEFAULT_CONFIG) -> dict[str, str]:
     """Per-field display strings the renderer would emit for a resolved work
     dict (as produced by ``export_renderer._collect_export_data``).
 
@@ -96,9 +94,15 @@ def work_display_fields(
 # Typographic folds applied during cosmetic-noise suppression (InDesign smart
 # quotes vs the straight quotes typically stored in the spreadsheet).
 _TYPO_FOLD = {
-    "‘": "'", "’": "'", "‚": "'", "‛": "'",
+    "‘": "'",
+    "’": "'",
+    "‚": "'",
+    "‛": "'",
     "′": "'",
-    "“": '"', "”": '"', "„": '"', "″": '"',
+    "“": '"',
+    "”": '"',
+    "„": '"',
+    "″": '"',
 }
 _WS_RE = re.compile(r"\s+")
 
@@ -205,9 +209,7 @@ def _catsort(c: str):
 def _severity(config: LowDiffConfig, kind: str, fld: str | None = None) -> str:
     sev = config.severity
     if kind == "field_change":
-        return sev.get("field_change", {}).get(
-            fld, sev.get("field_change_default", "medium")
-        )
+        return sev.get("field_change", {}).get(fld, sev.get("field_change_default", "medium"))
     return sev.get(kind, "medium")
 
 

--- a/backend/app/services/low_tag_parser.py
+++ b/backend/app/services/low_tag_parser.py
@@ -47,9 +47,7 @@ from backend.app.services.export_renderer import DEFAULT_CONFIG, ExportConfig
 
 # Match both the verbose (our renderer) and short (InDesign) tag dialects.
 _PARA_RE = re.compile(r"^\s*<(?:ParaStyle|pstyle):([^>]*)>")
-_SPAN_RE = re.compile(
-    r"<(?:CharStyle|cstyle):([^>]+)>(.*?)<(?:CharStyle|cstyle):>", re.DOTALL
-)
+_SPAN_RE = re.compile(r"<(?:CharStyle|cstyle):([^>]+)>(.*?)<(?:CharStyle|cstyle):>", re.DOTALL)
 _INDESIGN_HINT = re.compile(r"<(?:pstyle|cstyle):")
 _HEX_RE = re.compile(r"<0x([0-9A-Fa-f]+)>")
 # InDesign escapes special characters with a backslash, in both content and
@@ -203,11 +201,7 @@ def recoverable_fields(config: ExportConfig) -> list[str]:
     """Enabled fields that carry a non-empty character style — i.e. the fields a
     parse can actually isolate (and therefore the only fields the LOW diff can
     check)."""
-    return [
-        f
-        for f in enabled_field_order(config)
-        if getattr(config, _FIELD_STYLE_ATTRS[f], "")
-    ]
+    return [f for f in enabled_field_order(config) if getattr(config, _FIELD_STYLE_ATTRS[f], "")]
 
 
 def _style_to_fields(config: ExportConfig) -> dict[str, list[str]]:
@@ -271,9 +265,7 @@ def _assign_spans(
     return out
 
 
-def parse_low_tags(
-    text: str, config: ExportConfig = DEFAULT_CONFIG
-) -> list[ParsedEntry]:
+def parse_low_tags(text: str, config: ExportConfig = DEFAULT_CONFIG) -> list[ParsedEntry]:
     """Parse a List of Works Tagged Text export into a list of ``ParsedEntry``.
 
     ``config`` must be the ExportConfig that produced the file (it supplies the

--- a/backend/app/services/normalisation_service.py
+++ b/backend/app/services/normalisation_service.py
@@ -36,8 +36,21 @@ DEFAULT_TEXT_SUBSTITUTIONS: List[dict] = [
 # stylised names). Matched case-insensitively; the value here is the form emitted.
 # Roman numerals are handled separately (by pattern), so they don't go here.
 DEFAULT_TITLE_CASE_EXCEPTIONS: List[str] = [
-    "RA", "PRA", "PPRA", "RWS", "RE", "NEAC", "OBE", "MBE", "CBE",
-    "USA", "UK", "NYC", "LA", "BBC", "MoMA",
+    "RA",
+    "PRA",
+    "PPRA",
+    "RWS",
+    "RE",
+    "NEAC",
+    "OBE",
+    "MBE",
+    "CBE",
+    "USA",
+    "UK",
+    "NYC",
+    "LA",
+    "BBC",
+    "MoMA",
 ]
 
 # Field keys an admin may target, mapped to the Work attribute they normalise.
@@ -61,11 +74,7 @@ def normalise_artist(raw_artist: str, honorific_tokens: Optional[List[str]] = No
 
     token_set: Set[str] = {
         t.upper()
-        for t in (
-            honorific_tokens
-            if honorific_tokens is not None
-            else DEFAULT_HONORIFIC_TOKENS
-        )
+        for t in (honorific_tokens if honorific_tokens is not None else DEFAULT_HONORIFIC_TOKENS)
     }
 
     parts = artist.split()
@@ -136,9 +145,7 @@ def _parse_edition_components(raw_edition):
 
     full_match = re.match(r"Edition of (\d+) at .*?([0-9,]+\.?[0-9]*)", value)
     if full_match:
-        return int(full_match.group(1)), int(
-            Decimal(full_match.group(2).replace(",", ""))
-        )
+        return int(full_match.group(1)), int(Decimal(full_match.group(2).replace(",", "")))
 
     partial_match = re.match(r"Edition of (\d+)", value)
     if partial_match:
@@ -209,20 +216,14 @@ def apply_text_substitutions(value, substitutions, field_key: str):
 
 # Strict Roman numeral (II, IV, VIII, XIV …). Single letters are excluded by the
 # length guard in the callback ("I" is handled by titlecase itself).
-_ROMAN_RE = re.compile(
-    r"^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$", re.IGNORECASE
-)
+_ROMAN_RE = re.compile(r"^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$", re.IGNORECASE)
 # Common words / short forms that match the Roman pattern but usually aren't
 # numerals — left as ordinary title-cased words (still override-correctable).
 _ROMAN_DENYLIST = {"mix", "di", "li", "mm", "cd", "mi", "dc"}
 
 
 def _looks_roman(core: str) -> bool:
-    return (
-        len(core) > 1
-        and core.lower() not in _ROMAN_DENYLIST
-        and bool(_ROMAN_RE.match(core))
-    )
+    return len(core) > 1 and core.lower() not in _ROMAN_DENYLIST and bool(_ROMAN_RE.match(core))
 
 
 def _title_token_reason(word: str, canon: dict) -> Tuple[str, Optional[str]]:
@@ -323,9 +324,7 @@ def normalise_work(
     here. Only derived fields are written; raw_* values are left canonical
     (principle 3).
     """
-    work.artist_name, work.artist_honorifics = normalise_artist(
-        work.raw_artist, honorific_tokens
-    )
+    work.artist_name, work.artist_honorifics = normalise_artist(work.raw_artist, honorific_tokens)
     work.price_numeric, work.price_text = parse_price(work.raw_price)
     work.edition_total, work.edition_price_numeric = parse_edition(
         work.raw_edition, suppress_max=edition_suppress_max
@@ -441,9 +440,7 @@ def collect_work_warnings(
             and work.price_numeric is None
             and work.price_text not in ("NFS", "*", None, "")
         ):
-            warnings.append(
-                ("unrecognised_price", f"Price could not be parsed: {raw_p!r}")
-            )
+            warnings.append(("unrecognised_price", f"Price could not be parsed: {raw_p!r}"))
 
     # Edition handling — re-derive the original components (ignoring suppression)
     # so we can explain what happened and flag the dangerous case.
@@ -488,8 +485,7 @@ def collect_work_warnings(
                     warnings.append(
                         (
                             "edition_suppressed",
-                            f"Edition suppressed (treated as the work itself): "
-                            f"{raw_ed!r}",
+                            f"Edition suppressed (treated as the work itself): {raw_ed!r}",
                         )
                     )
 

--- a/backend/app/services/override_service.py
+++ b/backend/app/services/override_service.py
@@ -97,11 +97,7 @@ def resolve_effective_work(work, override) -> EffectiveWork:
 
     return EffectiveWork(
         raw_cat_no=work.raw_cat_no,
-        title=(
-            override.title_override
-            if override.title_override is not None
-            else work.title
-        ),
+        title=(override.title_override if override.title_override is not None else work.title),
         title_cased=(
             override.title_cased_override
             if getattr(override, "title_cased_override", None) is not None
@@ -130,14 +126,8 @@ def resolve_effective_work(work, override) -> EffectiveWork:
             else work.edition_price_numeric
         ),
         artwork=(
-            override.artwork_override
-            if override.artwork_override is not None
-            else work.artwork
+            override.artwork_override if override.artwork_override is not None else work.artwork
         ),
-        medium=(
-            override.medium_override
-            if override.medium_override is not None
-            else work.medium
-        ),
+        medium=(override.medium_override if override.medium_override is not None else work.medium),
         include_in_export=bool(work.include_in_export),
     )

--- a/backend/app/services/reimport_matcher.py
+++ b/backend/app/services/reimport_matcher.py
@@ -386,13 +386,8 @@ def match_overrides(
         # No fingerprint match. If the cat-no was occupied by a content
         # mismatch in pass 1, surface that specifically — it's a different
         # signal than "the work just isn't in the new file at all".
-        cat_collision_new_idx = (
-            new_by_cat.get(old_w.cat_no) if old_w.cat_no else None
-        )
-        if (
-            cat_collision_new_idx is not None
-            and cat_collision_new_idx not in matched_new_indices
-        ):
+        cat_collision_new_idx = new_by_cat.get(old_w.cat_no) if old_w.cat_no else None
+        if cat_collision_new_idx is not None and cat_collision_new_idx not in matched_new_indices:
             collision_row = in_scope_new[cat_collision_new_idx]
             plan.ambiguous.append(
                 AmbiguousItem(
@@ -449,9 +444,7 @@ def match_overrides(
     # Derived counts
     # ------------------------------------------------------------------
     plan.added = len(in_scope_new) - len(matched_new_indices)
-    plan.removed = (
-        len(in_scope_old) - plan.matched_by_cat_no - plan.matched_by_fingerprint
-    )
+    plan.removed = len(in_scope_old) - plan.matched_by_cat_no - plan.matched_by_fingerprint
 
     return plan
 

--- a/backend/app/services/seed_service.py
+++ b/backend/app/services/seed_service.py
@@ -36,9 +36,7 @@ def seed_builtin_templates(db=None) -> None:
                 seed = json.load(fp)
             name = seed.pop("_name", slug)
             config_type = seed.pop("_config_type", "template")
-            cfg_hash = hashlib.sha256(
-                json.dumps(seed, sort_keys=True).encode()
-            ).hexdigest()
+            cfg_hash = hashlib.sha256(json.dumps(seed, sort_keys=True).encode()).hexdigest()
             existing = db.query(_Ruleset).filter(_Ruleset.slug == slug).first()
             if existing:
                 if existing.name != name:
@@ -62,8 +60,7 @@ def seed_builtin_templates(db=None) -> None:
 
         # Delete built-in templates that no longer have a corresponding file
         db_slugs = {
-            row[0]
-            for row in db.query(_Ruleset.slug).filter(_Ruleset.is_builtin == True).all()
+            row[0] for row in db.query(_Ruleset.slug).filter(_Ruleset.is_builtin == True).all()
         }
         deleted_slugs = db_slugs - seed_slugs
         if deleted_slugs:

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -214,9 +214,7 @@ class S3Storage(StorageBackend):
         import tempfile
 
         data = self.load(key)
-        tmp = tempfile.NamedTemporaryFile(
-            delete=False, prefix="catalogue_s3_", suffix=".xlsx"
-        )
+        tmp = tempfile.NamedTemporaryFile(delete=False, prefix="catalogue_s3_", suffix=".xlsx")
         try:
             tmp.write(data)
             tmp.flush()
@@ -249,9 +247,7 @@ def _build_storage() -> StorageBackend:
     if backend == "local":
         return LocalStorage(base_dir=UPLOAD_DIR)
 
-    raise RuntimeError(
-        f"Unknown STORAGE_BACKEND: {backend!r}  (expected 'local' or 's3')"
-    )
+    raise RuntimeError(f"Unknown STORAGE_BACKEND: {backend!r}  (expected 'local' or 's3')")
 
 
 storage: StorageBackend = _build_storage()

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -75,9 +75,7 @@ def _seed_section(db, imp, name="Section A", position=1):
     return sec
 
 
-def _seed_work(
-    db, imp, sec, position=1, raw_cat_no="1", title="Sunset", artist_name="Jane"
-):
+def _seed_work(db, imp, sec, position=1, raw_cat_no="1", title="Sunset", artist_name="Jane"):
     w = Work(
         import_id=imp.id,
         section_id=sec.id,
@@ -133,9 +131,7 @@ class TestImportAuditLog:
         sec = _seed_section(db_session, imp)
         work = _seed_work(db_session, imp, sec)
         _seed_audit(db_session, imp, work)
-        _seed_audit(
-            db_session, imp, work, field="price_numeric_override", new_value="1000"
-        )
+        _seed_audit(db_session, imp, work, field="price_numeric_override", new_value="1000")
 
         r = client.get(f"/imports/{imp.id}/audit-log")
         assert r.status_code == 200
@@ -145,9 +141,7 @@ class TestImportAuditLog:
     def test_includes_work_context(self, client, db_session):
         imp = _seed_import(db_session)
         sec = _seed_section(db_session, imp)
-        work = _seed_work(
-            db_session, imp, sec, raw_cat_no="42", title="Dawn", artist_name="Alice"
-        )
+        work = _seed_work(db_session, imp, sec, raw_cat_no="42", title="Dawn", artist_name="Alice")
         _seed_audit(db_session, imp, work)
 
         r = client.get(f"/imports/{imp.id}/audit-log")
@@ -358,11 +352,7 @@ class TestTemplateAuditLog:
         assert r.status_code == 201
         tid = r.json()["id"]
 
-        logs = (
-            db_session.query(AuditLog)
-            .filter(AuditLog.template_id == _uuid.UUID(tid))
-            .all()
-        )
+        logs = db_session.query(AuditLog).filter(AuditLog.template_id == _uuid.UUID(tid)).all()
         assert len(logs) == 1
         assert logs[0].action == "template_created"
         assert logs[0].new_value == "Test Template"

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -158,23 +158,17 @@ class TestExtractLowNameParts:
 
 class TestCompareNames:
     def test_exact_match(self):
-        level, diffs = _compare_names(
-            "Roger Adams", None, "Roger", "Adams", None, None, False
-        )
+        level, diffs = _compare_names("Roger Adams", None, "Roger", "Adams", None, None, False)
         assert level == MatchLevel.exact
 
     def test_equivalent_same_words(self):
         """LoW 'Ryan Gander RA' vs Index first='Ryan' last='Gander' quals='RA'."""
-        level, diffs = _compare_names(
-            "Ryan Gander", "RA", "Ryan", "Gander", None, "RA", False
-        )
+        level, diffs = _compare_names("Ryan Gander", "RA", "Ryan", "Gander", None, "RA", False)
         assert level in (MatchLevel.exact, MatchLevel.equivalent)
 
     def test_partial_extra_quals_in_index(self):
         """LoW 'Ryan Gander RA' vs Index 'Ryan Gander OBE RA'."""
-        level, diffs = _compare_names(
-            "Ryan Gander", "RA", "Ryan", "Gander", None, "OBE RA", False
-        )
+        level, diffs = _compare_names("Ryan Gander", "RA", "Ryan", "Gander", None, "OBE RA", False)
         assert level == MatchLevel.partial_honorific
         assert any("extra_quals_in_index" in d for d in diffs)
 
@@ -200,15 +194,11 @@ class TestCompareNames:
         assert level in (MatchLevel.exact, MatchLevel.equivalent)
 
     def test_no_match(self):
-        level, diffs = _compare_names(
-            "Alice Smith", None, "Bob", "Jones", None, None, False
-        )
+        level, diffs = _compare_names("Alice Smith", None, "Bob", "Jones", None, None, False)
         assert level == MatchLevel.none
 
     def test_last_name_match_first_name_different(self):
-        level, diffs = _compare_names(
-            "Alice Smith", None, "Bob", "Smith", None, None, False
-        )
+        level, diffs = _compare_names("Alice Smith", None, "Bob", "Smith", None, None, False)
         assert level == MatchLevel.partial_name
         assert "first_name_different" in diffs
 
@@ -432,11 +422,7 @@ class TestCompareDatasets:
         db_session.commit()
 
         # Apply override to correct the Index name
-        artist = (
-            db_session.query(IndexArtist)
-            .filter(IndexArtist.import_id == idx.id)
-            .first()
-        )
+        artist = db_session.query(IndexArtist).filter(IndexArtist.import_id == idx.id).first()
         ovr = IndexArtistOverride(
             artist_id=artist.id,
             first_name_override="Roger",

--- a/tests/test_configurable_normalisation.py
+++ b/tests/test_configurable_normalisation.py
@@ -94,11 +94,11 @@ def test_blank_find_is_skipped():
 def test_whole_word_does_not_mangle_substrings():
     """Without whole_word, "pla" → "PLA" would corrupt "plaster" and
     "display". With whole_word set, only the standalone token matches."""
-    subs = [{"find": "pla", "replace": "PLA",
-             "fields": ["medium"], "whole_word": True}]
-    assert apply_text_substitutions(
-        "pla, plaster on display", subs, "medium"
-    ) == "PLA, plaster on display"
+    subs = [{"find": "pla", "replace": "PLA", "fields": ["medium"], "whole_word": True}]
+    assert (
+        apply_text_substitutions("pla, plaster on display", subs, "medium")
+        == "PLA, plaster on display"
+    )
 
 
 def test_whole_word_off_is_legacy_substring():
@@ -106,23 +106,21 @@ def test_whole_word_off_is_legacy_substring():
     behaviour — needed for the ``...`` → ``…`` rule whose find has no word
     chars and so couldn't match with word boundaries anyway."""
     subs = [{"find": "pla", "replace": "PLA", "fields": ["medium"]}]
-    assert apply_text_substitutions(
-        "pla, plaster", subs, "medium"
-    ) == "PLA, PLAster"
+    assert apply_text_substitutions("pla, plaster", subs, "medium") == "PLA, PLAster"
 
 
 def test_whole_word_matches_at_string_boundaries():
     """Word boundaries must fire at start-of-string, end-of-string, and
     next to punctuation — covers the real cases of medium fields like
     "mdf" alone, "and mdf", or "mdf, perspex"."""
-    subs = [{"find": "mdf", "replace": "MDF",
-             "fields": ["medium"], "whole_word": True}]
+    subs = [{"find": "mdf", "replace": "MDF", "fields": ["medium"], "whole_word": True}]
     assert apply_text_substitutions("mdf", subs, "medium") == "MDF"
     assert apply_text_substitutions("oil on mdf", subs, "medium") == "oil on MDF"
     assert apply_text_substitutions("mdf, paint", subs, "medium") == "MDF, paint"
-    assert apply_text_substitutions(
-        "perspex, petg, and mdf", subs, "medium"
-    ) == "perspex, petg, and MDF"
+    assert (
+        apply_text_substitutions("perspex, petg, and mdf", subs, "medium")
+        == "perspex, petg, and MDF"
+    )
 
 
 def test_whole_word_treats_hyphen_as_boundary():
@@ -130,19 +128,15 @@ def test_whole_word_treats_hyphen_as_boundary():
     has a word boundary between "mdf" and "-". Worth pinning so a future
     reader knows the behaviour (some users might expect hyphenated
     compounds to *not* match)."""
-    subs = [{"find": "mdf", "replace": "MDF",
-             "fields": ["medium"], "whole_word": True}]
-    assert apply_text_substitutions(
-        "mdf-board on oak", subs, "medium"
-    ) == "MDF-board on oak"
+    subs = [{"find": "mdf", "replace": "MDF", "fields": ["medium"], "whole_word": True}]
+    assert apply_text_substitutions("mdf-board on oak", subs, "medium") == "MDF-board on oak"
 
 
 def test_whole_word_with_regex_metachars_in_find_is_literal():
     """The find is regex-escaped before being wrapped in word boundaries,
     so a literal ``.`` doesn't act as "any char". (Combined with whole_word,
     this is a rare combination but the safety still has to hold.)"""
-    subs = [{"find": "a.b", "replace": "AXB",
-             "fields": ["title"], "whole_word": True}]
+    subs = [{"find": "a.b", "replace": "AXB", "fields": ["title"], "whole_word": True}]
     # Should NOT match "axb" — the . in the find is a literal, not wildcard
     assert apply_text_substitutions("a.b axb", subs, "title") == "AXB axb"
 
@@ -151,8 +145,7 @@ def test_whole_word_with_dollar_sign_in_replace_is_literal():
     """The replace string is passed through a lambda so regex backreference
     syntax (``\\1``, ``\\g<name>``) isn't interpreted — important because
     editors writing replacement text shouldn't have to escape backslashes."""
-    subs = [{"find": "mdf", "replace": r"M\1F",
-             "fields": ["medium"], "whole_word": True}]
+    subs = [{"find": "mdf", "replace": r"M\1F", "fields": ["medium"], "whole_word": True}]
     assert apply_text_substitutions("mdf", subs, "medium") == r"M\1F"
 
 
@@ -318,9 +311,7 @@ def test_priceless_suppressed_edition_of_1_is_benign():
 def test_get_config_returns_new_defaults(client):
     cfg = client.get("/config").json()
     assert cfg["edition_suppress_max"] == 0
-    assert any(
-        s["find"] == "..." and s["replace"] == "…" for s in cfg["text_substitutions"]
-    )
+    assert any(s["find"] == "..." and s["replace"] == "…" for s in cfg["text_substitutions"])
 
 
 def test_put_config_round_trips_all_fields(client):
@@ -344,9 +335,7 @@ def test_put_config_rejects_blank_find(client):
 
 
 def test_put_config_rejects_unknown_field(client):
-    body = {
-        "text_substitutions": [{"find": "x", "replace": "y", "fields": ["nonsense"]}]
-    }
+    body = {"text_substitutions": [{"find": "x", "replace": "y", "fields": ["nonsense"]}]}
     assert client.put("/config", json=body).status_code == 422
 
 
@@ -398,20 +387,14 @@ def test_saved_config_is_applied_on_import(client, db_session):
         json={
             "honorific_tokens": ["RA"],
             "edition_suppress_max": 1,
-            "text_substitutions": [
-                {"find": "ZZZ", "replace": "QQQ", "fields": ["title"]}
-            ],
+            "text_substitutions": [{"find": "ZZZ", "replace": "QQQ", "fields": ["title"]}],
         },
     )
     import_id = _import(
         client,
         [[1, "Gallery A", "Hello ZZZ", "Jane Doe", "100", "Edition of 1 at £50", None, "Oil"]],
     )
-    work = (
-        db_session.query(Work)
-        .filter(Work.import_id == uuid.UUID(import_id))
-        .first()
-    )
+    work = db_session.query(Work).filter(Work.import_id == uuid.UUID(import_id)).first()
     assert work.title == "Hello QQQ"  # substitution from saved config applied
     assert work.edition_total is None  # edition-of-1 suppressed per saved threshold
     assert work.price_numeric == 100  # work's own price stands
@@ -423,9 +406,5 @@ def test_default_substitution_applies_on_import_without_saved_config(client, db_
         client,
         [[1, "Gallery A", "Wait...", "Jane Doe", "100", None, None, "Oil"]],
     )
-    work = (
-        db_session.query(Work)
-        .filter(Work.import_id == uuid.UUID(import_id))
-        .first()
-    )
+    work = db_session.query(Work).filter(Work.import_id == uuid.UUID(import_id)).first()
     assert work.title == "Wait…"

--- a/tests/test_export_diff.py
+++ b/tests/test_export_diff.py
@@ -268,9 +268,7 @@ class TestComputeDiff:
     def test_changed_work_field_level(self, db_session):
         imp = _seed_import(db_session)
         sec = _seed_section(db_session, imp)
-        w = _seed_work(
-            db_session, imp, sec, raw_cat_no="10", title="Old Title", artist_name="Ann"
-        )
+        w = _seed_work(db_session, imp, sec, raw_cat_no="10", title="Old Title", artist_name="Ann")
 
         save_export_snapshot(imp.id, None, db_session)
 
@@ -284,9 +282,7 @@ class TestComputeDiff:
         ch = diff["changed"][0]
         assert ch["cat_no"] == "10"
         assert any(
-            f["field"] == "title"
-            and f["old"] == "Old Title"
-            and f["new"] == "New Title"
+            f["field"] == "title" and f["old"] == "Old Title" and f["new"] == "New Title"
             for f in ch["fields"]
         )
 
@@ -294,12 +290,8 @@ class TestComputeDiff:
         imp = _seed_import(db_session)
         sec = _seed_section(db_session, imp)
         _seed_work(db_session, imp, sec, raw_cat_no="1", title="Stays Same")
-        w_change = _seed_work(
-            db_session, imp, sec, raw_cat_no="2", position=2, title="Will Change"
-        )
-        w_remove = _seed_work(
-            db_session, imp, sec, raw_cat_no="3", position=3, title="Goes Away"
-        )
+        w_change = _seed_work(db_session, imp, sec, raw_cat_no="2", position=2, title="Will Change")
+        w_remove = _seed_work(db_session, imp, sec, raw_cat_no="3", position=3, title="Goes Away")
 
         save_export_snapshot(imp.id, None, db_session)
 

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -50,9 +50,7 @@ class FakeSession:
 
 
 def _section(name="Gallery 1", position=1, section_id="sec1"):
-    return SimpleNamespace(
-        id=section_id, import_id="imp1", name=name, position=position
-    )
+    return SimpleNamespace(id=section_id, import_id="imp1", name=name, position=position)
 
 
 def _work(
@@ -284,9 +282,7 @@ def test_csv_export_work_values():
 
 
 def test_csv_export_empty_edition_fields_when_none():
-    db = FakeSession(
-        [_section()], [_work(edition_total=None, edition_price_numeric=None)]
-    )
+    db = FakeSession([_section()], [_work(edition_total=None, edition_price_numeric=None)])
     rows = _parse_csv(render_import_as_csv("imp1", db))
 
     row = rows[0]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -108,7 +108,6 @@ def health_client(db_session):
 
 
 class TestHealthEndpoint:
-
     def test_returns_200(self, health_client):
         assert health_client.get("/health").status_code == 200
 
@@ -152,7 +151,6 @@ class TestHealthEndpoint:
 
 
 class TestHealthDbDown:
-
     @pytest.fixture()
     def broken_client(self):
         """Client whose engine always raises on connect."""
@@ -184,7 +182,6 @@ class TestHealthDbDown:
 
 
 class TestVersionEndpoint:
-
     @pytest.fixture()
     def version_client(self):
         """Minimal app with /version, no DB needed."""

--- a/tests/test_import_override_export_routes.py
+++ b/tests/test_import_override_export_routes.py
@@ -350,9 +350,7 @@ class TestWarnings:
         imp = _seed_import(db_session)
         sec = _seed_section(db_session, imp)
         w = _seed_work(db_session, imp, sec, title="Untitled")
-        _seed_warning(
-            db_session, imp, w, warning_type="missing_title", message="No title"
-        )
+        _seed_warning(db_session, imp, w, warning_type="missing_title", message="No title")
 
         r = client.get(f"/imports/{imp.id}/warnings")
         assert r.status_code == 200
@@ -369,9 +367,7 @@ class TestWarnings:
 
     def test_import_level_warning_has_null_work_fields(self, client, db_session):
         imp = _seed_import(db_session)
-        _seed_warning(
-            db_session, imp, None, warning_type="duplicate_filename", message="Dup"
-        )
+        _seed_warning(db_session, imp, None, warning_type="duplicate_filename", message="Dup")
 
         r = client.get(f"/imports/{imp.id}/warnings")
         data = r.json()
@@ -433,9 +429,7 @@ class TestOverrideCRUD:
         )
         logs = db_session.query(AuditLog).filter(AuditLog.work_id == w.id).all()
         assert len(logs) >= 1
-        assert any(
-            log.action == "override_set" and log.field == "title_override" for log in logs
-        )
+        assert any(log.action == "override_set" and log.field == "title_override" for log in logs)
 
     # --- PUT override (update) ---
     def test_put_updates_existing_override(self, client, db_session):
@@ -479,19 +473,13 @@ class TestOverrideCRUD:
         # value is unambiguously newer. (SQLite's CURRENT_TIMESTAMP only has
         # second resolution, and a back-to-back PUT can otherwise land in
         # the same second.)
-        ovr = (
-            db_session.query(WorkOverride)
-            .filter(WorkOverride.work_id == w.id)
-            .one()
-        )
+        ovr = db_session.query(WorkOverride).filter(WorkOverride.work_id == w.id).one()
         original_updated_at = ovr.updated_at
         ovr.updated_at = original_updated_at - timedelta(hours=1)
         db_session.commit()
         backdated_value = ovr.updated_at
 
-        audit_count_before = (
-            db_session.query(AuditLog).filter(AuditLog.work_id == w.id).count()
-        )
+        audit_count_before = db_session.query(AuditLog).filter(AuditLog.work_id == w.id).count()
 
         # Update the override (changes title_override "First" → "Second").
         client.put(
@@ -501,11 +489,7 @@ class TestOverrideCRUD:
         db_session.expire_all()
 
         # Assertion 1: updated_at moved forward.
-        ovr2 = (
-            db_session.query(WorkOverride)
-            .filter(WorkOverride.work_id == w.id)
-            .one()
-        )
+        ovr2 = db_session.query(WorkOverride).filter(WorkOverride.work_id == w.id).one()
         assert ovr2.updated_at > backdated_value, (
             f"updated_at should have moved forward after PUT; "
             f"backdated to {backdated_value}, still {ovr2.updated_at}"
@@ -516,9 +500,7 @@ class TestOverrideCRUD:
         # created_at (SQLite has only second resolution and the two PUTs may
         # land in the same second). Query specifically for the update row
         # by its distinguishing values instead.
-        total_logs = (
-            db_session.query(AuditLog).filter(AuditLog.work_id == w.id).count()
-        )
+        total_logs = db_session.query(AuditLog).filter(AuditLog.work_id == w.id).count()
         assert total_logs == audit_count_before + 1, (
             f"expected exactly one new audit row for the changed field; "
             f"had {audit_count_before}, now {total_logs}"
@@ -585,11 +567,7 @@ class TestOverrideCRUD:
             json={"title_override": "Temp"},
         )
         client.delete(f"/imports/{imp.id}/works/{w.id}/override")
-        logs = (
-            db_session.query(AuditLog)
-            .filter(AuditLog.action == "override_deleted")
-            .all()
-        )
+        logs = db_session.query(AuditLog).filter(AuditLog.action == "override_deleted").all()
         assert len(logs) == 1
 
 
@@ -633,9 +611,7 @@ class TestExcludeInclude:
             f"/imports/{imp.id}/works/{w.id}/exclude",
             params={"exclude": True},
         )
-        logs = (
-            db_session.query(AuditLog).filter(AuditLog.action == "work_excluded").all()
-        )
+        logs = db_session.query(AuditLog).filter(AuditLog.action == "work_excluded").all()
         assert len(logs) == 1
 
     def test_noop_exclude_does_not_create_audit_log(self, client, db_session):

--- a/tests/test_index_export_diff.py
+++ b/tests/test_index_export_diff.py
@@ -260,9 +260,7 @@ class TestComputeIndexDiff:
         save_index_export_snapshot(imp.id, None, db_session)
 
         # Add a new artist
-        a2 = _seed_artist(
-            db_session, imp, first_name="Bob", last_name="Brown", row_number=3
-        )
+        a2 = _seed_artist(db_session, imp, first_name="Bob", last_name="Brown", row_number=3)
         _seed_cat_no(db_session, a2, 2)
 
         diff = compute_index_diff(imp.id, None, db_session)
@@ -275,9 +273,7 @@ class TestComputeIndexDiff:
         imp = _seed_index_import(db_session)
         a1 = _seed_artist(db_session, imp)
         _seed_cat_no(db_session, a1, 1)
-        a2 = _seed_artist(
-            db_session, imp, first_name="Bob", last_name="Brown", row_number=3
-        )
+        a2 = _seed_artist(db_session, imp, first_name="Bob", last_name="Brown", row_number=3)
         _seed_cat_no(db_session, a2, 2)
 
         save_index_export_snapshot(imp.id, None, db_session)
@@ -308,8 +304,7 @@ class TestComputeIndexDiff:
         assert len(diff["changed"]) == 1
         ch = diff["changed"][0]
         assert any(
-            f["field"] == "quals" and f["old"] is None and f["new"] == "RA"
-            for f in ch["fields"]
+            f["field"] == "quals" and f["old"] is None and f["new"] == "RA" for f in ch["fields"]
         )
 
     def test_cat_nos_change_detected(self, db_session):
@@ -326,9 +321,7 @@ class TestComputeIndexDiff:
         diff = compute_index_diff(imp.id, None, db_session)
         assert diff["has_changes"] is True
         assert len(diff["changed"]) == 1
-        cat_field = next(
-            f for f in diff["changed"][0]["fields"] if f["field"] == "cat_nos"
-        )
+        cat_field = next(f for f in diff["changed"][0]["fields"] if f["field"] == "cat_nos")
         assert cat_field["old"] == [1]
         assert sorted(cat_field["new"]) == [1, 5]
 
@@ -340,9 +333,7 @@ class TestComputeIndexDiff:
             db_session, imp, first_name="Will", last_name="Change", row_number=3
         )
         _seed_cat_no(db_session, a_change, 2)
-        a_remove = _seed_artist(
-            db_session, imp, first_name="Goes", last_name="Away", row_number=4
-        )
+        a_remove = _seed_artist(db_session, imp, first_name="Goes", last_name="Away", row_number=4)
         _seed_cat_no(db_session, a_remove, 3)
 
         save_index_export_snapshot(imp.id, None, db_session)
@@ -350,9 +341,7 @@ class TestComputeIndexDiff:
         # Modify, exclude, add
         a_change.quals = "OBE"
         a_remove.include_in_export = False
-        a_new = _seed_artist(
-            db_session, imp, first_name="Brand", last_name="New", row_number=5
-        )
+        a_new = _seed_artist(db_session, imp, first_name="Brand", last_name="New", row_number=5)
         _seed_cat_no(db_session, a_new, 4)
         db_session.commit()
 
@@ -415,8 +404,7 @@ class TestIndexExportDiffRoute:
         assert data["has_changes"] is True
         assert len(data["changed"]) == 1
         assert any(
-            f["field"] == "quals" and f["new"] == "CBE"
-            for f in data["changed"][0]["fields"]
+            f["field"] == "quals" and f["new"] == "CBE" for f in data["changed"][0]["fields"]
         )
 
     def test_snapshot_created_on_tags_export(self, client, db_session):

--- a/tests/test_index_importer.py
+++ b/tests/test_index_importer.py
@@ -31,9 +31,7 @@ def _make_workbook(rows, tmp_path: Path) -> str:
     """
     wb = Workbook()
     ws = wb.active
-    ws.append(
-        ["Title", "First Name", "Last Name", "Quals", "Company", "Address 1", "Cat Nos"]
-    )
+    ws.append(["Title", "First Name", "Last Name", "Quals", "Company", "Address 1", "Cat Nos"])
     for row in rows:
         ws.append(list(row))
     path = str(tmp_path / "index.xlsx")
@@ -349,20 +347,13 @@ class TestMerging:
         courtesy_artists = [
             a
             for a in artists
-            if db_session.query(IndexCatNumber)
-            .filter_by(artist_id=a.id)
-            .first()
-            .courtesy
+            if db_session.query(IndexCatNumber).filter_by(artist_id=a.id).first().courtesy
             is not None
         ]
         plain_artists = [
             a
             for a in artists
-            if db_session.query(IndexCatNumber)
-            .filter_by(artist_id=a.id)
-            .first()
-            .courtesy
-            is None
+            if db_session.query(IndexCatNumber).filter_by(artist_id=a.id).first().courtesy is None
         ]
         assert len(courtesy_artists) == 1
         assert len(plain_artists) == 1

--- a/tests/test_index_override_service.py
+++ b/tests/test_index_override_service.py
@@ -1,6 +1,5 @@
 """Tests for the index override resolution service."""
 
-
 from backend.app.services.index_override_service import (
     build_index_name,
     resolve_index_artist,
@@ -433,9 +432,7 @@ class TestBuildIndexName:
 
     def test_company(self):
         assert (
-            build_index_name(
-                "AKT II", None, None, None, None, None, None, None, None, None, True
-            )
+            build_index_name("AKT II", None, None, None, None, None, None, None, None, None, True)
             == "AKT II"
         )
 
@@ -502,9 +499,7 @@ class TestBuildIndexName:
 
     def test_empty(self):
         assert (
-            build_index_name(
-                None, None, None, None, None, None, None, None, None, None, False
-            )
+            build_index_name(None, None, None, None, None, None, None, None, None, None, False)
             == ""
         )
 
@@ -513,45 +508,85 @@ class TestBuildIndexName:
     def test_two_artists_plain(self):
         """Scenario 1: Two artists, no shared surname, no quals."""
         name = build_index_name(
-            "Caruso", "Adam", None, None,
-            "Peter", "St John", None,
-            None, None, None, False,
+            "Caruso",
+            "Adam",
+            None,
+            None,
+            "Peter",
+            "St John",
+            None,
+            None,
+            None,
+            None,
+            False,
         )
         assert name == "Caruso, Adam, and Peter St John"
 
     def test_two_artists_a2_with_quals(self):
         """Scenario 3: Two artists, A2 has quals."""
         name = build_index_name(
-            "Langlands", "Ben", None, None,
-            "Nikki", "Bell", "CBE",
-            None, None, None, False,
+            "Langlands",
+            "Ben",
+            None,
+            None,
+            "Nikki",
+            "Bell",
+            "CBE",
+            None,
+            None,
+            None,
+            False,
         )
         assert name == "Langlands, Ben, and Nikki Bell CBE"
 
     def test_two_artists_both_plain(self):
         """Scenario 4: Two artists, both plain (no quals/title)."""
         name = build_index_name(
-            "Boyd", "Arthur", None, None,
-            "Mary", "Evans", None,
-            None, None, None, False,
+            "Boyd",
+            "Arthur",
+            None,
+            None,
+            "Mary",
+            "Evans",
+            None,
+            None,
+            None,
+            None,
+            False,
         )
         assert name == "Boyd, Arthur, and Mary Evans"
 
     def test_two_artists_a1_title_quals_ra(self):
         """Scenario 5: Two artists, A1 has title + quals + RA."""
         name = build_index_name(
-            "Adjaye", "David", "Sir", "OM OBE RA",
-            "Mariam", "Kamara", None,
-            None, None, None, False,
+            "Adjaye",
+            "David",
+            "Sir",
+            "OM OBE RA",
+            "Mariam",
+            "Kamara",
+            None,
+            None,
+            None,
+            None,
+            False,
         )
         assert name == "Adjaye, Sir David OM OBE RA, and Mariam Kamara"
 
     def test_two_artists_shared_a1_title_quals(self):
         """Scenario 8: Two artists, shared surname, A1 has title + quals."""
         name = build_index_name(
-            "Smith", "Melanie", "Dame", "DBE",
-            "Michael", "Smith", None,
-            None, None, None, False,
+            "Smith",
+            "Melanie",
+            "Dame",
+            "DBE",
+            "Michael",
+            "Smith",
+            None,
+            None,
+            None,
+            None,
+            False,
             artist2_shared_surname=True,
         )
         assert name == "Smith, Dame Melanie DBE and Michael"
@@ -559,9 +594,17 @@ class TestBuildIndexName:
     def test_two_artists_shared_a2_ra_quals(self):
         """Scenario 9: Two artists, shared surname, A2 has RA quals."""
         name = build_index_name(
-            "Hirst", "Damien", None, None,
-            "Connor", "Hirst", "RA",
-            None, None, None, False,
+            "Hirst",
+            "Damien",
+            None,
+            None,
+            "Connor",
+            "Hirst",
+            "RA",
+            None,
+            None,
+            None,
+            False,
             artist2_shared_surname=True,
         )
         assert name == "Hirst, Damien and Connor RA"
@@ -569,9 +612,16 @@ class TestBuildIndexName:
     def test_three_artists_no_shared_all_quals(self):
         """Scenario 11: Three artists, no shared surname, all with quals."""
         name = build_index_name(
-            "Eggerling", "Gabriele", None, "RA",
-            "Dhruv", "Jadhav", "CBE",
-            "Hannah", "Puerta-Carlson", "OBE",
+            "Eggerling",
+            "Gabriele",
+            None,
+            "RA",
+            "Dhruv",
+            "Jadhav",
+            "CBE",
+            "Hannah",
+            "Puerta-Carlson",
+            "OBE",
             False,
         )
         assert name == "Eggerling, Gabriele RA, Dhruv Jadhav CBE, and Hannah Puerta-Carlson OBE"
@@ -579,9 +629,16 @@ class TestBuildIndexName:
     def test_three_artists_all_shared_with_quals(self):
         """Scenario 13: Three artists, A2+A3 shared surname, with quals."""
         name = build_index_name(
-            "Smith", "Melanie", None, "RA",
-            "Michael", "Smith", "CBE",
-            "Anthony", "Smith", None,
+            "Smith",
+            "Melanie",
+            None,
+            "RA",
+            "Michael",
+            "Smith",
+            "CBE",
+            "Anthony",
+            "Smith",
+            None,
             False,
             artist2_shared_surname=True,
             artist3_shared_surname=True,
@@ -591,9 +648,17 @@ class TestBuildIndexName:
     def test_single_name_ra_with_second_artist(self):
         """Scenario 17: Single-name RA artist with a second artist."""
         name = build_index_name(
-            None, "Assemble", None, "RA",
-            "Jane", "Doe", None,
-            None, None, None, False,
+            None,
+            "Assemble",
+            None,
+            "RA",
+            "Jane",
+            "Doe",
+            None,
+            None,
+            None,
+            None,
+            False,
         )
         assert name == "Assemble RA, and Jane Doe"
 
@@ -874,9 +939,16 @@ class TestBuildIndexNameSharedSurname:
     def test_two_artists_shared_surname(self):
         """Shared surname suppresses artist 2's last name, no comma before 'and'."""
         name = build_index_name(
-            "Orta", "Lucy", None, None,
-            "Jorge", "Orta", None,
-            None, None, None,
+            "Orta",
+            "Lucy",
+            None,
+            None,
+            "Jorge",
+            "Orta",
+            None,
+            None,
+            None,
+            None,
             False,
             artist2_shared_surname=True,
         )
@@ -885,9 +957,16 @@ class TestBuildIndexNameSharedSurname:
     def test_two_artists_no_shared_surname(self):
         """Without shared surname, artist 2's last name is preserved."""
         name = build_index_name(
-            "Orta", "Lucy", None, None,
-            "Jorge", "Orta", None,
-            None, None, None,
+            "Orta",
+            "Lucy",
+            None,
+            None,
+            "Jorge",
+            "Orta",
+            None,
+            None,
+            None,
+            None,
             False,
             artist2_shared_surname=False,
         )
@@ -896,9 +975,16 @@ class TestBuildIndexNameSharedSurname:
     def test_three_artists_all_shared_surname(self):
         """Three artists with shared surname — A2 gets family-unit 'and', A3 gets Oxford comma."""
         name = build_index_name(
-            "Smith", "Melanie", None, None,
-            "Michael", "Smith", None,
-            "Anthony", "Smith", None,
+            "Smith",
+            "Melanie",
+            None,
+            None,
+            "Michael",
+            "Smith",
+            None,
+            "Anthony",
+            "Smith",
+            None,
             False,
             artist2_shared_surname=True,
             artist3_shared_surname=True,
@@ -908,9 +994,16 @@ class TestBuildIndexNameSharedSurname:
     def test_three_artists_only_artist2_shared(self):
         """Three artists, only artist 2 shares surname — family 'and' for A2, Oxford comma for A3."""
         name = build_index_name(
-            "Smith", "Melanie", None, None,
-            "Michael", "Smith", None,
-            "Anthony", "Jones", None,
+            "Smith",
+            "Melanie",
+            None,
+            None,
+            "Michael",
+            "Smith",
+            None,
+            "Anthony",
+            "Jones",
+            None,
             False,
             artist2_shared_surname=True,
             artist3_shared_surname=False,
@@ -920,9 +1013,16 @@ class TestBuildIndexNameSharedSurname:
     def test_shared_surname_with_quals(self):
         """Shared surname still shows quals, no comma before 'and'."""
         name = build_index_name(
-            "Orta", "Lucy", None, "RA",
-            "Jorge", "Orta", "CBE",
-            None, None, None,
+            "Orta",
+            "Lucy",
+            None,
+            "RA",
+            "Jorge",
+            "Orta",
+            "CBE",
+            None,
+            None,
+            None,
             False,
             artist2_shared_surname=True,
         )
@@ -943,9 +1043,16 @@ class TestBuildIndexNameSharedSurname:
     def test_three_artist_grammar_no_shared_surname(self):
         """Regression: 3-artist entries use Oxford-comma pattern (no 'and' before artist 2)."""
         name = build_index_name(
-            "Eggerling", "Gabriele", None, None,
-            "Dhruv", "Jadhav", None,
-            "Hannah", "Puerta-Carlson", None,
+            "Eggerling",
+            "Gabriele",
+            None,
+            None,
+            "Dhruv",
+            "Jadhav",
+            None,
+            "Hannah",
+            "Puerta-Carlson",
+            None,
             False,
         )
         assert name == "Eggerling, Gabriele, Dhruv Jadhav, and Hannah Puerta-Carlson"
@@ -953,9 +1060,16 @@ class TestBuildIndexNameSharedSurname:
     def test_three_artist_a2_shared_family_unit(self):
         """3-artist entry with A2 shared — family 'and' for A2, Oxford comma for A3."""
         name = build_index_name(
-            "Rivera", "Maria", None, None,
-            "Carlos", "Rivera", None,
-            "Hannah", "Jones", None,
+            "Rivera",
+            "Maria",
+            None,
+            None,
+            "Carlos",
+            "Rivera",
+            None,
+            "Hannah",
+            "Jones",
+            None,
             False,
             artist2_shared_surname=True,
             artist3_shared_surname=False,

--- a/tests/test_index_reimport.py
+++ b/tests/test_index_reimport.py
@@ -192,9 +192,7 @@ class TestIndexReimportOverrides:
         # Verify override was restored
         artists_after = _get_artists(client, import_id)
         adams_after = next(a for a in artists_after if a["last_name"] == "Adams")
-        ovr = client.get(
-            f"/index/imports/{import_id}/artists/{adams_after['id']}/override"
-        )
+        ovr = client.get(f"/index/imports/{import_id}/artists/{adams_after['id']}/override")
         assert ovr.status_code == 200
         assert ovr.json()["first_name_override"] == "Sir Roger"
 
@@ -255,9 +253,7 @@ class TestIndexReimportOverrides:
 
         artists_after = _get_artists(client, import_id)
         adams_after = next(a for a in artists_after if a["last_name"] == "Adams")
-        ovr = client.get(
-            f"/index/imports/{import_id}/artists/{adams_after['id']}/override"
-        )
+        ovr = client.get(f"/index/imports/{import_id}/artists/{adams_after['id']}/override")
         assert ovr.status_code == 200
         assert ovr.json()["is_company_override"] is True
 
@@ -332,9 +328,7 @@ class TestIndexReimportAuditAndWarnings:
         # e.g. assert the rows have higher created_at than before, or check
         # that the warning records carry the new import's id only.
         warnings_after = (
-            db_session.query(ValidationWarning)
-            .filter(ValidationWarning.import_id == iid)
-            .all()
+            db_session.query(ValidationWarning).filter(ValidationWarning.import_id == iid).all()
         )
         assert isinstance(warnings_after, list)
 

--- a/tests/test_index_renderer.py
+++ b/tests/test_index_renderer.py
@@ -1,6 +1,5 @@
 """Tests for the Artists' Index renderer."""
 
-
 from backend.app.services.index_renderer import (
     ArtistExportEntry,
     IndexExportConfig,
@@ -112,8 +111,7 @@ class TestRenderCatNos:
         cfg = IndexExportConfig(cat_no_separator=";")
         result = _render_cat_nos([10, 20], cfg)
         assert result == (
-            "<cstyle:Index works numbers>10<cstyle:>"
-            "; <cstyle:Index works numbers>20<cstyle:>"
+            "<cstyle:Index works numbers>10<cstyle:>; <cstyle:Index works numbers>20<cstyle:>"
         )
 
     def test_empty(self):
@@ -195,21 +193,15 @@ class TestRenderNamePart:
         assert result == "8014, "
 
     def test_the_late(self):
-        e = _entry(
-            last_name="Ackroyd", first_name="Norman", title="The late Prof.", is_ra=True
-        )
+        e = _entry(last_name="Ackroyd", first_name="Norman", title="The late Prof.", is_ra=True)
         result = _render_name_part(e, CFG)
-        assert (
-            result
-            == "<cstyle:RA Member Cap Surname>Ackroyd<cstyle:>, The late Prof. Norman, "
-        )
+        assert result == "<cstyle:RA Member Cap Surname>Ackroyd<cstyle:>, The late Prof. Norman, "
 
 
 class TestRenderCourtesy:
     def test_courtesy(self):
         assert (
-            _render_courtesy("Courtesy of Flowers Gallery", None)
-            == "Courtesy of Flowers Gallery, "
+            _render_courtesy("Courtesy of Flowers Gallery", None) == "Courtesy of Flowers Gallery, "
         )
 
     def test_company(self):
@@ -559,9 +551,7 @@ class TestSectionSep:
 
     def test_with_style(self):
         assert _section_sep("paragraph", "Spacer") == "<pstyle:Spacer>\r"
-        assert (
-            _section_sep("column_break", "Spacer") == "<pstyle:Spacer><cnxc:Column>\r"
-        )
+        assert _section_sep("column_break", "Spacer") == "<pstyle:Spacer><cnxc:Column>\r"
 
 
 class TestLetterKey:
@@ -619,9 +609,7 @@ class TestLetterGroupRendering:
         assert len(parts) == 3  # header + 2 entries
 
     def test_column_break_separator(self):
-        cfg = IndexExportConfig(
-            section_separator="column_break", section_separator_style="Spacer"
-        )
+        cfg = IndexExportConfig(section_separator="column_break", section_separator_style="Spacer")
         entries = [
             _entry(last_name="Adams", sort_key="adams", cat_nos=[1]),
             _entry(last_name="Baker", sort_key="baker", cat_nos=[2]),
@@ -640,9 +628,7 @@ class TestLetterHeading:
         result = render_index_tagged_text(entries, CFG)
         # No standalone "A" or "B" heading lines
         parts = result.split("\r")
-        assert not any(
-            p.strip() in ("<pstyle:Index Text>A", "<pstyle:Index Text>B") for p in parts
-        )
+        assert not any(p.strip() in ("<pstyle:Index Text>A", "<pstyle:Index Text>B") for p in parts)
 
     def test_heading_enabled_uses_entry_style(self):
         cfg = IndexExportConfig(letter_heading_enabled=True)
@@ -722,10 +708,7 @@ class TestSharedSurnameRenderer:
         result = render_index_tagged_text(entries, CFG)
         line = result.split("\r")[1]
         expected = (
-            "<pstyle:Index Text>"
-            "Orta, Lucy "
-            "and Jorge, "
-            "<cstyle:Index works numbers>42<cstyle:>"
+            "<pstyle:Index Text>Orta, Lucy and Jorge, <cstyle:Index works numbers>42<cstyle:>"
         )
         assert line == expected
 
@@ -845,68 +828,97 @@ class TestMultiArtistScenarios:
 
     def test_scenario_1_two_artists_plain(self):
         """Two artists, no shared surname, no quals."""
-        entries = [_entry(
-            last_name="Caruso", first_name="Adam",
-            artist2_first_name="Peter", artist2_last_name="St John",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Caruso",
+                first_name="Adam",
+                artist2_first_name="Peter",
+                artist2_last_name="St John",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "Adam, and Peter St John, " in line
 
     def test_scenario_2_two_artists_a1_ra(self):
         """Two artists, A1 is RA styled."""
-        entries = [_entry(
-            last_name="Caruso", first_name="Adam", quals="RA", is_ra=True,
-            artist2_first_name="Peter", artist2_last_name="St John",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Caruso",
+                first_name="Adam",
+                quals="RA",
+                is_ra=True,
+                artist2_first_name="Peter",
+                artist2_last_name="St John",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "<cstyle:RA Member Cap Surname>Caruso<cstyle:>" in line
         assert "and Peter St John, " in line
 
     def test_scenario_3_two_artists_a2_quals(self):
         """Two artists, A2 with quals."""
-        entries = [_entry(
-            last_name="Langlands", first_name="Ben",
-            artist2_first_name="Nikki", artist2_last_name="Bell",
-            artist2_quals="CBE",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Langlands",
+                first_name="Ben",
+                artist2_first_name="Nikki",
+                artist2_last_name="Bell",
+                artist2_quals="CBE",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "and Nikki Bell" in line
         assert "cbe" in line.lower()
 
     def test_scenario_4_two_artists_both_plain(self):
         """Two artists, both plain."""
-        entries = [_entry(
-            last_name="Boyd", first_name="Arthur",
-            artist2_first_name="Mary", artist2_last_name="Evans",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Boyd",
+                first_name="Arthur",
+                artist2_first_name="Mary",
+                artist2_last_name="Evans",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "Arthur, and Mary Evans, " in line
 
     def test_scenario_5_two_artists_a1_title_quals(self):
         """Two artists, A1 has title + quals + RA."""
-        entries = [_entry(
-            last_name="Adjaye", first_name="David", title="Sir",
-            quals="OM OBE RA", is_ra=True,
-            artist2_first_name="Mariam", artist2_last_name="Kamara",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Adjaye",
+                first_name="David",
+                title="Sir",
+                quals="OM OBE RA",
+                is_ra=True,
+                artist2_first_name="Mariam",
+                artist2_last_name="Kamara",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "Sir David" in line
         assert "and Mariam Kamara, " in line
 
     def test_scenario_8_two_artists_shared_a1_title_quals(self):
         """Two artists, shared surname, A1 has title + quals."""
-        entries = [_entry(
-            last_name="Smith", first_name="Melanie", title="Dame",
-            quals="DBE",
-            artist2_first_name="Michael", artist2_last_name="Smith",
-            artist2_shared_surname=True,
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Smith",
+                first_name="Melanie",
+                title="Dame",
+                quals="DBE",
+                artist2_first_name="Michael",
+                artist2_last_name="Smith",
+                artist2_shared_surname=True,
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         # No comma before "and" — family unit
         assert "Dame Melanie" in line
@@ -917,13 +929,18 @@ class TestMultiArtistScenarios:
 
     def test_scenario_9_two_artists_shared_a2_ra_quals(self):
         """Two artists, shared surname, A2 has RA quals."""
-        entries = [_entry(
-            last_name="Hirst", first_name="Damien",
-            artist2_first_name="Connor", artist2_last_name="Hirst",
-            artist2_quals="RA", artist2_ra_styled=True,
-            artist2_shared_surname=True,
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Hirst",
+                first_name="Damien",
+                artist2_first_name="Connor",
+                artist2_last_name="Hirst",
+                artist2_quals="RA",
+                artist2_ra_styled=True,
+                artist2_shared_surname=True,
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "Damien " in line
         assert "and Connor " in line
@@ -931,26 +948,37 @@ class TestMultiArtistScenarios:
 
     def test_scenario_10_three_artists_plain(self):
         """Three artists, no shared surname, no quals (renderer)."""
-        entries = [_entry(
-            last_name="Eggerling", first_name="Gabriele",
-            artist2_first_name="Dhruv", artist2_last_name="Jadhav",
-            artist3_first_name="Hannah", artist3_last_name="Puerta-Carlson",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Eggerling",
+                first_name="Gabriele",
+                artist2_first_name="Dhruv",
+                artist2_last_name="Jadhav",
+                artist3_first_name="Hannah",
+                artist3_last_name="Puerta-Carlson",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "Gabriele, Dhruv Jadhav, and Hannah Puerta-Carlson, " in line
 
     def test_scenario_11_three_artists_all_quals(self):
         """Three artists, no shared surname, all with quals."""
-        entries = [_entry(
-            last_name="Eggerling", first_name="Gabriele",
-            quals="RA", is_ra=True,
-            artist2_first_name="Dhruv", artist2_last_name="Jadhav",
-            artist2_quals="CBE",
-            artist3_first_name="Hannah", artist3_last_name="Puerta-Carlson",
-            artist3_quals="OBE",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Eggerling",
+                first_name="Gabriele",
+                quals="RA",
+                is_ra=True,
+                artist2_first_name="Dhruv",
+                artist2_last_name="Jadhav",
+                artist2_quals="CBE",
+                artist3_first_name="Hannah",
+                artist3_last_name="Puerta-Carlson",
+                artist3_quals="OBE",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "Dhruv Jadhav" in line
         assert "and Hannah Puerta-Carlson" in line
@@ -959,15 +987,22 @@ class TestMultiArtistScenarios:
 
     def test_scenario_13_three_artists_all_shared_with_quals(self):
         """Three artists, A2+A3 shared surname, with quals."""
-        entries = [_entry(
-            last_name="Smith", first_name="Melanie",
-            quals="RA", is_ra=True,
-            artist2_first_name="Michael", artist2_last_name="Smith",
-            artist2_quals="CBE", artist2_shared_surname=True,
-            artist3_first_name="Anthony", artist3_last_name="Smith",
-            artist3_shared_surname=True,
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Smith",
+                first_name="Melanie",
+                quals="RA",
+                is_ra=True,
+                artist2_first_name="Michael",
+                artist2_last_name="Smith",
+                artist2_quals="CBE",
+                artist2_shared_surname=True,
+                artist3_first_name="Anthony",
+                artist3_last_name="Smith",
+                artist3_shared_surname=True,
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         # Family unit "and" for A2, Oxford comma "and" for A3
         assert "and Michael " in line
@@ -979,24 +1014,34 @@ class TestMultiArtistScenarios:
 
     def test_scenario_16_a1_quals_a2_plain(self):
         """Two artists, A1 with CBE RA quals, A2 plain."""
-        entries = [_entry(
-            last_name="Parker", first_name="Cornelia",
-            quals="CBE RA", is_ra=True,
-            artist2_first_name="John", artist2_last_name="Doe",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name="Parker",
+                first_name="Cornelia",
+                quals="CBE RA",
+                is_ra=True,
+                artist2_first_name="John",
+                artist2_last_name="Doe",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "<cstyle:RA Member Cap Surname>Parker<cstyle:>" in line
         assert "and John Doe, " in line
 
     def test_scenario_17_single_name_ra_with_a2(self):
         """Single-name RA artist with a second artist."""
-        entries = [_entry(
-            last_name=None, first_name="Assemble",
-            quals="RA", is_ra=True,
-            artist2_first_name="Jane", artist2_last_name="Doe",
-            cat_nos=[10],
-        )]
+        entries = [
+            _entry(
+                last_name=None,
+                first_name="Assemble",
+                quals="RA",
+                is_ra=True,
+                artist2_first_name="Jane",
+                artist2_last_name="Doe",
+                cat_nos=[10],
+            )
+        ]
         line = render_index_tagged_text(entries, CFG).split("\r")[1]
         assert "Assemble" in line
         assert "and Jane Doe, " in line

--- a/tests/test_index_routes.py
+++ b/tests/test_index_routes.py
@@ -21,9 +21,7 @@ def _make_index_xlsx(rows) -> io.BytesIO:
     """Create an in-memory .xlsx with standard Index headers."""
     wb = Workbook()
     ws = wb.active
-    ws.append(
-        ["Title", "First Name", "Last Name", "Quals", "Company", "Address 1", "Cat Nos"]
-    )
+    ws.append(["Title", "First Name", "Last Name", "Quals", "Company", "Address 1", "Cat Nos"])
     for row in rows:
         ws.append(list(row))
     buf = io.BytesIO()
@@ -326,9 +324,7 @@ class TestDeleteIndex:
         artist_ids = [a.id for a in artists]
         client.delete(f"/index/imports/{imp.id}")
 
-        remaining = (
-            db_session.query(IndexArtist).filter(IndexArtist.id.in_(artist_ids)).count()
-        )
+        remaining = db_session.query(IndexArtist).filter(IndexArtist.id.in_(artist_ids)).count()
         assert remaining == 0
 
     def test_delete_404(self, client):
@@ -620,9 +616,7 @@ class TestMergeUnmerge:
         import_id = r.json()["import_id"]
 
         warnings = client.get(f"/index/imports/{import_id}/warnings").json()
-        merge_warnings = [
-            w for w in warnings if w["warning_type"] == "duplicate_name_merged"
-        ]
+        merge_warnings = [w for w in warnings if w["warning_type"] == "duplicate_name_merged"]
         assert len(merge_warnings) == 1
         assert "Rows 2, 3" in merge_warnings[0]["message"]
         assert "John Smith" in merge_warnings[0]["message"]

--- a/tests/test_index_templates.py
+++ b/tests/test_index_templates.py
@@ -30,9 +30,7 @@ def _make_index_ruleset(db, *, name, is_builtin=False):
     r = Ruleset(
         name=name,
         config=cfg,
-        config_hash=hashlib.sha256(
-            json.dumps(cfg, sort_keys=True).encode()
-        ).hexdigest(),
+        config_hash=hashlib.sha256(json.dumps(cfg, sort_keys=True).encode()).hexdigest(),
         config_type="index_template",
         is_builtin=is_builtin,
     )
@@ -92,9 +90,7 @@ def test_list_index_templates_excludes_low_templates(client, db_session):
         Ruleset(
             name="LoW Template",
             config=low_cfg,
-            config_hash=hashlib.sha256(
-                json.dumps(low_cfg, sort_keys=True).encode()
-            ).hexdigest(),
+            config_hash=hashlib.sha256(json.dumps(low_cfg, sort_keys=True).encode()).hexdigest(),
             config_type="template",
             is_builtin=False,
         )

--- a/tests/test_low_diff.py
+++ b/tests/test_low_diff.py
@@ -51,10 +51,20 @@ def _section(id, name, position):
 
 def _work(section_id, pos, cat_no, **kw):
     base = dict(
-        id=f"w{cat_no}", raw_cat_no=cat_no, artist_name="", artist_honorifics=None,
-        title="", price_numeric=None, price_text="", edition_total=None,
-        edition_price_numeric=None, artwork=None, medium=None,
-        section_id=section_id, position_in_section=pos, include_in_export=True,
+        id=f"w{cat_no}",
+        raw_cat_no=cat_no,
+        artist_name="",
+        artist_honorifics=None,
+        title="",
+        price_numeric=None,
+        price_text="",
+        edition_total=None,
+        edition_price_numeric=None,
+        artwork=None,
+        medium=None,
+        section_id=section_id,
+        position_in_section=pos,
+        include_in_export=True,
     )
     base.update(kw)
     return SimpleNamespace(**base)
@@ -66,16 +76,52 @@ def _base_import():
     config = ExportConfig()
     sections = [_section("s1", "Gallery I", 1), _section("s2", "Gallery II", 2)]
     works = [
-        _work("s1", 1, 101, artist_name="Cornelia Parker", artist_honorifics="RA",
-              title="Cold Dark Matter", price_numeric=12000, medium="mixed media"),
-        _work("s1", 2, 102, artist_name="Anish Kapoor", title="Void",
-              price_text="NFS", medium="pigment"),
-        _work("s2", 1, 103, artist_name="David Hockney", title="Spring",
-              price_numeric=9000, medium="iPad drawing"),
-        _work("s2", 2, 104, artist_name="Rachel Whiteread",
-              title="Artist's Study", price_numeric=5000, medium="resin"),
-        _work("s2", 3, 105, artist_name="Frank Bowling", title="Map",
-              price_numeric=7000, medium="acrylic on canvas"),
+        _work(
+            "s1",
+            1,
+            101,
+            artist_name="Cornelia Parker",
+            artist_honorifics="RA",
+            title="Cold Dark Matter",
+            price_numeric=12000,
+            medium="mixed media",
+        ),
+        _work(
+            "s1",
+            2,
+            102,
+            artist_name="Anish Kapoor",
+            title="Void",
+            price_text="NFS",
+            medium="pigment",
+        ),
+        _work(
+            "s2",
+            1,
+            103,
+            artist_name="David Hockney",
+            title="Spring",
+            price_numeric=9000,
+            medium="iPad drawing",
+        ),
+        _work(
+            "s2",
+            2,
+            104,
+            artist_name="Rachel Whiteread",
+            title="Artist's Study",
+            price_numeric=5000,
+            medium="resin",
+        ),
+        _work(
+            "s2",
+            3,
+            105,
+            artist_name="Frank Bowling",
+            title="Map",
+            price_numeric=7000,
+            medium="acrylic on canvas",
+        ),
     ]
     db = FakeSession(sections, works)
     text = render_import_as_tagged_text("imp1", db, config)
@@ -93,12 +139,14 @@ def _move_entry(text, cat_no, target_section, config):
     paras = text.split("\r")
     span = _catspan(config, cat_no)
     ei = next(
-        i for i, p in enumerate(paras)
+        i
+        for i, p in enumerate(paras)
         if p.startswith(f"<ParaStyle:{config.entry_style}>") and span in p
     )
     entry = paras.pop(ei)
     ti = next(
-        i for i, p in enumerate(paras)
+        i
+        for i, p in enumerate(paras)
         if p.startswith(f"<ParaStyle:{config.section_style}>{target_section}")
     )
     paras.insert(ti + 1, entry)
@@ -214,20 +262,40 @@ def test_manual_newline_in_field_is_not_a_finding():
     in the DB but deleted by the parser when it round-trips through InDesign's
     soft returns. That must read as cosmetic, not a real change. (Found on the
     real 2025 catalogue.)"""
-    collected = [{
-        "section_name": "Gallery I", "position": 1,
-        "works": [{
-            "number": "1", "artist": "A", "honorifics": None, "title": "T",
-            "price_numeric": 100, "price_text": "", "edition_total": None,
-            "edition_price_numeric": None, "artwork": None,
-            "medium": "resin\nand steel",
-        }],
-    }]
-    parsed = [ParsedEntry(
-        cat_no="1", section_name="Gallery I", paragraph_index=0,
-        fields={"work_number": "1", "artist": "A", "title": "T",
-                "price": "£100", "medium": "resinand steel"},
-    )]
+    collected = [
+        {
+            "section_name": "Gallery I",
+            "position": 1,
+            "works": [
+                {
+                    "number": "1",
+                    "artist": "A",
+                    "honorifics": None,
+                    "title": "T",
+                    "price_numeric": 100,
+                    "price_text": "",
+                    "edition_total": None,
+                    "edition_price_numeric": None,
+                    "artwork": None,
+                    "medium": "resin\nand steel",
+                }
+            ],
+        }
+    ]
+    parsed = [
+        ParsedEntry(
+            cat_no="1",
+            section_name="Gallery I",
+            paragraph_index=0,
+            fields={
+                "work_number": "1",
+                "artist": "A",
+                "title": "T",
+                "price": "£100",
+                "medium": "resinand steel",
+            },
+        )
+    ]
     result = diff_low(parsed, collected, ExportConfig())
     assert [f for f in result.findings if f.field == "medium"] == []
     assert result.counts["suppressed_cosmetic"] >= 1
@@ -247,9 +315,9 @@ def test_combined_canonical_mutations():
     assert kinds.count("entry_removed") == 1
     assert kinds.count("room_move") == 1
 
-    assert result.counts["matched"] == 4   # 101, 103, 104, 105 (102 renumbered)
+    assert result.counts["matched"] == 4  # 101, 103, 104, 105 (102 renumbered)
     assert result.counts["low_only"] == 1  # 120
-    assert result.counts["db_only"] == 1   # 102
+    assert result.counts["db_only"] == 1  # 102
     # Every finding is routed and tiered.
     assert all(f.fix_channel in ("override", "spreadsheet") for f in result.findings)
     assert all(f.severity in ("high", "medium", "info") for f in result.findings)

--- a/tests/test_low_real_sample.py
+++ b/tests/test_low_real_sample.py
@@ -23,9 +23,7 @@ from backend.app.services.low_tag_parser import parse_low_tags
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Git-tracked fixtures required by the test suite live here; the rest of
 # test_sample_files/ is disposable/local-only working data.
-_SAMPLES = os.path.join(
-    _REPO, "test_sample_files", "tracked_samples_for_automated_tests"
-)
+_SAMPLES = os.path.join(_REPO, "test_sample_files", "tracked_samples_for_automated_tests")
 _TXT = os.path.join(_SAMPLES, "Sample 26-05-26 with edition cstyle.txt")
 _XLSX = os.path.join(_SAMPLES, "Catalogue List 2025_renamed.xlsx")
 _SEED = os.path.join(_REPO, "backend", "seed_templates", "list-of-works-2026.json")
@@ -71,9 +69,7 @@ def test_real_export_parses_all_entries_and_fields():
 
 def test_real_export_diffs_clean_against_source(db_session):
     config = _config_2026()
-    imp = import_excel(
-        _XLSX, db_session, display_name="Catalogue List 2025_renamed.xlsx"
-    )
+    imp = import_excel(_XLSX, db_session, display_name="Catalogue List 2025_renamed.xlsx")
     collected = _collect_export_data(imp.id, db_session)
     result = diff_low(_parse_real(), collected, config)
 

--- a/tests/test_low_reconcile_routes.py
+++ b/tests/test_low_reconcile_routes.py
@@ -23,17 +23,41 @@ def _seed(db):
     db.refresh(s2)
     db.add_all(
         [
-            Work(import_id=imp.id, section_id=s1.id, position_in_section=1,
-                 raw_cat_no="1", title="Sunset", artist_name="Jane Doe",
-                 price_numeric=500, price_text="£500", medium="oil",
-                 include_in_export=True),
-            Work(import_id=imp.id, section_id=s1.id, position_in_section=2,
-                 raw_cat_no="2", title="Moonrise", artist_name="John Roe",
-                 price_numeric=750, price_text="", medium="acrylic",
-                 include_in_export=True),
-            Work(import_id=imp.id, section_id=s2.id, position_in_section=1,
-                 raw_cat_no="3", title="Dawn", artist_name="Sam Poe",
-                 price_text="NFS", medium="watercolour", include_in_export=True),
+            Work(
+                import_id=imp.id,
+                section_id=s1.id,
+                position_in_section=1,
+                raw_cat_no="1",
+                title="Sunset",
+                artist_name="Jane Doe",
+                price_numeric=500,
+                price_text="£500",
+                medium="oil",
+                include_in_export=True,
+            ),
+            Work(
+                import_id=imp.id,
+                section_id=s1.id,
+                position_in_section=2,
+                raw_cat_no="2",
+                title="Moonrise",
+                artist_name="John Roe",
+                price_numeric=750,
+                price_text="",
+                medium="acrylic",
+                include_in_export=True,
+            ),
+            Work(
+                import_id=imp.id,
+                section_id=s2.id,
+                position_in_section=1,
+                raw_cat_no="3",
+                title="Dawn",
+                artist_name="Sam Poe",
+                price_text="NFS",
+                medium="watercolour",
+                include_in_export=True,
+            ),
         ]
     )
     db.commit()
@@ -159,10 +183,7 @@ def test_workflow_a_override_resolves_finding(client, db_session):
 
     body = _post_snapshot(client, imp.id, modified).json()
     sid = body["snapshot"]["id"]
-    assert any(
-        f["cat_no"] == "1" and f["field"] == "title"
-        for f in body["diff"]["findings"]
-    )
+    assert any(f["cat_no"] == "1" and f["field"] == "title" for f in body["diff"]["findings"])
 
     # Apply the correction as an override on the matching work.
     work = db_session.query(Work).filter(Work.raw_cat_no == "1").first()
@@ -172,8 +193,7 @@ def test_workflow_a_override_resolves_finding(client, db_session):
     # Re-view the same stored snapshot — diff recomputes against current data.
     after = client.get(f"/imports/{imp.id}/low-tag-snapshots/{sid}").json()
     assert not [
-        f for f in after["diff"]["findings"]
-        if f["cat_no"] == "1" and f["field"] == "title"
+        f for f in after["diff"]["findings"] if f["cat_no"] == "1" and f["field"] == "title"
     ]
 
 

--- a/tests/test_low_tag_parser.py
+++ b/tests/test_low_tag_parser.py
@@ -182,19 +182,33 @@ def test_roundtrip_default_config():
     sections = [_section("s1", "Gallery I", 1), _section("s2", "Gallery II", 2)]
     works = [
         _work(
-            "s1", 1, 1,
-            artist_name="Cornelia Parker", artist_honorifics="RA",
-            title="Cold Dark Matter", price_numeric=12000,
-            edition_total=7, edition_price_numeric=920, medium="mixed media",
+            "s1",
+            1,
+            1,
+            artist_name="Cornelia Parker",
+            artist_honorifics="RA",
+            title="Cold Dark Matter",
+            price_numeric=12000,
+            edition_total=7,
+            edition_price_numeric=920,
+            medium="mixed media",
         ),
         _work(
-            "s1", 2, 2,
-            artist_name="Anish Kapoor", title="Void", price_text="NFS",
+            "s1",
+            2,
+            2,
+            artist_name="Anish Kapoor",
+            title="Void",
+            price_text="NFS",
             medium="pigment on fibreglass",
         ),
         _work(
-            "s2", 1, 3,
-            artist_name="David Hockney", title="Spring", edition_total=5,
+            "s2",
+            1,
+            3,
+            artist_name="David Hockney",
+            title="Spring",
+            edition_total=5,
             medium="iPad drawing",
         ),
     ]
@@ -208,17 +222,25 @@ def test_roundtrip_2026_config_with_wrap_collision_and_interleave():
         # Long title forces a wrap; price is interleaved into the first line;
         # cat-no and title share the "Work Number/Name" style.
         _work(
-            "s1", 1, 101,
-            artist_name="Grayson Perry", artist_honorifics="RA",
+            "s1",
+            1,
+            101,
+            artist_name="Grayson Perry",
+            artist_honorifics="RA",
             title="A Really Quite Long Painting Title That Must Wrap",
             price_numeric=1500,
             medium="Oil, acrylic and mixed media on reclaimed canvas board",
         ),
         _work(
-            "s1", 2, 102,
+            "s1",
+            2,
+            102,
             artist_name="Tracey Emin",
-            title="Short One", price_numeric=8000,
-            edition_total=3, edition_price_numeric=450, medium="neon",
+            title="Short One",
+            price_numeric=8000,
+            edition_total=3,
+            edition_price_numeric=450,
+            medium="neon",
         ),
     ]
     _roundtrip_check(sections, works, config)
@@ -241,7 +263,9 @@ def test_collision_and_interleave_assignment():
         components=[
             ComponentConfig("work_number", "tab"),
             ComponentConfig(
-                "title", "tab", max_line_chars=10,
+                "title",
+                "tab",
+                max_line_chars=10,
                 next_component_position="end_of_first_line",
             ),
             ComponentConfig("price", "none"),
@@ -318,13 +342,15 @@ def test_local_style_modifications_ignored_anywhere():
     control char, a leading leading-override <cl:>, mid-run kerning <ck:> — must
     not pollute the cat number or title (not just a leading change)."""
     config = ExportConfig(
-        section_style="Sec", entry_style="Entry",
-        cat_no_style="WNN", title_style="WNN",
-        components=[ComponentConfig("work_number", "tab"),
-                    ComponentConfig("title", "tab")],
+        section_style="Sec",
+        entry_style="Entry",
+        cat_no_style="WNN",
+        title_style="WNN",
+        components=[ComponentConfig("work_number", "tab"), ComponentConfig("title", "tab")],
     )
-    body = ("<CharStyle:WNN>\x03<cl:9.150000>\t405\t"
-            "CHILDREN<0x2019>S <ck:-10>GAMES\t<cl:><CharStyle:>")
+    body = (
+        "<CharStyle:WNN>\x03<cl:9.150000>\t405\tCHILDREN<0x2019>S <ck:-10>GAMES\t<cl:><CharStyle:>"
+    )
     doc = f"<ASCII-MAC>\r<ParaStyle:Sec>Room\r<ParaStyle:Entry>{body}\r"
     e = parse_low_tags(doc, config)[0]
     assert e.cat_no == "405"

--- a/tests/test_lpg_render.py
+++ b/tests/test_lpg_render.py
@@ -37,10 +37,7 @@ _SEED = _REPO / "backend" / "seed_templates" / "large-print-guide-2026.json"
 # A small, git-tracked excerpt of the real export (the full file is too large to
 # commit). Covers both per-work paragraph-style shapes (with / without edition).
 _SAMPLE = (
-    _REPO
-    / "test_sample_files"
-    / "tracked_samples_for_automated_tests"
-    / "lpg_sample_small.txt"
+    _REPO / "test_sample_files" / "tracked_samples_for_automated_tests" / "lpg_sample_small.txt"
 )
 
 
@@ -62,23 +59,49 @@ def _seed(db):
     db.add_all(
         [
             # plain, NFS, no edition
-            Work(import_id=imp.id, section_id=sec.id, position_in_section=1,
-                 raw_cat_no="1", title="The Meddling Fiend",
-                 title_cased="The Meddling Fiend", artist_name="Nicola Turner",
-                 medium="mixed media", price_text="NFS", include_in_export=True),
+            Work(
+                import_id=imp.id,
+                section_id=sec.id,
+                position_in_section=1,
+                raw_cat_no="1",
+                title="The Meddling Fiend",
+                title_cased="The Meddling Fiend",
+                artist_name="Nicola Turner",
+                medium="mixed media",
+                price_text="NFS",
+                include_in_export=True,
+            ),
             # priced, with an edition
-            Work(import_id=imp.id, section_id=sec.id, position_in_section=2,
-                 raw_cat_no="3", title="Superhero Rabbit",
-                 title_cased="Superhero Rabbit", artist_name="Joanna Ham",
-                 medium="screenprint with UV neon ink", price_numeric=140,
-                 price_text="140", edition_total=200, edition_price_numeric=90,
-                 include_in_export=True),
+            Work(
+                import_id=imp.id,
+                section_id=sec.id,
+                position_in_section=2,
+                raw_cat_no="3",
+                title="Superhero Rabbit",
+                title_cased="Superhero Rabbit",
+                artist_name="Joanna Ham",
+                medium="screenprint with UV neon ink",
+                price_numeric=140,
+                price_text="140",
+                edition_total=200,
+                edition_price_numeric=90,
+                include_in_export=True,
+            ),
             # honorifics (small caps), priced
-            Work(import_id=imp.id, section_id=sec.id, position_in_section=3,
-                 raw_cat_no="5", title="Centre-Fold", title_cased="Centre-Fold",
-                 artist_name="John Carter",
-                 artist_honorifics="RA", medium="acrylic with marble powder on plywood",
-                 price_numeric=7500, price_text="7500", include_in_export=True),
+            Work(
+                import_id=imp.id,
+                section_id=sec.id,
+                position_in_section=3,
+                raw_cat_no="5",
+                title="Centre-Fold",
+                title_cased="Centre-Fold",
+                artist_name="John Carter",
+                artist_honorifics="RA",
+                medium="acrylic with marble powder on plywood",
+                price_numeric=7500,
+                price_text="7500",
+                include_in_export=True,
+            ),
         ]
     )
     db.commit()
@@ -105,10 +128,7 @@ def test_lpg_render_matches_sample_structure(db_session):
     assert "<ParaStyle:LPGPRICE>£140\r" in out
 
     # Work 5: honorifics as an inline small-caps run, lowercased to match the LPG.
-    assert (
-        "<ParaStyle:LPGARTIST>John Carter <CharStyle:LPGSMALLCAPS>ra<CharStyle:>\r"
-        in out
-    )
+    assert "<ParaStyle:LPGARTIST>John Carter <CharStyle:LPGSMALLCAPS>ra<CharStyle:>\r" in out
 
 
 def test_lpg_title_cased_falls_back_to_title_when_absent(db_session):
@@ -123,10 +143,18 @@ def test_lpg_title_cased_falls_back_to_title_when_absent(db_session):
     db_session.commit()
     db_session.refresh(sec)
     db_session.add(
-        Work(import_id=imp.id, section_id=sec.id, position_in_section=1,
-             raw_cat_no="1", title="LEGACY ALL CAPS", title_cased=None,
-             artist_name="Someone", medium="oil", price_text="NFS",
-             include_in_export=True)
+        Work(
+            import_id=imp.id,
+            section_id=sec.id,
+            position_in_section=1,
+            raw_cat_no="1",
+            title="LEGACY ALL CAPS",
+            title_cased=None,
+            artist_name="Someone",
+            medium="oil",
+            price_text="NFS",
+            include_in_export=True,
+        )
     )
     db_session.commit()
     out = render_import_as_tagged_text(imp.id, db_session, _lpg_config())
@@ -173,9 +201,7 @@ def _seed_lpg_template(db):
     rs = Ruleset(
         name="Large Print Guide 2026",
         config=cfg,
-        config_hash=hashlib.sha256(
-            json.dumps(cfg, sort_keys=True).encode()
-        ).hexdigest(),
+        config_hash=hashlib.sha256(json.dumps(cfg, sort_keys=True).encode()).hexdigest(),
         config_type="template",
         is_builtin=False,
         slug="lpg-test",
@@ -190,9 +216,7 @@ def test_section_export_filename_embeds_template_and_gallery(client, db_session)
     imp = _seed(db_session)
     sec = db_session.query(Section).filter(Section.import_id == imp.id).first()
     rs = _seed_lpg_template(db_session)
-    r = client.get(
-        f"/imports/{imp.id}/sections/{sec.id}/export-tags?template_id={rs.id}"
-    )
+    r = client.get(f"/imports/{imp.id}/sections/{sec.id}/export-tags?template_id={rs.id}")
     assert r.status_code == 200
     cd = r.headers.get("content-disposition", "")
     assert "Large-Print-Guide-2026" in cd

--- a/tests/test_normalise_work.py
+++ b/tests/test_normalise_work.py
@@ -1,6 +1,5 @@
 """Unit tests for normalise_work — the orchestrator that ties all normalisation together."""
 
-
 from backend.app.services.normalisation_service import normalise_work
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -81,9 +81,7 @@ def _do_import(client, headers=None, rows=None) -> str:
     return r.json()["import_id"]
 
 
-def _do_reimport(
-    client, import_id: str, headers=None, rows=None, filename="updated.xlsx"
-):
+def _do_reimport(client, import_id: str, headers=None, rows=None, filename="updated.xlsx"):
     """Re-import into an existing import and return the response."""
     hdrs = headers or ALL_HEADERS
     data = rows or [
@@ -276,17 +274,13 @@ class TestReimportOverridePreservation:
         db_session.commit()
 
         sections = _get_sections(client, import_id)
-        work2_check = next(
-            w for s in sections for w in s["works"] if w["raw_cat_no"] == "2"
-        )
+        work2_check = next(w for s in sections for w in s["works"] if w["raw_cat_no"] == "2")
         assert work2_check["include_in_export"] is False
 
         _do_reimport(client, import_id)
 
         sections = _get_sections(client, import_id)
-        work2_after = next(
-            w for s in sections for w in s["works"] if w["raw_cat_no"] == "2"
-        )
+        work2_after = next(w for s in sections for w in s["works"] if w["raw_cat_no"] == "2")
         assert work2_after["include_in_export"] is False
 
     def test_override_lost_for_removed_work(self, client):
@@ -310,10 +304,9 @@ class TestReimportOverridePreservation:
         assert data["overrides_preserved"] == 0
         # And the cat 3 override appears in the unmatched/ambiguous list so
         # the user knows what was lost.
-        flagged_cat_nos = (
-            {u["old_cat_no"] for u in data["unmatched"]}
-            | {a["old_cat_no"] for a in data["ambiguous"]}
-        )
+        flagged_cat_nos = {u["old_cat_no"] for u in data["unmatched"]} | {
+            a["old_cat_no"] for a in data["ambiguous"]
+        }
         assert "3" in flagged_cat_nos
 
     def test_no_overrides_all_new(self, client):
@@ -503,9 +496,7 @@ class TestReimportAuditAndWarnings:
         sections = _get_sections(client, import_id)
         all_works = [w for s in sections for w in s["works"]]
         work1 = next(w for w in all_works if w["raw_cat_no"] == "1")
-        _set_override(
-            client, import_id, work1["id"], title_override="After First Reimport"
-        )
+        _set_override(client, import_id, work1["id"], title_override="After First Reimport")
 
         # Second reimport — override should still be preserved
         r2 = _do_reimport(client, import_id)
@@ -532,7 +523,8 @@ class TestReimportDryRun:
         sections_before = _get_sections(client, import_id)
         snapshot_before = [
             (w["raw_cat_no"], w["raw_title"], w.get("raw_artist"))
-            for s in sections_before for w in s["works"]
+            for s in sections_before
+            for w in s["works"]
         ]
 
         buf = _make_xlsx(
@@ -547,7 +539,8 @@ class TestReimportDryRun:
             f"/imports/{import_id}/reimport?dry_run=true",
             files={
                 "file": (
-                    "preview.xlsx", buf,
+                    "preview.xlsx",
+                    buf,
                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 )
             },
@@ -556,7 +549,7 @@ class TestReimportDryRun:
         data = r.json()
         assert data["dry_run"] is True
         # Plan reports the same counts as a real re-import would
-        assert data["matched_by_cat_no"] == 1   # cat 2 only
+        assert data["matched_by_cat_no"] == 1  # cat 2 only
         assert data["added"] == 2
         assert data["removed"] == 2
 
@@ -564,7 +557,8 @@ class TestReimportDryRun:
         sections_after = _get_sections(client, import_id)
         snapshot_after = [
             (w["raw_cat_no"], w["raw_title"], w.get("raw_artist"))
-            for s in sections_after for w in s["works"]
+            for s in sections_after
+            for w in s["works"]
         ]
         assert snapshot_before == snapshot_after
 
@@ -580,8 +574,13 @@ class TestReimportDryRun:
         )
         r = client.put(
             f"/imports/{import_id}/reimport?dry_run=true",
-            files={"file": ("p.xlsx", buf,
-                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+            files={
+                "file": (
+                    "p.xlsx",
+                    buf,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
         )
         assert r.status_code == 200
         gs = r.json()["galleries"]
@@ -590,7 +589,7 @@ class TestReimportDryRun:
         assert by_name["Gallery A"]["work_count"] == 2
         assert by_name["Gallery A"]["cat_no_min"] == 1
         assert by_name["Gallery A"]["cat_no_max"] == 2
-        assert by_name["Gallery A"]["in_scope"] is True   # no filter → all in scope
+        assert by_name["Gallery A"]["in_scope"] is True  # no filter → all in scope
         assert by_name["Gallery B"]["work_count"] == 1
 
 
@@ -621,8 +620,13 @@ class TestReimportGalleryScope:
         )
         r = client.put(
             f"/imports/{import_id}/reimport?galleries=Gallery+A",
-            files={"file": ("scoped.xlsx", buf,
-                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+            files={
+                "file": (
+                    "scoped.xlsx",
+                    buf,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
         )
         assert r.status_code == 200, r.text
 
@@ -657,13 +661,19 @@ class TestReimportGalleryScope:
         )
         r = client.put(
             f"/imports/{import_id}/reimport?galleries=Gallery+A&dry_run=true",
-            files={"file": ("move.xlsx", buf,
-                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+            files={
+                "file": (
+                    "move.xlsx",
+                    buf,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
         )
         assert r.status_code == 200
         warnings = r.json()["cross_gallery_warnings"]
         assert any(
-            w["raw_title"] == "Noon" and w["old_gallery"] == "Gallery B"
+            w["raw_title"] == "Noon"
+            and w["old_gallery"] == "Gallery B"
             and w["new_gallery"] == "Gallery A"
             for w in warnings
         )
@@ -681,7 +691,9 @@ class TestReimportSilentMisapplicationRegression:
         all_works = [w for s in sections for w in s["works"]]
         work3 = next(w for w in all_works if w["raw_cat_no"] == "3")
         _set_override(
-            client, import_id, work3["id"],
+            client,
+            import_id,
+            work3["id"],
             title_override="Noon's secret title",
             price_numeric_override=99999,
         )
@@ -701,8 +713,13 @@ class TestReimportSilentMisapplicationRegression:
         )
         r = client.put(
             f"/imports/{import_id}/reimport",
-            files={"file": ("insert.xlsx", buf,
-                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+            files={
+                "file": (
+                    "insert.xlsx",
+                    buf,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
         )
         assert r.status_code == 200, r.text
         data = r.json()

--- a/tests/test_reimport_matcher.py
+++ b/tests/test_reimport_matcher.py
@@ -48,8 +48,7 @@ def test_fingerprint_handles_missing_fields():
 # ---------------------------------------------------------------------------
 
 
-def _old(cat_no, title, artist, medium="oil", gallery="G1", *, override=None,
-         include=True):
+def _old(cat_no, title, artist, medium="oil", gallery="G1", *, override=None, include=True):
     return OldWorkSnapshot(
         cat_no=str(cat_no),
         gallery=gallery,
@@ -115,18 +114,18 @@ def test_insertion_shifts_cat_nos_fingerprint_recovers_overrides():
     ]
     new = [
         _new(1, "Sunset", "Jane"),
-        _new(2, "Brand New", "Bob"),   # inserted
-        _new(3, "Dawn", "John"),       # was cat 2
-        _new(4, "Noon", "Alice"),      # was cat 3
+        _new(2, "Brand New", "Bob"),  # inserted
+        _new(3, "Dawn", "John"),  # was cat 2
+        _new(4, "Noon", "Alice"),  # was cat 3
     ]
     plan = match_overrides(old, new)
 
     # All three old works are accounted for, two via fingerprint
-    assert plan.matched_by_cat_no == 1   # only "Sunset" still at cat 1
+    assert plan.matched_by_cat_no == 1  # only "Sunset" still at cat 1
     assert plan.matched_by_fingerprint == 2
     assert plan.overrides_preserved == 2  # both shifted overrides recovered
     assert plan.overrides_at_risk == 0
-    assert plan.added == 1               # "Brand New"
+    assert plan.added == 1  # "Brand New"
     assert plan.removed == 0
     assert plan.unmatched == []
     assert plan.ambiguous == []
@@ -152,12 +151,16 @@ def test_silent_misapplication_regression():
     real target elsewhere, simply matched there)."""
     old = [
         _old(1, "Sunset", "Jane"),
-        _old(2, "Dawn", "John", override={"price_numeric_override": 9999,
-                                          "title_override": "EXCLUSIVE"}),
+        _old(
+            2,
+            "Dawn",
+            "John",
+            override={"price_numeric_override": 9999, "title_override": "EXCLUSIVE"},
+        ),
     ]
     new = [
         _new(1, "Sunset", "Jane"),
-        _new(2, "Brand New", "Bob"),   # different work at cat 2 — must not steal Dawn's override
+        _new(2, "Brand New", "Bob"),  # different work at cat 2 — must not steal Dawn's override
     ]
     plan = match_overrides(old, new)
 
@@ -192,8 +195,7 @@ def test_title_edit_after_renumber_is_flagged_not_silently_lost():
     user can decide whether to re-apply it manually."""
     old = [
         _old(1, "Sunset", "Jane"),
-        _old(2, "Untitled (after dust)", "John",
-             override={"price_numeric_override": 1200}),
+        _old(2, "Untitled (after dust)", "John", override={"price_numeric_override": 1200}),
         _old(3, "Noon", "Alice"),
     ]
     new = [
@@ -236,10 +238,7 @@ def test_fingerprint_collision_is_ambiguous():
     plan = match_overrides(old, new)
     assert plan.overrides_preserved == 0
     assert plan.overrides_at_risk == 1
-    assert any(
-        x.reason == "fingerprint_collision" and x.old_cat_no == "99"
-        for x in plan.ambiguous
-    )
+    assert any(x.reason == "fingerprint_collision" and x.old_cat_no == "99" for x in plan.ambiguous)
 
 
 # ---------------------------------------------------------------------------
@@ -291,13 +290,13 @@ def test_gallery_scope_detects_cross_gallery_move():
     """A work whose fingerprint exists in a non-scope gallery shouldn't be
     silently duplicated into the selected gallery. The matcher warns."""
     old = [
-        _old(1, "A", "X", gallery="G1"),     # out of scope
-        _old(5, "Z", "Y", gallery="G2"),     # in scope
+        _old(1, "A", "X", gallery="G1"),  # out of scope
+        _old(5, "Z", "Y", gallery="G2"),  # in scope
     ]
     new = [
         # A new row in G2 looks (by content) like the work currently in G1
         _new(5, "Z", "Y", gallery="G2"),
-        _new(6, "A", "X", gallery="G2"),     # cross-gallery move into scope
+        _new(6, "A", "X", gallery="G2"),  # cross-gallery move into scope
     ]
     plan = match_overrides(old, new, gallery_scope={"G2"})
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -383,9 +383,7 @@ def test_manual_line_breaks_with_end_of_first_line():
 
 def test_manual_line_breaks_medium():
     """Newlines in medium should also bypass auto-wrap."""
-    db = _manual_break_db(
-        title="Normal Title", medium="oil on canvas\nmounted on board"
-    )
+    db = _manual_break_db(title="Normal Title", medium="oil on canvas\nmounted on board")
     cfg = ExportConfig(
         components=[
             ComponentConfig(field="work_number", separator_after="tab"),

--- a/tests/test_request_size_limit.py
+++ b/tests/test_request_size_limit.py
@@ -51,9 +51,7 @@ class TestBodySizeLimit:
         # We don't need to hit *exactly* the limit; just confirm a sub-limit
         # request passes. (Exact equality is fiddly because TestClient may
         # add/strip whitespace.)
-        assert r.status_code == 200, (
-            f"a {len(body)}-byte body should pass when limit is 1000"
-        )
+        assert r.status_code == 200, f"a {len(body)}-byte body should pass when limit is 1000"
 
     def test_non_numeric_content_length_passes(self):
         """A garbage Content-Length shouldn't 413 — falls through to the

--- a/tests/test_role_guards.py
+++ b/tests/test_role_guards.py
@@ -29,9 +29,7 @@ from backend.app.models.work_model import Work
 
 def _seed_import(db):
     """Create a minimal LoW import with one section and one work."""
-    imp = Import(
-        filename="test.xlsx", disk_filename="test.xlsx", product_type="list_of_works"
-    )
+    imp = Import(filename="test.xlsx", disk_filename="test.xlsx", product_type="list_of_works")
     db.add(imp)
     db.flush()
     sec = Section(import_id=imp.id, name="A", position=1)
@@ -53,9 +51,7 @@ def _seed_import(db):
 
 def _seed_index_import(db):
     """Create a minimal index import with one artist."""
-    imp = Import(
-        filename="index.xlsx", disk_filename="index.xlsx", product_type="artists_index"
-    )
+    imp = Import(filename="index.xlsx", disk_filename="index.xlsx", product_type="artists_index")
     db.add(imp)
     db.flush()
     artist = IndexArtist(
@@ -81,9 +77,7 @@ def _seed_template(db, config_type="template"):
     r = Ruleset(
         name="Test Template",
         config=cfg,
-        config_hash=hashlib.sha256(
-            json.dumps(cfg, sort_keys=True).encode()
-        ).hexdigest(),
+        config_hash=hashlib.sha256(json.dumps(cfg, sort_keys=True).encode()).hexdigest(),
         config_type=config_type,
         is_builtin=False,
     )
@@ -312,16 +306,12 @@ class TestIndexRoles:
 class TestIndexTemplateRoles:
     def test_viewer_cannot_create(self, client):
         body = {"name": "T", "paragraph_separator": ""}
-        r = client.post(
-            "/index/templates", json=body, headers={"X-User-Role": "viewer"}
-        )
+        r = client.post("/index/templates", json=body, headers={"X-User-Role": "viewer"})
         assert r.status_code == 403
 
     def test_editor_can_create(self, client):
         body = {"name": "T", "paragraph_separator": ""}
-        r = client.post(
-            "/index/templates", json=body, headers={"X-User-Role": "editor"}
-        )
+        r = client.post("/index/templates", json=body, headers={"X-User-Role": "editor"})
         assert r.status_code == 201
 
     def test_editor_cannot_delete(self, client, db_session):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -24,9 +24,7 @@ def _make_ruleset(db, *, name, config_type="template", is_builtin=False, slug=No
     r = Ruleset(
         name=name,
         config=cfg,
-        config_hash=hashlib.sha256(
-            json.dumps(cfg, sort_keys=True).encode()
-        ).hexdigest(),
+        config_hash=hashlib.sha256(json.dumps(cfg, sort_keys=True).encode()).hexdigest(),
         config_type=config_type,
         is_builtin=is_builtin,
         slug=slug,
@@ -356,9 +354,7 @@ def test_resolve_export_config_returns_ruleset_for_valid_id(db_session):
 
 def test_resolve_export_config_ignores_normalisation_rows(db_session):
     """A normalisation row must never be used as a template."""
-    norm = _make_ruleset(
-        db_session, name="global_normalisation", config_type="normalisation"
-    )
+    norm = _make_ruleset(db_session, name="global_normalisation", config_type="normalisation")
     result = resolve_export_config(db_session, ruleset_id=norm.id)
     assert result is None
 

--- a/tests/test_seed_templates.py
+++ b/tests/test_seed_templates.py
@@ -89,9 +89,7 @@ class TestKnownArtistsSeed:
         for i, entry in enumerate(entries):
             first = entry.get("match_first_name")
             last = entry.get("match_last_name")
-            assert (
-                first or last
-            ), f"Entry {i} has neither match_first_name nor match_last_name"
+            assert first or last, f"Entry {i} has neither match_first_name nor match_last_name"
 
     def test_text_fields_are_strings_or_null(self, entries):
         """Text fields must be str or None, never int/bool/list."""
@@ -126,9 +124,7 @@ class TestKnownArtistsSeed:
                 (entry.get("match_last_name") or "").strip().lower(),
                 (entry.get("match_quals") or "").strip().lower(),
             )
-            assert (
-                key not in seen
-            ), f"Duplicate match pattern at entries {seen[key]} and {i}: {key}"
+            assert key not in seen, f"Duplicate match pattern at entries {seen[key]} and {i}: {key}"
             seen[key] = i
 
 
@@ -142,9 +138,7 @@ class TestTemplateSeedFiles:
 
     @pytest.fixture(scope="class")
     def template_files(self):
-        files = [
-            f for f in sorted(SEED_DIR.glob("*.json")) if f.name != "known-artists.json"
-        ]
+        files = [f for f in sorted(SEED_DIR.glob("*.json")) if f.name != "known-artists.json"]
         assert len(files) > 0, "No template seed files found"
         return files
 
@@ -153,9 +147,9 @@ class TestTemplateSeedFiles:
         for f in template_files:
             with open(f, encoding="utf-8") as fp:
                 data = json.load(fp)
-            assert isinstance(
-                data, dict
-            ), f"{f.name} must be a JSON object, got {type(data).__name__}"
+            assert isinstance(data, dict), (
+                f"{f.name} must be a JSON object, got {type(data).__name__}"
+            )
 
     def test_all_have_name(self, template_files):
         """Each template file must have a _name field."""
@@ -200,6 +194,7 @@ class TestTemplateSeedFiles:
 def test_seed_templates_deletes_orphaned_builtins(db_session):
     """Templates marked is_builtin are deleted if no corresponding file exists."""
     from backend.app.services.seed_service import seed_builtin_templates as _seed_builtin_templates
+
     # 1. Create an orphaned built-in template that has no corresponding file
     db_session.add(
         Ruleset(

--- a/tests/test_tagged_text_escape.py
+++ b/tests/test_tagged_text_escape.py
@@ -153,7 +153,9 @@ def test_inline_render_escapes_backslash_in_title():
 def test_inline_render_escapes_artist_and_medium():
     section = _section("s1", "Room", 1)
     work = _work(
-        "s1", 1, 1,
+        "s1",
+        1,
+        1,
         artist_name="A & <B>",
         title="t",
         medium="oil on <canvas>",
@@ -209,20 +211,23 @@ def test_wrapped_title_end_of_first_line_escapes_per_line():
         components=[
             ComponentConfig("work_number", "tab", omit_sep_when_empty=False),
             ComponentConfig(
-                "title", "tab", max_line_chars=22, balance_lines=True,
+                "title",
+                "tab",
+                max_line_chars=22,
+                balance_lines=True,
                 next_component_position="end_of_first_line",
             ),
             ComponentConfig("price", "none", omit_sep_when_empty=False),
         ],
     )
     out = _render_one_work_with_config(
-        "ENTANGLEMENT (200) INTERACTION > INTRA-ACTION", config, price_numeric=2400,
+        "ENTANGLEMENT (200) INTERACTION > INTRA-ACTION",
+        config,
+        price_numeric=2400,
     )
     # Literal ``>`` from the title must never make it to the file body.
     # Allow the ``>`` inside ``<ParaStyle:…>``, ``<CharStyle:…>``, ``<ASCII-MAC>``.
-    assert _has_no_unescaped_gt_in_content(out), (
-        f"unescaped > in body of:\n{out}"
-    )
+    assert _has_no_unescaped_gt_in_content(out), f"unescaped > in body of:\n{out}"
     # And the escape sequence is present.
     assert "\\>" in out
 
@@ -271,18 +276,13 @@ def test_decode_content_strips_inline_tags_but_preserves_escaped_brackets():
     greedily consume the ``<x\\>`` slice and lose the title body. The
     single-pass walker keeps escaped brackets as literals first, then drops
     the inline tag."""
-    assert (
-        _decode_content("Hello \\<world\\> <ccase:upper>X<ccase:>")
-        == "Hello <world> X"
-    )
+    assert _decode_content("Hello \\<world\\> <ccase:upper>X<ccase:>") == "Hello <world> X"
 
 
 def test_decode_content_hex_escape_still_works():
     assert _decode_content("M<0x2019>Coul") == "M’Coul"
     # Hex inside an otherwise-escaped run — the cases compose.
-    assert (
-        _decode_content("\\<a<0x2014>b\\>") == "<a—b>"
-    )
+    assert _decode_content("\\<a<0x2014>b\\>") == "<a—b>"
 
 
 def test_clean_strips_control_chars_after_decoding():
@@ -308,7 +308,10 @@ def test_roundtrip_title_with_metacharacters():
         components=[
             ComponentConfig("work_number", "tab", omit_sep_when_empty=False),
             ComponentConfig(
-                "title", "tab", max_line_chars=22, balance_lines=True,
+                "title",
+                "tab",
+                max_line_chars=22,
+                balance_lines=True,
                 next_component_position="end_of_first_line",
             ),
             ComponentConfig("price", "none", omit_sep_when_empty=False),

--- a/tests/test_title_case.py
+++ b/tests/test_title_case.py
@@ -80,9 +80,7 @@ def test_preserved_tokens_emits_canonical_exception_casing():
 
 
 def test_preserved_tokens_dedupes_within_title():
-    assert title_case_preserved_tokens("WAVE II AND WAVE II") == [
-        ("II", "roman_numeral")
-    ]
+    assert title_case_preserved_tokens("WAVE II AND WAVE II") == [("II", "roman_numeral")]
 
 
 def test_preserved_tokens_empty_for_clean_title():
@@ -105,11 +103,24 @@ def test_preserved_tokens_none_and_empty():
 
 def _raw_work(**kwargs):
     defaults = dict(
-        raw_cat_no="1", raw_gallery="G", raw_title=None, raw_artist=None,
-        raw_price=None, raw_edition=None, raw_artwork=None, raw_medium=None,
-        title=None, title_cased=None, artist_name=None, artist_honorifics=None,
-        price_numeric=None, price_text=None, edition_total=None,
-        edition_price_numeric=None, artwork=None, medium=None,
+        raw_cat_no="1",
+        raw_gallery="G",
+        raw_title=None,
+        raw_artist=None,
+        raw_price=None,
+        raw_edition=None,
+        raw_artwork=None,
+        raw_medium=None,
+        title=None,
+        title_cased=None,
+        artist_name=None,
+        artist_honorifics=None,
+        price_numeric=None,
+        price_text=None,
+        edition_total=None,
+        edition_price_numeric=None,
+        artwork=None,
+        medium=None,
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -141,11 +152,18 @@ def test_normalise_work_title_cased_none_when_no_title():
 
 def _work(**kw):
     d = dict(
-        raw_cat_no="1", title="WHAT DO ANIMALS DREAM OF?",
-        title_cased="What Do Animals Dream Of?", artist_name="A",
-        artist_honorifics=None, price_numeric=None, price_text="*",
-        edition_total=None, edition_price_numeric=None, artwork=None,
-        medium=None, include_in_export=True,
+        raw_cat_no="1",
+        title="WHAT DO ANIMALS DREAM OF?",
+        title_cased="What Do Animals Dream Of?",
+        artist_name="A",
+        artist_honorifics=None,
+        price_numeric=None,
+        price_text="*",
+        edition_total=None,
+        edition_price_numeric=None,
+        artwork=None,
+        medium=None,
+        include_in_export=True,
     )
     d.update(kw)
     return SimpleNamespace(**d)
@@ -153,11 +171,17 @@ def _work(**kw):
 
 def _override(**kw):
     d = dict(
-        title_override=None, title_cased_override=None, artist_name_override=None,
-        artist_honorifics_override=None, price_numeric_override=None,
-        price_text_override=None, edition_total_override=None,
-        edition_price_numeric_override=None, artwork_override=None,
-        medium_override=None, notes=None,
+        title_override=None,
+        title_cased_override=None,
+        artist_name_override=None,
+        artist_honorifics_override=None,
+        price_numeric_override=None,
+        price_text_override=None,
+        edition_total_override=None,
+        edition_price_numeric_override=None,
+        artwork_override=None,
+        medium_override=None,
+        notes=None,
     )
     d.update(kw)
     return SimpleNamespace(**d)
@@ -196,9 +220,13 @@ def _seed_one_work(db):
     db.commit()
     db.refresh(sec)
     work = Work(
-        import_id=imp.id, section_id=sec.id, position_in_section=1,
-        raw_cat_no="1", title="WHAT DO ANIMALS DREAM OF?",
-        title_cased="What Do Animals Dream Of?", artist_name="A",
+        import_id=imp.id,
+        section_id=sec.id,
+        position_in_section=1,
+        raw_cat_no="1",
+        title="WHAT DO ANIMALS DREAM OF?",
+        title_cased="What Do Animals Dream Of?",
+        artist_name="A",
         include_in_export=True,
     )
     db.add(work)

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -110,9 +110,7 @@ class TestListUsers:
         client_mock, tc = mock_cognito
         user = _make_cognito_user("abc-123", "alice@example.com")
         client_mock.list_users.return_value = {"Users": [user]}
-        client_mock.admin_list_groups_for_user.return_value = {
-            "Groups": [{"GroupName": "editor"}]
-        }
+        client_mock.admin_list_groups_for_user.return_value = {"Groups": [{"GroupName": "editor"}]}
 
         r = tc.get("/users")
         assert r.status_code == 200
@@ -166,9 +164,7 @@ class TestCreateUser:
     def test_create_basic_user(self, mock_cognito):
         client_mock, tc = mock_cognito
         client_mock.admin_create_user.return_value = {
-            "User": _make_cognito_user(
-                "abc-123", "new@example.com", status="FORCE_CHANGE_PASSWORD"
-            )
+            "User": _make_cognito_user("abc-123", "new@example.com", status="FORCE_CHANGE_PASSWORD")
         }
         client_mock.admin_add_user_to_group.return_value = {}
 
@@ -210,9 +206,7 @@ class TestCreateUser:
 
     def test_duplicate_user_returns_409(self, mock_cognito):
         client_mock, tc = mock_cognito
-        client_mock.admin_create_user.side_effect = _client_error(
-            "UsernameExistsException"
-        )
+        client_mock.admin_create_user.side_effect = _client_error("UsernameExistsException")
 
         r = tc.post("/users", json={"email": "dup@example.com", "role": "viewer"})
         assert r.status_code == 409
@@ -236,9 +230,7 @@ class TestUpdateUserRole:
     def test_change_role(self, mock_cognito):
         client_mock, tc = mock_cognito
         client_mock.admin_get_user.return_value = _make_cognito_user("u1", "u@e.com")
-        client_mock.admin_list_groups_for_user.return_value = {
-            "Groups": [{"GroupName": "viewer"}]
-        }
+        client_mock.admin_list_groups_for_user.return_value = {"Groups": [{"GroupName": "viewer"}]}
         client_mock.admin_remove_user_from_group.return_value = {}
         client_mock.admin_add_user_to_group.return_value = {}
 
@@ -285,18 +277,14 @@ class TestEnableDisable:
 
     def test_disable_not_found(self, mock_cognito):
         client_mock, tc = mock_cognito
-        client_mock.admin_disable_user.side_effect = _client_error(
-            "UserNotFoundException"
-        )
+        client_mock.admin_disable_user.side_effect = _client_error("UserNotFoundException")
 
         r = tc.post("/users/ghost/disable")
         assert r.status_code == 404
 
     def test_enable_not_found(self, mock_cognito):
         client_mock, tc = mock_cognito
-        client_mock.admin_enable_user.side_effect = _client_error(
-            "UserNotFoundException"
-        )
+        client_mock.admin_enable_user.side_effect = _client_error("UserNotFoundException")
 
         r = tc.post("/users/ghost/enable")
         assert r.status_code == 404
@@ -312,9 +300,7 @@ class TestResetPassword:
         client_mock, tc = mock_cognito
         client_mock.admin_set_user_password.return_value = {}
 
-        r = tc.post(
-            "/users/u1/reset-password", json={"temporary_password": "NewPass12345"}
-        )
+        r = tc.post("/users/u1/reset-password", json={"temporary_password": "NewPass12345"})
         assert r.status_code == 200
         assert r.json()["ok"] is True
         call_kwargs = client_mock.admin_set_user_password.call_args.kwargs
@@ -322,9 +308,7 @@ class TestResetPassword:
 
     def test_reset_password_not_found(self, mock_cognito):
         client_mock, tc = mock_cognito
-        client_mock.admin_set_user_password.side_effect = _client_error(
-            "UserNotFoundException"
-        )
+        client_mock.admin_set_user_password.side_effect = _client_error("UserNotFoundException")
 
         r = tc.post("/users/ghost/reset-password", json={"temporary_password": "X"})
         assert r.status_code == 404

--- a/tests/test_validation_warnings.py
+++ b/tests/test_validation_warnings.py
@@ -255,9 +255,7 @@ def test_warns_title_case_exception_for_curated_token():
 def test_title_case_exception_honours_custom_exceptions():
     # With a custom list that lacks "USA", no exception warning fires.
     work = make_work(title="PORTRAIT OF THE USA")
-    types = [
-        t for t, _ in collect_work_warnings(work, title_case_exceptions=["RA"])
-    ]
+    types = [t for t, _ in collect_work_warnings(work, title_case_exceptions=["RA"])]
     assert "title_case_exception" not in types
 
 

--- a/tests/test_wrap_and_layout.py
+++ b/tests/test_wrap_and_layout.py
@@ -51,9 +51,7 @@ def _section():
     return SimpleNamespace(id="sec1", import_id="imp1", name="Gallery", position=1)
 
 
-def _make_work(
-    title="Test Title", medium="Oil", price_numeric=1000, edition_total=None
-):
+def _make_work(title="Test Title", medium="Oil", price_numeric=1000, edition_total=None):
     return SimpleNamespace(
         id="w1",
         raw_cat_no="1",
@@ -256,9 +254,7 @@ def test_end_of_first_line_multiline_nc_after_first_line():
     assert "WHAT DO ANIMALS" in output or "WHAT DO" in output
     # There should be a soft return (\n) as InDesign line break within the entry
     # (the entry is a single paragraph separated by \r)
-    entry_para = [
-        p for p in output.split("\r") if "<ParaStyle:" in p and "Gallery" not in p
-    ]
+    entry_para = [p for p in output.split("\r") if "<ParaStyle:" in p and "Gallery" not in p]
     assert any("\n" in p for p in entry_para)
 
 
@@ -282,9 +278,7 @@ def test_end_of_first_line_price_before_remaining_title_lines():
     output = render_import_as_tagged_text("imp1", db, config=cfg)
     price_pos = output.index("£999")
     # "ONE TWO THREE" is the first line; remaining title text comes after price
-    first_line_end = output.index(
-        "\t", output.index("ONE")
-    )  # tab = sep after title line 1
+    first_line_end = output.index("\t", output.index("ONE"))  # tab = sep after title line 1
     assert price_pos > first_line_end  # price comes after the tab following line 1
     # And at least part of the remaining title must follow the price
     remaining_start = output.index("\n", first_line_end)
@@ -321,9 +315,7 @@ def test_final_sep_last_component_omitted_adopts_its_separator():
     # After "Artist" there should be no soft-return before the paragraph ends
     artist_idx = entry_para[0].rindex("Artist")
     tail = entry_para[0][artist_idx + len("Artist") :]
-    assert (
-        "\n" not in tail
-    )  # no soft return — artist adopted Edition's separator (none)
+    assert "\n" not in tail  # no soft return — artist adopted Edition's separator (none)
 
 
 def test_final_sep_last_component_present_normal_behaviour():
@@ -343,9 +335,7 @@ def test_final_sep_last_component_present_normal_behaviour():
     assert entry_para
     artist_idx = entry_para[0].rindex("Artist")
     tail = entry_para[0][artist_idx + len("Artist") :]
-    assert (
-        "\n" in tail
-    )  # soft return is still there (raw \n before escape_for_mac_roman)
+    assert "\n" in tail  # soft return is still there (raw \n before escape_for_mac_roman)
 
 
 def test_final_sep_disabled_no_change():


### PR DESCRIPTION
One-shot mechanical sweep produced by:

```bash
ruff format backend/ tests/
```

**65 files reformatted, 27 already formatted, net −127 lines.** No semantic changes; every diff is one of:

- implicit string-concatenation collapsed to a single string
- multi-line function call collapsed onto one line where it fits
- trailing-comma additions or removals per PEP 8 + Ruff defaults
- string-quote normalisation (`"` preferred)
- whitespace inside/around braces and brackets

## Review guidance

Don't try to read the diff line-by-line — that's not where the value is. Instead:

1. Trust that `ruff format` is deterministic.
2. Confirm CI's `lint` and `test` jobs both pass on this PR.
3. Optionally spot-check 2–3 files of interest and confirm the changes look like reformatting only.

## Verified locally

| Check | Result |
|---|---|
| `ruff format --check backend/ tests/` | **92 files already formatted** (idempotent — re-running produces no further changes) |
| `ruff check backend/ tests/` | clean |
| `pytest tests/` | **965 passed** in 17s (no change from main) |

## Follow-up worth noting

The pre-commit and CI configs do **not** yet enforce `ruff format` — they only run `ruff check`. With the codebase now in canonical form, enabling enforcement is a tiny follow-up PR: uncomment the `ruff-format` hook in `.pre-commit-config.yaml` (currently a TODO comment in the config), and add `ruff format --check` to the lint job in `.github/workflows/ci.yml`. Happy to do that as a separate PR right after this lands if you want; without it, the codebase will drift back to mixed formatting.