### PR TITLE
Pack 02a: migrate LoW row flags to pill intents (fixes RA inversion)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4429,11 +4429,14 @@ function _lowWarnLabel(type) {
   return _LOW_WARNING_LABELS[type] || type;
 }
 
-// Badge colour for a LoW warning type: red (high) / blue (benign change) / yellow (review).
+// Pill intent for a LoW warning type — Pack 02a (2026-05-29), keyed to the
+// Pack 01 token layer: error (high) / info (benign auto-change) / review
+// (needs human). Propagates to row-level flag pills AND to the Import-notes
+// chips (both call this), so the same change re-skins both surfaces.
 function _lowWarnBadgeClass(type) {
-  if (_LOW_HIGH_SEVERITY_TYPES.has(type)) return 'badge-removed';
-  if (_LOW_CHANGED_TYPES.has(type)) return 'badge-info';
-  return 'badge-warning';
+  if (_LOW_HIGH_SEVERITY_TYPES.has(type)) return 'pill pill--error';
+  if (_LOW_CHANGED_TYPES.has(type))       return 'pill pill--info';
+  return 'pill pill--review';
 }
 
 // Shared "Import notes" panel renderer \u2014 used by both the LoW and Index
@@ -4856,7 +4859,7 @@ function _workNormReasons(w) {
 function _workNormBadges(w) {
   const reasons = _workNormReasons(w);
   if (!reasons.length) return '';
-  return `<div class="norm-reasons"><strong>Normalised:</strong> <span class="badge badge-normalised" title="${esc(reasons.join('; '))}">${esc(reasons.join('; '))}</span></div>`;
+  return `<div class="norm-reasons"><strong>Normalised:</strong> <span class="pill pill--info" title="${esc(reasons.join('; '))}">${esc(reasons.join('; '))}</span></div>`;
 }
 
 // Warning types whose .message carries useful detail to show inline
@@ -4868,7 +4871,7 @@ function _workWarningsBadges(workId) {
   const warns = (_warningsByWorkId[workId] || []).filter(w => !_LOW_CHANGED_TYPES.has(w.warning_type));
   if (!warns.length) return '';
   const badges = warns.map(w => {
-    return `<span class="badge ${_lowWarnBadgeClass(w.warning_type)}" title="${esc(w.message)}">${esc(_lowWarnLabel(w.warning_type))}</span>`;
+    return `<span class="${_lowWarnBadgeClass(w.warning_type)}" title="${esc(w.message)}">${esc(_lowWarnLabel(w.warning_type))}</span>`;
   }).join(' ');
   // Collect detailed explanations for warning types that benefit from inline detail
   const details = warns
@@ -4942,7 +4945,7 @@ function workRowHTML(importId, w, cfg) {
 
   // Build flags
   const flags = [];
-  if (hasOverride) flags.push('<span class="badge badge-override" title="Has a user override">Override</span>');
+  if (hasOverride) flags.push('<span class="pill pill--edit" title="Has a user override">Override</span>');
   // Normalisation detection: compare raw vs normalised fields
   const _normDiffs = [];
   const _wsTrimmed = [];
@@ -4969,9 +4972,9 @@ function workRowHTML(importId, w, cfg) {
   // Show RA badge when honorifics contain RA-type tokens
   if (_hon) {
     if (_isRaMember(_hon)) {
-      flags.push('<span class="badge badge-ra" title="RA honorific extracted from artist name">RA</span>');
+      flags.push('<span class="pill pill--id is-ra" title="RA honorific extracted from artist name">RA</span>');
     } else {
-      flags.push(`<span class="badge badge-normalised" title="Honorific extracted: ${esc(_hon)}">${esc(_hon)}</span>`);
+      flags.push(`<span class="pill pill--info" title="Honorific extracted: ${esc(_hon)}">${esc(_hon)}</span>`);
     }
   }
   const _rawAFull = w.raw_artist ?? '';
@@ -4988,14 +4991,14 @@ function workRowHTML(importId, w, cfg) {
       }
     }
   }
-  if (_wsTrimmed.length) flags.push(`<span class="badge badge-info" title="Whitespace trimmed: ${esc(_wsTrimmed.join(', '))}">${esc('Trimmed')}</span>`);
-  if (_normDiffs.length) flags.push(`<span class="badge badge-normalised" title="Normalised: ${esc(_normDiffs.join(', '))}">${esc('Norm')}</span>`);
+  if (_wsTrimmed.length) flags.push(`<span class="pill pill--info" title="Whitespace trimmed: ${esc(_wsTrimmed.join(', '))}">${esc('Trimmed')}</span>`);
+  if (_normDiffs.length) flags.push(`<span class="pill pill--info" title="Normalised: ${esc(_normDiffs.join(', '))}">${esc('Norm')}</span>`);
   // Warnings from the per-work lookup (exclude "changed" types — those are normalisations)
   const wWarns = _warningsByWorkId[w.id];
   if (wWarns && wWarns.length) {
     const warnTypes = [...new Set(wWarns.filter(ww => !_LOW_CHANGED_TYPES.has(ww.warning_type)).map(ww => ww.warning_type))];
     for (const wt of warnTypes) {
-      flags.push(`<span class="badge ${_lowWarnBadgeClass(wt)}" title="${esc(wWarns.find(ww => ww.warning_type === wt)?.message ?? wt)}">${esc(_lowWarnLabel(wt))}</span>`);
+      flags.push(`<span class="${_lowWarnBadgeClass(wt)}" title="${esc(wWarns.find(ww => ww.warning_type === wt)?.message ?? wt)}">${esc(_lowWarnLabel(wt))}</span>`);
     }
   }
 


### PR DESCRIPTION
Second step of the May 2026 system-wide design refresh (`Handoff - Systemwide 2026/`, Pack 02a). Depends on Pack 01 (#85) — uses the `.pill`/`.pill--*` classes added there. **Fixes the RA inversion**: RA stops being the loudest pill in a LoW row (was solid brand-red for neutral metadata) and becomes a quiet red-outline identity pill, so genuine warnings can read at correct priority.

## What changes

`frontend/app.js` only — 15 insertions / 12 deletions, no CSS changes (brief-faithful — the styles arrived in Pack 01).

| Site | Was | Now |
|---|---|---|
| `_lowWarnBadgeClass` (4436) | `badge-removed`/`badge-info`/`badge-warning` | `pill pill--error`/`pill--info`/`pill--review` |
| `_workNormBadges` (4862) | `badge badge-normalised` | `pill pill--info` |
| `_workWarningsBadges` (4874) | `badge ${cls}` | `${cls}` (cls now carries `pill`) |
| `workRowHTML` Override (4948) | `badge badge-override` | `pill pill--edit` |
| `workRowHTML` RA (4975) | `badge badge-ra` | `pill pill--id is-ra` — **no dot, quiet red outline** |
| `workRowHTML` honorific (4977) | `badge badge-normalised` | `pill pill--info` |
| `workRowHTML` Trimmed / Norm (4994/4995) | `badge badge-info` / `badge-normalised` | `pill pill--info` (both) |
| `workRowHTML` per-work warning (5001) | `badge ${cls}` | `${cls}` |

The Import-notes panel chips (rendered through the shared `_renderImportNotesPanel`) automatically inherit the new palette via the `_lowWarnBadgeClass` callback. The chip template retains its `badge` prefix for Index compatibility until Pack 02b; `.pill--*` rules cascade-win on LoW chips with no visual regression.

## Verification

| Check | Result |
|---|---|
| `pytest tests/ -q` | 965 passed |
| `ruff check backend/ tests/` | clean |
| Pack 01 + 02a CSS alive on localhost | `fetch('/ui/style.css').then(t => t.includes('--pill-info-bg'))` → `true` |
| API populated | 2 LoW imports, 2 Index imports (manual upload of `Catalogue List 2025_260527.xlsx`) |
| Visual QA — RA quiet red outline (no fill, no dot) | ✓ |
| Visual QA — Trimmed/Norm/honorific uniform calm teal | ✓ |
| Visual QA — Review-type warnings amber | ✓ |
| Visual QA — Import-notes chips re-skinned, click+Alt-click handlers intact, count divider intact, muted state intact, detail table re-skinned | ✓ |
| Visual QA — Index, Compare, Audit log, Tools panel unchanged | ✓ |
| Visual QA — Error-type pill (`edition_suppressed_no_price`) and Export-diff viewer | ⓘ not testable in current imports / no recon snapshot available; deferred |
| Visual QA — Override pill | ⓘ deferred to Pack 04 QA (no `work_overrides` rows in current import) |

## Known minor regression — flagged for Pack 05b

Chip hover-deepen lost on LoW. The existing `.badge-info.warning-filter-btn:hover` and `.badge-warning.warning-filter-btn:hover` rules (style.css ~1110–1111) only match elements carrying `.badge-info`/`.badge-warning`. LoW chips now carry `.pill--info`/`.pill--review`/`.pill--error` instead, so the hover-deepen vanishes. Subtle — only visible on mouseover. Added to the Pack 05b task as carry-over so equivalent hover rules for `.pill--*.warning-filter-btn:hover` get added when the token sweep lands. Index chips will be affected too after Pack 02b.

## What's NOT in this PR

- Index row markup migration — Pack 02b (`index-row-pills`)
- Compare match ramp + summary collapse — Pack 02c (`compare-match-ramp`)
- Sticky markup — Pack 03
- Drawer + output preview — Pack 04 (a/b/c)
- Orphan badge deletion — Pack 05a
- Chip hover rules for pill-styled chips — Pack 05b