### PR TITLE
Pack 04a: extract renderEntryPreview as a pure refactor

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -623,3 +623,26 @@ controls and editor UX around it.
 
 - **Request tracing**: add `X-Request-Id` propagation to logs for easier
   troubleshooting.
+
+- **Entry-Layout preview: `final_sep_from_last_component` is invisible.**
+  The "If the last element is omitted, use its separator after the final
+  non-empty field instead" checkbox in the Entry Layout editor updates the
+  template config correctly and the backend export renderer honours it,
+  but the live preview pane does not — `renderEntryPreview` ignores the
+  setting entirely, so the editor gives no visual feedback that the
+  toggle has done anything. Discovered during Pack 04a (2026-05-30) while
+  fixing the adjacent missing-re-render bug on the three wrap-options
+  handlers. Two viable directions:
+
+  1. *Implement preview-side support.* The renderer would need to inspect
+     visible items after filtering, detect when the last enabled component
+     was omitted-because-empty, and substitute its `separator_after` after
+     the final remaining item. Modest amount of code; matches the export
+     renderer's existing logic.
+  2. *Mark it as export-only.* Add a small inline hint next to the
+     checkbox ("affects export only — not previewable") and leave the
+     renderer alone. Lower cost; honest about scope.
+
+  No correctness issue in the export itself — the bug is purely editor
+  ergonomics. Currently the user has no way to tell whether the toggle
+  is doing what they expect without exporting and inspecting the file.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -646,3 +646,26 @@ controls and editor UX around it.
   No correctness issue in the export itself — the bug is purely editor
   ergonomics. Currently the user has no way to tell whether the toggle
   is doing what they expect without exporting and inspecting the file.
+
+- **Index template editor has no Tagged Text preview tab.** The LoW
+  template editor (`renderTemplateEdit` for `list_of_works` templates)
+  has two preview tabs: a structural preview and a Tagged Text preview
+  showing the actual `<ParaStyle:…>` / `<CharStyle:…>` codes that will
+  be written to the export. The Index template editor has only the
+  structural preview. Discovered during Pack 04a QA (2026-05-30). Two
+  viable directions:
+
+  1. *Build the tab on Index.* `_teTaggedTextHTML`-equivalent for index
+     templates exists in spirit (the backend index renderer emits the
+     same kind of tagged output), so it's mostly a matter of wiring the
+     existing logic into the editor. Symmetry with LoW; helps when
+     debugging unexpected styling in the published index.
+  2. *Document the asymmetry as deliberate.* The Index output is
+     simpler than LoW (no LPG counterpart, fewer character styles per
+     entry) and the structural preview already shows what the editor
+     needs. Add a short note in the Index template editor explaining
+     that the Tagged Text view isn't available because the output
+     shape is predictable from the structural preview alone.
+
+  No correctness impact in either case — pure editor ergonomics, and
+  Index editors are a small audience.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3609,79 +3609,161 @@ function _teWrapValue(comp, value) {
   return comp.balance_lines ? _teBalanceWrap(value, comp.max_line_chars) : _teWrapLines(value, comp.max_line_chars);
 }
 
-function _teTokenHTML(comp, text) {
-  const styled = !!comp.char_style;
+// Pack 04a (2026-05-30) — Style maps for works-mode preview rendering.
+// Walks the components in order and collects distinct char_style and
+// paragraph_style names. entry_style is prepended to the pa map (it's
+// the implicit style for paragraph 1 when no explicit override is set),
+// so the colour index for the first paragraph is stable.
+function _buildStyleMaps(components, entry_style) {
+  const cs = [];
+  const pa = [];
+  if (entry_style) pa.push(entry_style);
+  components.forEach(c => {
+    if (c.char_style && cs.indexOf(c.char_style) < 0) cs.push(c.char_style);
+    if (c.paragraph_style && pa.indexOf(c.paragraph_style) < 0) pa.push(c.paragraph_style);
+  });
+  return { cs, pa };
+}
+
+// Pack 04a — Render a single token. mode:'editor' keeps the current
+// pv-tok--styled treatment with a visible style-name label; mode:'works'
+// emits pv-tok pv-tok--cs cs-N where N is the char_style's index in the
+// style map (modulo 6 colour slots), with no label.
+function _renderPreviewTokenHTML(comp, text, mode, maps) {
   const body = text !== '' && text != null
     ? esc(text)
     : `<em class="pv-tok__empty">(${esc(_TE_FIELD_LABEL[comp.field] || comp.field)})</em>`;
+  if (mode === 'works' && maps) {
+    const idx = comp.char_style ? maps.cs.indexOf(comp.char_style) : -1;
+    const cls = idx >= 0 ? `pv-tok pv-tok--cs cs-${idx % 6}` : 'pv-tok';
+    return `<span class="pv-pair"><span class="${cls}">${body}</span></span>`;
+  }
+  const styled = !!comp.char_style;
   const lbl = styled ? `<span class="pv-tok__label">${esc(comp.char_style)}</span>` : '';
   return `<span class="pv-pair"><span class="pv-tok${styled ? ' pv-tok--styled' : ''}">${body}${lbl}</span></span>`;
 }
 
-function _tePreviewHTML() {
-  const groups = _teComputeParagraphs(_te.components);
-  const sample = _TE_SAMPLES[_te.sampleVariant];
-  const renderable = groups.map((g, gi) => ({ g, gi, items: _teVisibleItems(g, sample) })).filter(o => o.items.length);
-  const firstGi = renderable.length ? renderable[0].gi : -1;
-  const lastGi = renderable.length ? renderable[renderable.length - 1].gi : -1;
+// Pack 04a — Wrap a paragraph's inner lines. mode:'editor' keeps the
+// current pv-para__tag header showing the paragraph-style name above
+// the lines; mode:'works' emits pv-para pa-N (bordered box, colour per
+// paragraph_style) with no inline tag.
+function _renderPreviewParagraphHTML(linesHTML, styleName, mode, maps) {
+  if (mode === 'works' && maps) {
+    const idx = styleName ? maps.pa.indexOf(styleName) : -1;
+    const cls = idx >= 0 ? `pv-para pa-${idx % 6}` : 'pv-para pa-none';
+    return `<div class="${cls}">${linesHTML}</div>`;
+  }
+  return `<div class="pv-para"><div class="pv-para__tag"><span class="pv-tag--para">&para; ${styleName ? esc(styleName) : '<em>default</em>'}</span></div>${linesHTML}</div>`;
+}
 
-  let paper = renderable.map(({ g, gi, items }) => {
-    const styleName = g.paragraph_style || (gi === 0 ? _te.entry_style : '');
-    // Build visual lines (each becomes its own .pv-para__line), so wrapped
-    // components actually break at their max-chars width.
-    const vlines = [''];
-    let cur = 0;
-    const add = (html) => { vlines[cur] += html; };
-    const breakLine = () => { vlines.push(''); cur = vlines.length - 1; };
-    const skip = new Set();
-
-    if (gi === firstGi && _te.leading_separator && _te.leading_separator !== 'none') {
-      add(`<span class="pv-edge" title="Leading separator">${_teSepGlyph(_te.leading_separator)}</span>`);
-    }
-    items.forEach(({ comp }, ci) => {
-      if (skip.has(ci)) return;
-      const value = sample[comp.field] ?? '';
-      const wrapped = _teWrapValue(comp, value);
-      const isLast = ci === items.length - 1;
-      if (wrapped.length <= 1) {
-        add(_teTokenHTML(comp, value));
-        if (!isLast && comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
-      } else if (comp.next_component_position === 'end_of_first_line' && ci + 1 < items.length) {
-        // First wrapped line, this component's separator, then the NEXT element
-        // inline; the remaining wrapped lines drop below.
-        const nc = items[ci + 1].comp;
-        const ncVal = sample[nc.field] ?? '';
-        add(_teTokenHTML(comp, wrapped[0]));
-        if (comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
-        add(_teTokenHTML(nc, ncVal));
-        skip.add(ci + 1);
-        for (let li = 1; li < wrapped.length; li++) { add(_teSepGlyph('soft_return')); breakLine(); add(_teTokenHTML(comp, wrapped[li])); }
-        if (ci + 1 !== items.length - 1 && nc.separator_after !== 'none') add(_teSepGlyph(nc.separator_after));
-      } else {
-        // Multi-line, normal: one visual line per wrapped line (soft return between).
-        for (let li = 0; li < wrapped.length; li++) {
-          if (li > 0) { add(_teSepGlyph('soft_return')); breakLine(); }
-          add(_teTokenHTML(comp, wrapped[li]));
-        }
-        if (!isLast && comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
-      }
-    });
-    if (gi === lastGi && _te.trailing_separator && _te.trailing_separator !== 'none') {
-      add(`<span class="pv-edge" title="Trailing separator">${_teSepGlyph(_te.trailing_separator)}</span>`);
-    }
-    const linesHTML = vlines.map(l => `<div class="pv-para__line">${l}</div>`).join('');
-    return `<div class="pv-para"><div class="pv-para__tag"><span class="pv-tag--para">&para; ${styleName ? esc(styleName) : '<em>default</em>'}</span></div>${linesHTML}</div>`;
-  }).join('');
-  if (!paper) paper = `<p style="color:var(--muted);font-size:13px;margin:0">No visible elements for this sample.</p>`;
-
-  return `<div class="preview"><div class="preview__paper">${paper}</div>
-    <div class="preview__legend">
+// Pack 04a — Render the preview legend. mode:'editor' is the existing
+// 5-icon static key; mode:'works' is the colour-swatch map from
+// _buildStyleMaps plus the canonical separator key.
+function _renderPreviewLegendHTML(mode, maps) {
+  if (mode === 'works' && maps) {
+    const cs = maps.cs.length
+      ? maps.cs.map((n, i) => `<span class="lg-item"><span class="lg-sw cs-${i % 6}"></span>${esc(n)}</span>`).join('')
+      : '<span class="lg-item"><em>none</em></span>';
+    const pa = maps.pa.length
+      ? maps.pa.map((n, i) => `<span class="lg-item"><span class="lg-sw lg-pa pa-${i % 6}"></span>${esc(n)}</span>`).join('')
+      : '<span class="lg-item"><em>none</em></span>';
+    return `<div class="preview__legend">` +
+      `<span class="lg-grp"><b>fill = character style</b>${cs}</span>` +
+      `<span class="lg-grp"><b>border = paragraph</b>${pa}</span>` +
+      `<span class="lg-grp"><b>separators</b> <i>&middot;</i> space <i>&rarr;</i> tab <i>&#8677;</i> right-tab <i>&#8629;</i> return</span></div>`;
+  }
+  return `<div class="preview__legend">
       <span><i class="lg lg--styled"></i> character-styled</span>
       <span><i class="lg lg--tab">&rarr;</i> tab</span>
       <span><i class="lg lg--rtab">&#8677;</i> right-indent tab</span>
       <span><i class="lg lg--soft">&#8629;</i> soft return / wrap</span>
       <span><i class="lg lg--para">&para;</i> new paragraph</span>
-    </div></div>`;
+    </div>`;
+}
+
+// Pack 04a (2026-05-30) — Pure preview-renderer. Takes a template's
+// components, a sample/work's field values, and rendering options;
+// returns the same HTML string the Entry-Layout editor used to build
+// internally. The Entry-Layout editor calls this via _tePreviewHTML
+// with mode:'editor' (no behaviour change). Pack 04b's drawer will
+// call it with mode:'works' to render the output preview using the
+// colour-coded skin (fill = character style, border = paragraph,
+// no inline labels).
+function renderEntryPreview(components, fieldValues, opts) {
+  opts = opts || {};
+  const mode = opts.mode || 'editor';
+  const entry_style = opts.entry_style || '';
+  const leading_separator = opts.leading_separator || 'none';
+  const trailing_separator = opts.trailing_separator || 'none';
+
+  const groups = _teComputeParagraphs(components);
+  const renderable = groups
+    .map((g, gi) => ({ g, gi, items: _teVisibleItems(g, fieldValues) }))
+    .filter(o => o.items.length);
+  const firstGi = renderable.length ? renderable[0].gi : -1;
+  const lastGi = renderable.length ? renderable[renderable.length - 1].gi : -1;
+
+  const maps = mode === 'works' ? _buildStyleMaps(components, entry_style) : null;
+
+  let paper = renderable.map(({ g, gi, items }) => {
+    const styleName = g.paragraph_style || (gi === 0 ? entry_style : '');
+    const vlines = [''];
+    let cur = 0;
+    const add = (html) => { vlines[cur] += html; };
+    const breakLine = () => { vlines.push(''); cur = vlines.length - 1; };
+    const skip = new Set();
+    const renderToken = (comp, text) => _renderPreviewTokenHTML(comp, text, mode, maps);
+
+    if (gi === firstGi && leading_separator && leading_separator !== 'none') {
+      add(`<span class="pv-edge" title="Leading separator">${_teSepGlyph(leading_separator)}</span>`);
+    }
+    items.forEach(({ comp }, ci) => {
+      if (skip.has(ci)) return;
+      const value = fieldValues[comp.field] ?? '';
+      const wrapped = _teWrapValue(comp, value);
+      const isLast = ci === items.length - 1;
+      if (wrapped.length <= 1) {
+        add(renderToken(comp, value));
+        if (!isLast && comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
+      } else if (comp.next_component_position === 'end_of_first_line' && ci + 1 < items.length) {
+        const nc = items[ci + 1].comp;
+        const ncVal = fieldValues[nc.field] ?? '';
+        add(renderToken(comp, wrapped[0]));
+        if (comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
+        add(renderToken(nc, ncVal));
+        skip.add(ci + 1);
+        for (let li = 1; li < wrapped.length; li++) { add(_teSepGlyph('soft_return')); breakLine(); add(renderToken(comp, wrapped[li])); }
+        if (ci + 1 !== items.length - 1 && nc.separator_after !== 'none') add(_teSepGlyph(nc.separator_after));
+      } else {
+        for (let li = 0; li < wrapped.length; li++) {
+          if (li > 0) { add(_teSepGlyph('soft_return')); breakLine(); }
+          add(renderToken(comp, wrapped[li]));
+        }
+        if (!isLast && comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
+      }
+    });
+    if (gi === lastGi && trailing_separator && trailing_separator !== 'none') {
+      add(`<span class="pv-edge" title="Trailing separator">${_teSepGlyph(trailing_separator)}</span>`);
+    }
+    const linesHTML = vlines.map(l => `<div class="pv-para__line">${l}</div>`).join('');
+    return _renderPreviewParagraphHTML(linesHTML, styleName, mode, maps);
+  }).join('');
+  if (!paper) paper = `<p style="color:var(--muted);font-size:13px;margin:0">No visible elements for this sample.</p>`;
+
+  const wrapperCls = mode === 'works' ? 'preview preview--works' : 'preview';
+  return `<div class="${wrapperCls}"><div class="preview__paper">${paper}</div>${_renderPreviewLegendHTML(mode, maps)}</div>`;
+}
+
+// Thin wrapper used by the Entry-Layout editor — translates the editor's
+// module-level _te state into the parameters renderEntryPreview expects.
+// Behaviour and output are identical to the pre-Pack-04a code path.
+function _tePreviewHTML() {
+  return renderEntryPreview(_te.components, _TE_SAMPLES[_te.sampleVariant], {
+    mode: 'editor',
+    entry_style: _te.entry_style,
+    leading_separator: _te.leading_separator,
+    trailing_separator: _te.trailing_separator,
+  });
 }
 
 function _teTaggedSepChars(k) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3840,9 +3840,9 @@ function _teSetSepCb(idx) { return (v) => { _te.components[idx].separator_after 
 function _teSetLeading(v) { _te.leading_separator = v; _teRender(); }
 function _teSetTrailing(v) { _te.trailing_separator = v; _teRender(); }
 function _teToggleFinalSep(on) { _te.final_sep_from_last_component = on; }
-function _teSetMaxChars(idx, v) { _te.components[idx].max_line_chars = v ? parseInt(v, 10) : null; }
-function _teSetNextPos(idx, v) { _te.components[idx].next_component_position = v; }
-function _teToggleBalance(idx, on) { _te.components[idx].balance_lines = on; }
+function _teSetMaxChars(idx, v) { _te.components[idx].max_line_chars = v ? parseInt(v, 10) : null; _teRenderPreview(); }
+function _teSetNextPos(idx, v) { _te.components[idx].next_component_position = v; _teRenderPreview(); }
+function _teToggleBalance(idx, on) { _te.components[idx].balance_lines = on; _teRenderPreview(); }
 function _teToggleWrap(idx) { if (_te.wrapOpen.has(idx)) _te.wrapOpen.delete(idx); else _te.wrapOpen.add(idx); _teRender(); }
 function _teTab(tab) { _te.activeTab = tab; _teRenderPreview(); }
 function _teSample(v) { _te.sampleVariant = v; _teRenderPreview(); }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2607,6 +2607,53 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .lg--styled { background: var(--tok-bg); border: 1px solid var(--tok-bd); }
 .lg--tab, .lg--rtab, .lg--soft, .lg--para { color: var(--ra-red); border: 1px solid #eed5d1; background: #fdf3f2; }
 
+/* ------------------------------------------------------------------ */
+/* Works-mode preview overrides — Pack 04a (2026-05-30)                */
+/* Ported from artifacts/source/proto.css. Scoped via .preview--works  */
+/* so the Entry-Layout editor (mode:'editor') keeps its left-border +  */
+/* tag-above-paragraph treatment unchanged. The works skin renders     */
+/* each paragraph as a bordered box (border colour per paragraph_style)*/
+/* and each token with a coloured fill (per char_style), no labels.    */
+/* Nothing currently uses these rules — Pack 04b's drawer is the first */
+/* caller via renderEntryPreview(..., {mode:'works'}).                 */
+/* ------------------------------------------------------------------ */
+.preview--works .pv-para {
+  position: static;
+  padding: 11px 13px;
+  border-radius: 7px;
+  border: 1.5px solid var(--border);
+  margin-bottom: 11px;
+  margin-left: 0;
+  padding-left: 11px;
+}
+.preview--works .pv-para.pa-0 { border-color: #cdbf9f; }
+.preview--works .pv-para.pa-1 { border-color: #aec1dc; }
+.preview--works .pv-para.pa-2 { border-color: #a9ccb6; }
+.preview--works .pv-para.pa-3 { border-color: #c3b4e0; }
+.preview--works .pv-para.pa-4 { border-color: #e0b1c0; }
+.preview--works .pv-para.pa-5 { border-color: #a8cdd1; }
+.preview--works .pv-para.pa-none { border-color: var(--border); }
+.preview--works .pv-para__line { line-height: 1.95; }
+
+/* Token fills (works mode). The .pv-tok--cs class is only emitted by
+   mode:'works', so these rules do not affect the editor's pv-tok--styled. */
+.pv-tok--cs { border-radius: 3px; padding: 1px 4px; border: 1px solid; }
+.cs-0 { background: #fbeede; border-color: #ecc9a0; }
+.cs-1 { background: #e7effb; border-color: #bcd0ee; }
+.cs-2 { background: #e7f1ea; border-color: #b6d6c1; }
+.cs-3 { background: #efeafa; border-color: #cdbfee; }
+.cs-4 { background: #fbe9ee; border-color: #eebccb; }
+.cs-5 { background: #e6f1f2; border-color: #b3d4d8; }
+
+/* Works-mode legend swatches — only emitted when mode:'works'.
+   The shared .preview__legend rule above gives the flex container; these
+   add the swatch + group structure the works legend needs. */
+.lg-grp { display: inline-flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+.lg-grp b { color: var(--muted-2); font-weight: 600; }
+.lg-item { display: inline-flex; align-items: center; gap: 5px; color: var(--muted-2); }
+.lg-sw { width: 14px; height: 14px; border-radius: 3px; border: 1px solid; display: inline-block; }
+.lg-sw.lg-pa { background: transparent !important; border-width: 1.5px; }
+
 .taggedtext-wrap { position: relative; }
 .taggedtext {
   background: #1a1a1a; color: #f0f0f0; font-family: var(--mono); font-size: 12px; line-height: 1.6;


### PR DESCRIPTION
First step of Pack 04 (`Handoff - Systemwide 2026/04-works-preview-drawer.md`). **Pure refactor with zero visual change** — extracts the preview-engine body out of `_tePreviewHTML` into a standalone `renderEntryPreview(components, fieldValues, opts)` function. Plumbs `mode:'editor'` (used by the Entry-Layout editor, behaviour preserved bit-for-bit) and `mode:'works'` (the new colour-coded skin) but doesn't use the new mode yet — Pack 04b's drawer will be the first consumer.

> ⚡ Opened with CI running in parallel to QA, per the pattern from Packs 02/03.

## Architecture

```
renderEntryPreview(components, fieldValues, opts)
  ├─ opts.mode = 'editor' | 'works'                 ← skin selector
  ├─ opts.entry_style                               ← implicit style for paragraph 1
  ├─ opts.leading_separator / opts.trailing_separator
  │
  ├─ _teComputeParagraphs(components)               ← existing (pure)
  ├─ _teVisibleItems(group, fieldValues)            ← existing (pure)
  ├─ _teSepGlyph(kind)                              ← existing (pure)
  ├─ _teWrapValue(comp, value)                      ← existing (pure)
  │
  ├─ _buildStyleMaps(components, entry_style)       ← NEW (works mode only)
  ├─ _renderPreviewTokenHTML(comp, text, mode, maps) ← NEW (mode-aware)
  ├─ _renderPreviewParagraphHTML(linesHTML, styleName, mode, maps) ← NEW
  └─ _renderPreviewLegendHTML(mode, maps)           ← NEW

_tePreviewHTML()  ← thin 6-line wrapper translating _te.* state
                    into renderEntryPreview parameters with mode:'editor'
```

## Mode comparison

| Surface | `mode:'editor'` (current) | `mode:'works'` (Pack 04b will use) |
|---|---|---|
| Token | `<span class="pv-tok pv-tok--styled">value<span class="pv-tok__label">styleName</span></span>` | `<span class="pv-tok pv-tok--cs cs-N">value</span>` (no label) |
| Paragraph | `<div class="pv-para"><div class="pv-para__tag">¶ styleName</div>…lines…</div>` | `<div class="pv-para pa-N">…lines…</div>` (bordered box) |
| Legend | 5-icon static key | colour-swatch map + separator key |
| Wrapper | `<div class="preview">…` | `<div class="preview preview--works">…` |

## CSS (frontend/style.css)

New rules ported verbatim from `artifacts/source/proto.css`, scoped via `.preview--works` so the editor's existing left-border + tag-above-paragraph look is untouched:
- `.preview--works .pv-para` (bordered box)
- `.preview--works .pv-para.pa-0` through `.pa-5` + `.pa-none` (border colours)
- `.pv-tok--cs` + `.cs-0` through `.cs-5` (token fill colours; no scoping needed, `pv-tok--cs` is only emitted by works mode)
- `.lg-grp`, `.lg-item`, `.lg-sw`, `.lg-sw.lg-pa` (works legend swatches)

## What's preserved from the original engine

- **Line wrapping** (`_teWrapLines`, `_teBalanceWrap`, `_teWrapValue`) — both modes honour `max_line_chars` + `balance_lines`. The prototype's `structHTML` doesn't have these but the live engine does and editors rely on them.
- **`next_component_position: 'end_of_first_line'`** bridge logic — both modes.
- **Leading / trailing separators** — both modes.
- **Sample-empty placeholder** ("No visible elements for this sample.") — both modes.

So `mode:'works'` is genuinely a *skin* over the same logic, not a parallel engine.

## Verification

| Check | Result |
|---|---|
| `pytest tests/ -q` | 965 passed |
| `ruff check backend/ tests/` | clean |
| `fetch('/ui/app.js').then(t => t.includes('function renderEntryPreview'))` | true |
| `fetch('/ui/style.css').then(t => t.includes('.pv-tok--cs'))` | true |
| Docker rebuild | healthy, data preserved (2 LoW + 2 Index imports intact) |
| Editor probe (built-in LoW + LPG templates) | `wrapperCls: "preview"` ✓ ; `worksTokens: 0` ✓ ; `worksLegend: 0` ✓ ; `paBorders: 0` ✓ ; editor legend (5 icons) ✓ ; paragraph tags intact ✓ |
| Grep — orphaned `_teTokenHTML` references | 0 |
| Grep — live caller of `mode:'works'` anywhere | 0 (only function definitions reference it) |

## What's NOT in this PR

- Drawer container, hero block, output preview as rendered in the drawer — **Pack 04b**.
- Drawer full mode (untruncated diff + override form + pinned preview) — **Pack 04c**.
- Template select inside the drawer, Tagged Text tab inside the drawer — **Pack 04b**.
- Watch-outs for Pack 04b already logged in the task: body-glide vs descendant `position:sticky` (transform on an ancestor breaks sticky), pager keyboard nav gating on input/textarea focus, warning-detail messages surfacing (your catch from yesterday).