### PR TITLE
Pack 03: opt-in sticky for LoW galleries + Index letters

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4646,6 +4646,29 @@ function _applyWorksFilter(query, countEl, totalWorks) {
   }
 }
 
+/* Pack 03 (2026-05-29) — wire IntersectionObserver-based 'is-stuck' shadow
+   on every .section-block--sticky in the document. Idempotent via the
+   dataset.stickyWired guard, so safe to call after every renderSections /
+   renderIndexArtists. The sentinel sits 1px above the section-block; when
+   it scrolls out of the viewport the summary is "stuck". Audit log + Tools
+   panel use the bare .section-block (no --sticky modifier), so they're
+   provably unaffected by this whole mechanism. */
+function _wireStickySections() {
+  document.querySelectorAll('.section-block--sticky').forEach(block => {
+    const summary = block.querySelector('.section-summary');
+    if (!summary || summary.dataset.stickyWired) return;
+    summary.dataset.stickyWired = '1';
+    const sentinel = document.createElement('div');
+    sentinel.style.cssText = 'position:absolute;top:-1px;height:1px;width:1px;';
+    block.style.position = 'relative';
+    block.prepend(sentinel);
+    new IntersectionObserver(
+      ([e]) => summary.classList.toggle('is-stuck', e.intersectionRatio === 0),
+      { threshold: [0, 1] }
+    ).observe(sentinel);
+  });
+}
+
 function renderSections(importId, sections, cfg) {
   _currentLowImportId = importId;
   const container = document.getElementById('sections-container');
@@ -4684,7 +4707,7 @@ function renderSections(importId, sections, cfg) {
         : ` | numbers ${min}\u2013${max}`;  // en-dash for numeric ranges
     }
     return `
-    <details class="section-block" open>
+    <details class="section-block section-block--sticky" open>
       <summary class="section-summary">
         <span class="section-name">${esc(section.name)}</span>
         <span class="section-meta">${section.works.length} work${section.works.length !== 1 ? 's' : ''}${rangeText}</span>
@@ -4711,6 +4734,7 @@ function renderSections(importId, sections, cfg) {
       </table>
     </details>`;
   }).join('');
+  _wireStickySections();
 }
 
 // ---------------------------------------------------------------------------
@@ -6300,7 +6324,7 @@ function renderIndexArtists(importId, artists) {
   container.innerHTML = letterGroups.map(g => {
     const rows = g.artists.map(a => indexArtistRowHTML(importId, a, sortKeyColor[a.sort_key || ''], sortKeyNames)).join('');
     return `
-    <details class="section-block" open>
+    <details class="section-block section-block--sticky" open>
       <summary class="section-summary">
         <span class="section-name">${esc(g.letter)}</span>
         <span class="section-meta">${g.artists.length} artist${g.artists.length !== 1 ? 's' : ''}</span>
@@ -6315,6 +6339,7 @@ function renderIndexArtists(importId, artists) {
       </table>
     </details>`;
   }).join('');
+  _wireStickySections();
 }
 
 /**

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4673,6 +4673,13 @@ function _wireStickySections() {
     const summary = block.querySelector('.section-summary');
     if (!summary || summary.dataset.stickyWired) return;
     summary.dataset.stickyWired = '1';
+    // Mark blocks that have a data-table thead beneath, so CSS can move
+    // the stuck-shadow from the summary down to the bottom of the column
+    // header. Avoids :has() in CSS (browser support history is uneven)
+    // and lets one JS pass set up everything.
+    if (block.querySelector('.data-table thead')) {
+      block.classList.add('has-sticky-thead');
+    }
     const sentinel = document.createElement('div');
     sentinel.style.cssText = 'position:absolute;top:-1px;height:1px;width:1px;';
     block.style.position = 'relative';

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4654,13 +4654,20 @@ function _applyWorksFilter(query, countEl, totalWorks) {
    panel use the bare .section-block (no --sticky modifier), so they're
    provably unaffected by this whole mechanism. */
 function _wireStickySections() {
-  // Measure the rendered .site-header height and expose it as --site-header-h
-  // so the sticky summary + works-table thead can anchor BELOW the page
-  // header instead of sliding under it. Idempotent — safe to re-run.
+  // Measure the rendered .site-header height + a sample .section-summary
+  // height and expose them as CSS variables (--site-header-h and
+  // --low-summary-h). The two sticky CSS rules use these to anchor the
+  // summary below the page header and the works-table thead directly
+  // below the summary — no gap, no overlap. Idempotent — safe to re-run.
   const siteHeader = document.querySelector('.site-header');
   if (siteHeader) {
     const h = Math.ceil(siteHeader.getBoundingClientRect().height);
     document.documentElement.style.setProperty('--site-header-h', h + 'px');
+  }
+  const sampleSummary = document.querySelector('.section-block--sticky > .section-summary');
+  if (sampleSummary) {
+    const sh = Math.ceil(sampleSummary.getBoundingClientRect().height);
+    document.documentElement.style.setProperty('--low-summary-h', sh + 'px');
   }
   document.querySelectorAll('.section-block--sticky').forEach(block => {
     const summary = block.querySelector('.section-summary');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4654,6 +4654,14 @@ function _applyWorksFilter(query, countEl, totalWorks) {
    panel use the bare .section-block (no --sticky modifier), so they're
    provably unaffected by this whole mechanism. */
 function _wireStickySections() {
+  // Measure the rendered .site-header height and expose it as --site-header-h
+  // so the sticky summary + works-table thead can anchor BELOW the page
+  // header instead of sliding under it. Idempotent — safe to re-run.
+  const siteHeader = document.querySelector('.site-header');
+  if (siteHeader) {
+    const h = Math.ceil(siteHeader.getBoundingClientRect().height);
+    document.documentElement.style.setProperty('--site-header-h', h + 'px');
+  }
   document.querySelectorAll('.section-block--sticky').forEach(block => {
     const summary = block.querySelector('.section-summary');
     if (!summary || summary.dataset.stickyWired) return;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4684,10 +4684,16 @@ function _wireStickySections() {
     sentinel.style.cssText = 'position:absolute;top:-1px;height:1px;width:1px;';
     block.style.position = 'relative';
     block.prepend(sentinel);
-    new IntersectionObserver(
+    // Retain the IntersectionObserver explicitly. Some browsers GC'd it when
+    // it had no JS reference, even though it still had an active observation
+    // — symptom: the .is-stuck class never gets toggled. Storing it on the
+    // sentinel keeps it alive as long as the sentinel is in the DOM.
+    const io = new IntersectionObserver(
       ([e]) => summary.classList.toggle('is-stuck', e.intersectionRatio === 0),
       { threshold: [0, 1] }
-    ).observe(sentinel);
+    );
+    sentinel._io = io;
+    io.observe(sentinel);
   });
 }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1250,14 +1250,15 @@ details.section-block[open] > .section-summary::before {
 
 /* Opt-in sticky section (applied per page in Pack 03 — never on bare .section-block).
    Audit log + Tools keep the base class and are provably unaffected. */
-.section-block--sticky > .section-summary { position:sticky; top:0; z-index:20; background:var(--bg); }
+.section-block--sticky > .section-summary { position:sticky; top:var(--site-header-h,0); z-index:20; background:var(--bg); }
 .section-block--sticky > .section-summary.is-stuck { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
 /* Pin the works-table column header below the sticky summary so column meaning
-   survives the scroll. Pack 03 (2026-05-29). --low-summary-h is the rendered
-   summary height; defaults to 42px which fits the current section-summary. */
+   survives the scroll. Pack 03 (2026-05-29). --site-header-h is measured
+   at runtime by _wireStickySections; --low-summary-h defaults to 42px,
+   which fits the current section-summary rendered height. */
 .section-block--sticky .works-table thead th {
   position: sticky;
-  top: var(--low-summary-h, 42px);
+  top: calc(var(--site-header-h, 0px) + var(--low-summary-h, 42px));
   background: var(--card);
   z-index: 15;
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1251,27 +1251,32 @@ details.section-block[open] > .section-summary::before {
 /* Opt-in sticky section (applied per page in Pack 03 — never on bare .section-block).
    Audit log + Tools keep the base class and are provably unaffected. */
 .section-block--sticky > .section-summary { position:sticky; top:var(--site-header-h,0); z-index:20; background:var(--bg); }
-/* Default stuck-shadow: on the summary itself. Index letter groups stop here
-   (no sticky thead beneath), so the shadow sits at the bottom of their
-   pinned stack — the summary IS the stack. */
+/* Default stuck-shadow: on the summary itself. Applies whenever the block
+   has no sticky data-table thead beneath (e.g., a hypothetical sticky
+   section with no table). The .has-sticky-thead marker (set in JS at
+   wiring time) overrides this to move the shadow to the thead. */
 .section-block--sticky > .section-summary.is-stuck { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
-/* Pin the works-table column header below the sticky summary so column meaning
-   survives the scroll. Pack 03 (2026-05-29). --site-header-h is measured
-   at runtime by _wireStickySections; --low-summary-h is also measured at
-   runtime so the thead lands directly below the summary, no gap. */
-.section-block--sticky .works-table thead th {
+/* Pin the table column header below the sticky summary so column meaning
+   survives the scroll. Pack 03 (2026-05-29). Applies to any .data-table
+   inside a sticky block — covers LoW .works-table AND Index .index-table.
+   --site-header-h and --low-summary-h are measured at runtime by
+   _wireStickySections. The -1px is a deliberate 1px overlap with the
+   summary's bottom edge to defeat sub-pixel rounding gaps where scrolling
+   content would otherwise bleed through. */
+.section-block--sticky .data-table thead th {
   position: sticky;
-  top: calc(var(--site-header-h, 0px) + var(--low-summary-h, 42px));
+  top: calc(var(--site-header-h, 0px) + var(--low-summary-h, 42px) - 1px);
   background: var(--card);
   z-index: 15;
 }
-/* Pack 03 (2026-05-29) — when the section has a sticky works-table thead
+/* Pack 03 (2026-05-29) — when the section has a sticky data-table thead
    beneath the summary, the shadow moves DOWN to the bottom of the column
    header. The summary + thead are functionally one pinned header block
    while stuck; the shadow should sit below the whole block, not between
-   the two halves. */
-.section-block--sticky:has(.works-table) > .section-summary.is-stuck { box-shadow:none; }
-.section-summary.is-stuck ~ .works-table thead th { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
+   the two halves. JS adds .has-sticky-thead to qualifying blocks at
+   wiring time. */
+.section-block--sticky.has-sticky-thead > .section-summary.is-stuck { box-shadow:none; }
+.section-block--sticky.has-sticky-thead .section-summary.is-stuck ~ .data-table thead th { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
 
 /* Audit log */
 .audit-table .col-ts { width: 140px; font-size: 12px; }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1251,17 +1251,27 @@ details.section-block[open] > .section-summary::before {
 /* Opt-in sticky section (applied per page in Pack 03 — never on bare .section-block).
    Audit log + Tools keep the base class and are provably unaffected. */
 .section-block--sticky > .section-summary { position:sticky; top:var(--site-header-h,0); z-index:20; background:var(--bg); }
+/* Default stuck-shadow: on the summary itself. Index letter groups stop here
+   (no sticky thead beneath), so the shadow sits at the bottom of their
+   pinned stack — the summary IS the stack. */
 .section-block--sticky > .section-summary.is-stuck { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
 /* Pin the works-table column header below the sticky summary so column meaning
    survives the scroll. Pack 03 (2026-05-29). --site-header-h is measured
-   at runtime by _wireStickySections; --low-summary-h defaults to 42px,
-   which fits the current section-summary rendered height. */
+   at runtime by _wireStickySections; --low-summary-h is also measured at
+   runtime so the thead lands directly below the summary, no gap. */
 .section-block--sticky .works-table thead th {
   position: sticky;
   top: calc(var(--site-header-h, 0px) + var(--low-summary-h, 42px));
   background: var(--card);
   z-index: 15;
 }
+/* Pack 03 (2026-05-29) — when the section has a sticky works-table thead
+   beneath the summary, the shadow moves DOWN to the bottom of the column
+   header. The summary + thead are functionally one pinned header block
+   while stuck; the shadow should sit below the whole block, not between
+   the two halves. */
+.section-block--sticky:has(.works-table) > .section-summary.is-stuck { box-shadow:none; }
+.section-summary.is-stuck ~ .works-table thead th { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
 
 /* Audit log */
 .audit-table .col-ts { width: 140px; font-size: 12px; }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1252,6 +1252,15 @@ details.section-block[open] > .section-summary::before {
    Audit log + Tools keep the base class and are provably unaffected. */
 .section-block--sticky > .section-summary { position:sticky; top:0; z-index:20; background:var(--bg); }
 .section-block--sticky > .section-summary.is-stuck { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
+/* Pin the works-table column header below the sticky summary so column meaning
+   survives the scroll. Pack 03 (2026-05-29). --low-summary-h is the rendered
+   summary height; defaults to 42px which fits the current section-summary. */
+.section-block--sticky .works-table thead th {
+  position: sticky;
+  top: var(--low-summary-h, 42px);
+  background: var(--card);
+  z-index: 15;
+}
 
 /* Audit log */
 .audit-table .col-ts { width: 140px; font-size: 12px; }


### PR DESCRIPTION
Fifth step of the May 2026 design refresh (`Handoff - Systemwide 2026/`, Pack 03). Pins the gallery summary on List of Works and the letter-group summary on Artists Index when scrolling within them, so the section name and the column header stay visible. **Audit log + Tools panel are explicitly untouched** — they use the bare `.section-block` (or `.panel`) class and inherit no sticky behaviour from this pack.

> ⚡ Opened while visual QA runs in parallel. CI runs ahead of merge readiness. If a finding lands (most likely candidate: the `.site-header` overlap at item 5 of the QA list), a fixup commit will follow.

## Why opt-in via modifier class

`.section-block` is shared across **four** surfaces today (per [frontend-class-blast-map](.claude/projects/-Users-luke-hoyland-Code-Other-GitHub-RA-SummerExhibition-ListOfWorks/memory/frontend_class_blast_map.md)): LoW galleries, Index letter groups, Audit log, Tools panel. An earlier attempt that made `.section-summary` sticky globally would have made all four sticky at once. The fix is **opt-in**: a `.section-block--sticky` modifier added only at the two render sites that want it.

Pack 01 (#85) added the scaffold (`.section-block--sticky > .section-summary`). This pack flips it on at the two surfaces and adds the column-header pin.

## Markup changes (frontend/app.js)

- **`renderSections` line ~4710**: gallery `<details>` gains the `section-block--sticky` modifier
- **`renderIndexArtists` line ~6327**: letter-group `<details>` gains the modifier
- **Audit log (1029 + 1041)** and **Tools panel** (`.panel tools-panel`, not `.section-block` at all) remain unchanged — verified by grep

## New function: `_wireStickySections`

```js
function _wireStickySections() {
  document.querySelectorAll('.section-block--sticky').forEach(block => {
    const summary = block.querySelector('.section-summary');
    if (!summary || summary.dataset.stickyWired) return;
    summary.dataset.stickyWired = '1';
    const sentinel = document.createElement('div');
    sentinel.style.cssText = 'position:absolute;top:-1px;height:1px;width:1px;';
    block.style.position = 'relative';
    block.prepend(sentinel);
    new IntersectionObserver(
      ([e]) => summary.classList.toggle('is-stuck', e.intersectionRatio === 0),
      { threshold: [0, 1] }
    ).observe(sentinel);
  });
}
```

- Idempotent (`dataset.stickyWired` guard), so safe to call after every render
- Called at the end of `renderSections` and `renderIndexArtists`
- Sentinel sits 1px above each sticky block; IntersectionObserver toggles `.is-stuck` on the summary when the sentinel scrolls out — which Pack 01's CSS uses to add a subtle drop-shadow

## CSS additions (frontend/style.css)

```css
.section-block--sticky .works-table thead th {
  position: sticky;
  top: var(--low-summary-h, 42px);
  background: var(--card);
  z-index: 15;
}
```

- Pins the works-table column header **below** the sticky gallery summary so column meaning survives the scroll
- `42px` matches the current section-summary's rendered height; the `var()` hook lets a future pass measure and set it precisely if needed

## Watch-outs

- **Site-header overlap**: `.site-header` is `position:sticky; top:0; z-index:100`. The gallery summary uses `top:0; z-index:20`. Under scroll, the summary's pinned position may visually overlap with the header. **QA item 5** explicitly tests this. If overlap manifests, a follow-up commit on this branch will adjust `.section-block--sticky > .section-summary { top: <header-height>px }`.
- **`<details>` toggle still works**: clicking the summary collapses/expands as before. Sticky positioning doesn't change `<summary>` behaviour.
- **Export-section button** inside summary already calls `event.stopPropagation()` — preserved.

## Verification

| Check | Result |
|---|---|
| `pytest tests/ -q` | 965 passed |
| `ruff check backend/ tests/` | clean |
| `fetch('/ui/style.css').then(t => t.includes('section-block--sticky .works-table thead th'))` | `true` |
| `fetch('/ui/app.js').then(t => t.includes('_wireStickySections'))` | `true` |
| Docker rebuild | container healthy |
| Data preserved across rebuild | 2 LoW + 2 Index intact |
| Grep — only LoW + Index get the modifier | confirmed (Audit log lines 1029 + 1041 untouched) |
| Visual QA — sticky behaviour, header overlap, next-gallery-takes-over, shadow only when stuck, `<details>` toggle preserved | ⏳ running in parallel — will update if anything fails |

## What's NOT in this PR

- Preview engine extract — Pack 04a
- Drawer container + read mode — Pack 04b
- Drawer full mode — Pack 04c
- Orphan CSS deletion — Pack 05a
- Type/spacing/button/focus token sweep — Pack 05b