### PR TITLE
Enforce ruff format in pre-commit + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Ruff check
         run: ruff check backend/ tests/
 
+      - name: Ruff format (check only)
+        run: ruff format --check backend/ tests/
+
   # ── 2. Unit tests (all branches + PRs) ─────────────────────────────
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-      # `ruff-format` is intentionally NOT enabled yet — running it once would
-      # produce a sweeping diff across the whole codebase. Enable in a
-      # dedicated PR when ready.
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
Tiny follow-up to PR #83. Now that the codebase is in ruff format's canonical form, switch enforcement on so it doesn't silently drift back.

## Changes

### `.pre-commit-config.yaml`
Uncomment the `ruff-format` hook that was left as a TODO when the lint baseline (#77) was set up. Anyone with pre-commit installed now gets format-on-commit alongside lint-on-commit.

### `.github/workflows/ci.yml`
Add `ruff format --check` as a step in the existing lint job. Fails the build if any file isn't in canonical form. Cheap (sub-second) and shares the same ruff install step — no new install layer.

## Verification

```
$ ruff format --check backend/ tests/
92 files already formatted
```

The new CI step will pass on first run because #83 put everything into canonical form. From now on, anyone editing files in this repo either runs ruff format locally (pre-commit handles it automatically if installed) or sees CI fail.