### PR TITLE
Pack 02b: migrate Index row flags to pill intents (+ clean Company-toggle port)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6156,7 +6156,7 @@ function _idxWarningsBadges(artistId) {
   const warns = (_idxWarningsByArtistId[artistId] || []).filter(w => !_IDX_CHANGED_TYPES.has(w.warning_type));
   if (!warns.length) return '';
   const badges = warns.map(w => {
-    return `<span class="badge badge-warning" title="${esc(w.message)}">${esc(_idxWarnLabel(w.warning_type))}</span>`;
+    return `<span class="pill pill--review" title="${esc(w.message)}">${esc(_idxWarnLabel(w.warning_type))}</span>`;
   }).join(' ');
   // Collect detailed explanations for warning types that benefit from inline detail
   const details = warns
@@ -6173,7 +6173,7 @@ function _buildIndexWarningsPanel() {
     container: document.getElementById('index-warnings-panel'),
     warnings: _indexWarningsAll,
     labelOf: _idxWarnLabel,
-    badgeClassOf: (t) => _IDX_CHANGED_TYPES.has(t) ? 'badge-info' : 'badge-warning',
+    badgeClassOf: (t) => _IDX_CHANGED_TYPES.has(t) ? 'pill pill--info' : 'pill pill--review',
     isChanged: (t) => _IDX_CHANGED_TYPES.has(t),
     isHigh: () => false,  // Index has no high-severity warning tier
     getHidden: () => _hiddenIndexWarningTypes,
@@ -6762,22 +6762,22 @@ function indexArtistRowHTML(importId, a, groupColor, sortKeyNames) {
   const groupTitle = groupColor && sortKeyNames
     ? `Linked entries (same sort position): ${(sortKeyNames[a.sort_key || ''] || []).join(', ')}` : '';
   const badges = [];
-  if (a.is_ra_member) badges.push('<span class="badge badge-ra">RA</span>');
+  if (a.is_ra_member) badges.push('<span class="pill pill--id is-ra">RA</span>');
   const isCompanyOverridden = a.is_company !== a.is_company_auto;
   if (a.is_company) {
-    badges.push(`<span class="badge badge-company${isCompanyOverridden ? ' badge-overridden' : ''}" title="${isCompanyOverridden ? 'Company (manual override)' : 'Company'}">Company</span>`);
+    badges.push(`<span class="pill pill--id${isCompanyOverridden ? ' pill--id--overridden' : ''}" title="${isCompanyOverridden ? 'Company (manual override)' : 'Company'}">Company</span>`);
   } else if (isCompanyOverridden) {
-    badges.push(`<span class="badge badge-company-off badge-overridden" title="Not company (manual override)">Not Company</span>`);
+    badges.push(`<span class="pill pill--id pill--id--dashed pill--id--overridden" title="Not company (manual override)">Not Company</span>`);
   }
 
   // Detect normalisation changes and build human-readable reasons
   const normReasons = _normReasons(a);
   const hasNorm = normReasons.length > 0;
-  if (hasNorm) badges.push(`<span class="badge badge-normalised" title="${esc(normReasons.join('; '))}">Norm</span>`);
-  if (a.has_known_artist) badges.push('<span class="badge badge-known" title="Matched a Known Artist rule">Known</span>');
-  if (a.has_override) badges.push('<span class="badge badge-override" title="Has a user override">Override</span>');
+  if (hasNorm) badges.push(`<span class="pill pill--info" title="${esc(normReasons.join('; '))}">Norm</span>`);
+  if (a.has_known_artist) badges.push('<span class="pill pill--id" title="Matched a Known Artist rule">Known</span>');
+  if (a.has_override) badges.push('<span class="pill pill--edit" title="Has a user override">Override</span>');
   if (a.merged_from_rows && a.merged_from_rows.length > 1) {
-    badges.push(`<span class="badge badge-merged" title="Merged from spreadsheet rows ${a.merged_from_rows.join(', ')}">Merged</span>`);
+    badges.push(`<span class="pill pill--edit" title="Merged from spreadsheet rows ${a.merged_from_rows.join(', ')}">Merged</span>`);
   }
 
   // Per-artist server-side validation warnings (exclude "changed" types — those are normalisations)
@@ -6785,7 +6785,7 @@ function indexArtistRowHTML(importId, a, groupColor, sortKeyNames) {
   if (aWarns && aWarns.length) {
     const warnTypes = [...new Set(aWarns.filter(ww => !_IDX_CHANGED_TYPES.has(ww.warning_type)).map(ww => ww.warning_type))];
     for (const wt of warnTypes) {
-      badges.push(`<span class="badge badge-warning" title="${esc(aWarns.find(ww => ww.warning_type === wt)?.message ?? wt)}">${esc(_idxWarnLabel(wt))}</span>`);
+      badges.push(`<span class="pill pill--review" title="${esc(aWarns.find(ww => ww.warning_type === wt)?.message ?? wt)}">${esc(_idxWarnLabel(wt))}</span>`);
     }
   }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1234,6 +1234,8 @@ details.section-block[open] > .section-summary::before {
 .pill--id { background:var(--pill-id-bg); border-color:var(--pill-id-bd); color:var(--pill-id-fg);
   font-size:10.5px; text-transform:uppercase; letter-spacing:.04em; font-weight:700; }
 .pill--id.is-ra { color:var(--ra-red); border-color:#e0b8b2; }   /* quiet brand nod — NO dot */
+.pill--id--dashed { border-style:dashed; opacity:.85; }            /* "Not Company" — dashed border, slightly muted */
+.pill--id--overridden { box-shadow:0 0 0 2px var(--ra-red); }      /* Manually-overridden toggle state — red ring (was .badge-overridden) */
 
 /* Compare ordinal match ramp */
 .mp { display:inline-flex; align-items:center; gap:6px; font-size:12px; font-weight:600;


### PR DESCRIPTION
Third step of the May 2026 system-wide design refresh (`Handoff - Systemwide 2026/`, Pack 02b). Migrates the Artists Index row-level flags and Import-notes chips to the intent-keyed pill system (Pack 01 #85), and **clean-ports** the Company-toggle visual states. Builds on Pack 02a (#86, which did the same for List of Works).

Branched off main BEFORE Pack 02a merged — line ranges are non-overlapping (LoW code paths in 02a vs Index code paths here), so the merge is conflict-free.

## What changes

`frontend/app.js` (10 sites in the Index code path, lines ~6155–6790) + 2 CSS modifier rules.

### Row pills (`indexArtistRowHTML`)

| Field | Was | Now |
|---|---|---|
| RA | `badge badge-ra` | `pill pill--id is-ra` — quiet red identity |
| Company | `badge badge-company` (+ `badge-overridden` when overridden) | `pill pill--id` (+ `pill--id--overridden` when overridden) |
| Not Company | `badge badge-company-off badge-overridden` (only renders when overridden) | `pill pill--id pill--id--dashed pill--id--overridden` |
| Norm | `badge badge-normalised` | `pill pill--info` |
| Known | `badge badge-known` | `pill pill--id` |
| Override | `badge badge-override` | `pill pill--edit` |
| Merged | `badge badge-merged` | `pill pill--edit` |
| Per-artist warning | `badge badge-warning` | `pill pill--review` |

### Import-notes panel + warnings detail

`_buildIndexWarningsPanel`'s `badgeClassOf` callback now returns `'pill pill--info'` / `'pill pill--review'` (was `'badge-info'` / `'badge-warning'`). This propagates through the shared `_renderImportNotesPanel` to both Index chips and the warnings-detail table — they automatically pick up the new palette.

`_idxWarningsBadges` (the per-artist inline warning row used in some surfaces) — span class swapped to `pill pill--review`.

### CSS (style.css ~1237–1238)

Two minimal modifier rules added inside the Pack 01 pill block:

```css
.pill--id--dashed { border-style:dashed; opacity:.85; }            /* \"Not Company\" — dashed border, slightly muted */
.pill--id--overridden { box-shadow:0 0 0 2px var(--ra-red); }      /* Manually-overridden toggle state — red ring */
```

These port the `.badge-company-off` dashed border + `.badge-overridden` ring directly into the pill system. Both are minimal, composable, and reusable.

## Decision recorded: clean port (not class-alongside)

The brief offered two paths for the Company toggle: keep `badge-company-off` alongside `pill--id`, or fully port the dashed border into a `pill--id--dashed` variant. Decided 2026-05-29: **clean port**. This means **Pack 05a can fully delete `.badge-company*`, `.badge-toggle`, `.badge-overridden`** — they no longer have row-level callers.

## Verification

| Check | Result |
|---|---|
| `pytest tests/ -q` | 965 passed |
| `ruff check backend/ tests/` | clean |
| `fetch('/ui/style.css').then(t => t.includes('.pill--id--dashed'))` | `true` ✓ |
| `docker compose up -d --build app` rebuild | container healthy |
| **Data preserved across rebuild** | 2 LoW imports + 2 Index imports still present ✓ (memory contract held — `up -d --build app` is the non-destructive pattern) |
| Visual QA — RA quiet red outline | ✓ |
| Visual QA — Company / Not Company / Known quiet identity | ✓ |
| Visual QA — Norm calm teal | ✓ |
| Visual QA — Override / Merged slate | ✓ partial (Override testable, no Merged in data — but they share `pill--edit`) |
| Visual QA — Per-artist warnings amber | ✓ |
| Visual QA — Import-notes chips re-skinned, handlers + count divider + muted state intact | ✓ |
| Visual QA — LoW / Compare / Diff viewer / Audit / Tools unchanged | ✓ |

## What's NOT in this PR

- Shared `_renderImportNotesPanel` chip template + warnings-detail-table row still carry the `badge` prefix — intentional cascade-compatibility cushion. Pack 05a removes it.
- Chip hover rules for pill-styled intents — Pack 05b (the known hover-deepen regression now applies on both LoW and Index).
- `.badge-company*`, `.badge-toggle`, `.badge-overridden` deletion — Pack 05a.
- Compare match ramp + summary collapse — Pack 02c.
- Sticky markup — Pack 03.
- Drawer + output preview — Pack 04 (a/b/c).