### PR TITLE
Pack 04b: drawer + read mode + deep-link + body-glide (the big visible cut-over)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -647,6 +647,32 @@ controls and editor UX around it.
   ergonomics. Currently the user has no way to tell whether the toggle
   is doing what they expect without exporting and inspecting the file.
 
+- **Entry-Layout preview doesn't style RA honorifics separately from the
+  artist name.** The actual backend export renderer wraps the artist name
+  and the honorifics in two distinct `<CharStyle:…>` runs (using
+  `artist_style` and `honorifics_style` respectively), so an export for
+  "Sir Anish Kapoor RA" emits something like
+  `<CharStyle:Artist>Sir Anish Kapoor<CharStyle:> <CharStyle:Honorifics>RA<CharStyle:>`.
+  The Entry-Layout editor's preview (`_tePreviewHTML` → `renderEntryPreview`)
+  and the drawer's output preview both concatenate the honorifics into the
+  artist string and apply one style, so RA artists look mono-styled when
+  they will actually export bi-styled. Pre-existing in the editor; the
+  drawer inherits it. Discovered during Pack 04b QA (2026-05-30).
+
+  Fix shape (modest, contained):
+  1. Pass `honorifics` as a separate value in `fieldValues` (and add it to
+     `_TE_SAMPLES` for the editor).
+  2. Add a `honorifics` entry to `_TE_CHAR_KEY` mapped to `honorifics_style`.
+  3. Teach `renderEntryPreview` + `renderEntryTaggedText` that when
+     emitting the `artist` component's token, also emit a separately-
+     styled `honorifics` token after it (space-separated) if
+     `fieldValues.honorifics` is present.
+
+  Affects ~25%+ of works in any catalogue (every RA artist). The drawer's
+  output-preview pitch — "this is what export will produce" — is
+  materially wrong for those. Worth folding into a Pack 04 follow-up or
+  taking as its own small PR.
+
 - **Index template editor has no Tagged Text preview tab.** The LoW
   template editor (`renderTemplateEdit` for `list_of_works` templates)
   has two preview tabs: a structural preview and a Tagged Text preview

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3673,10 +3673,14 @@ function _renderPreviewLegendHTML(mode, maps) {
     const pa = maps.pa.length
       ? maps.pa.map((n, i) => `<span class="lg-item"><span class="lg-sw lg-pa pa-${i % 6}"></span>${esc(n)}</span>`).join('')
       : '<span class="lg-item"><em>none</em></span>';
+    // Separator glyphs reuse .pv-sep__glyph so the legend renders them
+    // with the exact same mono-font / colour / opacity / weight that
+    // the preview itself uses -- visual parity is the whole point.
+    const sg = (entity) => `<span class="pv-sep__glyph">${entity}</span>`;
     return `<div class="preview__legend">` +
       `<span class="lg-grp"><b>fill = character style</b>${cs}</span>` +
       `<span class="lg-grp"><b>border = paragraph</b>${pa}</span>` +
-      `<span class="lg-grp"><b>separators</b> <i>&middot;</i> space <i>&rarr;</i> tab <i>&#8677;</i> right-tab <i>&#8629;</i> return</span></div>`;
+      `<span class="lg-grp"><b>separators</b> ${sg('&middot;')} space ${sg('&rarr;')} tab ${sg('&#8677;')} right-tab ${sg('&#8629;')} return</span></div>`;
   }
   return `<div class="preview__legend">
       <span><i class="lg lg--styled"></i> character-styled</span>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5096,10 +5096,25 @@ let _drawer = {
   workId: null,
   mode: 'read',        // 'read' | 'full'
   workIds: [],         // flat ordered list across all sections, for the pager
-  templates: null,     // cached LoW templates (lazy-fetched on first open)
+  templates: null,     // summary list from /templates (id + name + is_builtin)
+  tplFull: {},         // id -> full config (with components), cached on demand
   tplId: null,         // selected template id for the output preview
   tab: 'struct',       // 'struct' | 'tagged'
 };
+
+// /templates returns only summaries (no components). The output preview
+// needs the full config -- fetched lazily per template id and cached.
+async function _drawerEnsureFullTemplate(tplId) {
+  if (!tplId) return null;
+  if (_drawer.tplFull[tplId]) return _drawer.tplFull[tplId];
+  try {
+    const cfg = await api('GET', `/templates/${tplId}`);
+    _drawer.tplFull[tplId] = cfg;
+    return cfg;
+  } catch (err) {
+    return null;
+  }
+}
 
 function _drawerMount() {
   if (document.getElementById('works-drawer')) return; // idempotent
@@ -5150,6 +5165,9 @@ async function _openDrawer(importId, workId) {
   if (!_drawer.tplId && _drawer.templates.length) {
     _drawer.tplId = (_drawer.templates.find(t => t.is_default) || _drawer.templates[0]).id;
   }
+  // Pre-fetch the selected template's FULL config (components etc.) so
+  // the output preview has something to render on first paint.
+  if (_drawer.tplId) await _drawerEnsureFullTemplate(_drawer.tplId);
   _drawerRefreshView();
   const drawerWidth = Math.min(640, window.innerWidth * 0.94);
   const leftMargin = Math.max(0, (window.innerWidth - 1240) / 2);
@@ -5237,8 +5255,11 @@ function _drawerRefreshView() {
     btn.addEventListener('click', () => _drawerSetMode(btn.dataset.drawerMode));
   });
   aside.querySelector('[data-drawer-exclude]')?.addEventListener('click', _drawerToggleExclude);
-  aside.querySelector('[data-drawer-tpl]')?.addEventListener('change', (e) => {
+  aside.querySelector('[data-drawer-tpl]')?.addEventListener('change', async (e) => {
     _drawer.tplId = e.target.value;
+    // Fetch the full config (with components) for the newly-selected
+    // template before re-rendering -- /templates returned summaries only.
+    await _drawerEnsureFullTemplate(_drawer.tplId);
     _drawerRefreshView();
   });
   aside.querySelectorAll('[data-drawer-tab]').forEach(btn => {
@@ -5392,9 +5413,11 @@ function _drawerRenderHeroHTML(w, cfg) {
 
 function _drawerRenderOutputPreviewHTML(w, cfg) {
   const templates = _drawer.templates || [];
-  const tpl = templates.find(t => t.id === _drawer.tplId) || templates[0];
+  const selectedId = _drawer.tplId || (templates[0] && templates[0].id);
+  const summary = templates.find(t => t.id === selectedId) || templates[0];
+  const full = selectedId ? _drawer.tplFull[selectedId] : null;
   const optionsHTML = templates.length
-    ? templates.map(t => `<option value="${esc(t.id)}"${tpl && t.id === tpl.id ? ' selected' : ''}>${esc(t.name || 'Untitled')}</option>`).join('')
+    ? templates.map(t => `<option value="${esc(t.id)}"${t.id === selectedId ? ' selected' : ''}>${esc(t.name || 'Untitled')}</option>`).join('')
     : '<option value="">(no templates)</option>';
   const tplBar = `
     <div class="opv__bar">
@@ -5406,18 +5429,25 @@ function _drawerRenderOutputPreviewHTML(w, cfg) {
         <button type="button" data-drawer-tab="tagged" class="${_drawer.tab === 'tagged' ? 'on' : ''}">Tagged Text</button>
       </div>
     </div>`;
-  if (!tpl || !Array.isArray(tpl.components)) {
-    return tplBar + '<p class="cmpl-none">No template available for preview.</p>';
+  if (!summary) {
+    return tplBar + '<p class="cmpl-none">No templates available.</p>';
+  }
+  if (!full) {
+    // Full config (with components) still loading from /templates/{id}.
+    return tplBar + '<p class="cmpl-none">Loading template…</p>';
+  }
+  if (!Array.isArray(full.components) || full.components.length === 0) {
+    return tplBar + '<p class="cmpl-none">Template has no components configured.</p>';
   }
   const fieldValues = _workEffectiveFieldValues(w, cfg);
   const opts = {
-    entry_style: tpl.entry_style || '',
-    leading_separator: tpl.leading_separator || 'none',
-    trailing_separator: tpl.trailing_separator || 'none',
+    entry_style: full.entry_style || '',
+    leading_separator: full.leading_separator || 'none',
+    trailing_separator: full.trailing_separator || 'none',
   };
   const body = _drawer.tab === 'tagged'
-    ? renderEntryTaggedText(tpl.components, fieldValues, opts)
-    : renderEntryPreview(tpl.components, fieldValues, { ...opts, mode: 'works' });
+    ? renderEntryTaggedText(full.components, fieldValues, opts)
+    : renderEntryPreview(full.components, fieldValues, { ...opts, mode: 'works' });
   return tplBar + body;
 }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3728,24 +3728,42 @@ function renderEntryPreview(components, fieldValues, opts) {
       const value = fieldValues[comp.field] ?? '';
       const wrapped = _teWrapValue(comp, value);
       const isLast = ci === items.length - 1;
+      // Honour soft_return as a real visual line break when it appears
+      // as a component's separator_after. Pre-Pack-04a the glyph was shown
+      // but didn't break the line, which the brief's design language
+      // (the ↵ glyph means "line break here") contradicted. Discovered
+      // during Pack 04b QA (2026-05-30); applies to both editor and
+      // works mode since the renderer is shared.
       if (wrapped.length <= 1) {
         add(renderToken(comp, value));
-        if (!isLast && comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
+        if (!isLast && comp.separator_after !== 'none') {
+          add(_teSepGlyph(comp.separator_after));
+          if (comp.separator_after === 'soft_return') breakLine();
+        }
       } else if (comp.next_component_position === 'end_of_first_line' && ci + 1 < items.length) {
         const nc = items[ci + 1].comp;
         const ncVal = fieldValues[nc.field] ?? '';
         add(renderToken(comp, wrapped[0]));
-        if (comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
+        if (comp.separator_after !== 'none') {
+          add(_teSepGlyph(comp.separator_after));
+          if (comp.separator_after === 'soft_return') breakLine();
+        }
         add(renderToken(nc, ncVal));
         skip.add(ci + 1);
         for (let li = 1; li < wrapped.length; li++) { add(_teSepGlyph('soft_return')); breakLine(); add(renderToken(comp, wrapped[li])); }
-        if (ci + 1 !== items.length - 1 && nc.separator_after !== 'none') add(_teSepGlyph(nc.separator_after));
+        if (ci + 1 !== items.length - 1 && nc.separator_after !== 'none') {
+          add(_teSepGlyph(nc.separator_after));
+          if (nc.separator_after === 'soft_return') breakLine();
+        }
       } else {
         for (let li = 0; li < wrapped.length; li++) {
           if (li > 0) { add(_teSepGlyph('soft_return')); breakLine(); }
           add(renderToken(comp, wrapped[li]));
         }
-        if (!isLast && comp.separator_after !== 'none') add(_teSepGlyph(comp.separator_after));
+        if (!isLast && comp.separator_after !== 'none') {
+          add(_teSepGlyph(comp.separator_after));
+          if (comp.separator_after === 'soft_return') breakLine();
+        }
       }
     });
     if (gi === lastGi && trailing_separator && trailing_separator !== 'none') {
@@ -5299,7 +5317,10 @@ function _workEffectiveFieldValues(w, cfg) {
   const artistFull  = hon ? `${artist} ${hon}`.trim() : artist;
   const priceText   = o.price_text_override   ?? w.price_text   ?? '';
   const priceNum    = o.price_numeric_override ?? w.price_numeric;
-  const priceDisplay = priceText || (priceNum != null ? formatPrice(priceNum, null, cfg) : '');
+  // Match workRowHTML's call shape: formatPrice handles the
+  // price_text-vs-price_numeric priority AND prepends the currency
+  // symbol when the text is a bare number ("600" -> "£600").
+  const priceDisplay = formatPrice(priceNum, priceText, cfg);
   const eTotal = o.edition_total_override ?? w.edition_total;
   const ePrice = o.edition_price_numeric_override ?? w.edition_price_numeric;
   const prefix = (cfg.edition_prefix ?? 'edition of').trim();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5460,6 +5460,15 @@ function _drawerRenderOutputPreviewHTML(w, cfg) {
   if (!Array.isArray(full.components) || full.components.length === 0) {
     return tplBar + '<p class="cmpl-none">Template has no components configured.</p>';
   }
+  // Inject per-field char_style onto each component -- the API stores
+  // char styles as top-level template fields (title_style, artist_style,
+  // ...), not on the components themselves. The editor does the same
+  // injection in renderTemplateEdit so renderEntryPreview /
+  // renderEntryTaggedText receive components that carry their style.
+  const componentsWithStyles = full.components.map(c => ({
+    ...c,
+    char_style: c.char_style || full[_TE_CHAR_KEY[c.field]] || '',
+  }));
   const fieldValues = _workEffectiveFieldValues(w, cfg);
   const opts = {
     entry_style: full.entry_style || '',
@@ -5467,8 +5476,8 @@ function _drawerRenderOutputPreviewHTML(w, cfg) {
     trailing_separator: full.trailing_separator || 'none',
   };
   const body = _drawer.tab === 'tagged'
-    ? renderEntryTaggedText(full.components, fieldValues, opts)
-    : renderEntryPreview(full.components, fieldValues, { ...opts, mode: 'works' });
+    ? renderEntryTaggedText(componentsWithStyles, fieldValues, opts)
+    : renderEntryPreview(componentsWithStyles, fieldValues, { ...opts, mode: 'works' });
   return tplBar + body;
 }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -895,6 +895,12 @@ function router() {
 
 window.addEventListener('hashchange', router);
 window.addEventListener('DOMContentLoaded', async () => {
+  // Pack 04b -- works drawer: mount the <aside> + <scrim> in <body> and wire
+  // the global keydown handler (Esc / ArrowLeft / ArrowRight, gated on
+  // INPUT/TEXTAREA focus). Safe to run before auth -- drawer is dormant
+  // until _openDrawer is called.
+  _drawerMount();
+  _drawerSetupKeyboard();
   // Discover auth mode before anything else
   await _initAuth();
   _syncHeader();
@@ -3777,43 +3783,62 @@ function _teTaggedSepChars(k) {
   }
 }
 
-function _teTaggedTextHTML() {
-  const groups = _teComputeParagraphs(_te.components);
-  const sample = _TE_SAMPLES[_te.sampleVariant];
+// Pack 04b (2026-05-30) -- Pure tagged-text renderer. Same shape as Pack
+// 04a's renderEntryPreview: take components + field values + opts, no
+// reads from _te state. The editor calls via the _teTaggedTextHTML
+// wrapper (preserved bit-for-bit); the drawer's Tagged Text tab will
+// call directly.
+function renderEntryTaggedText(components, fieldValues, opts) {
+  opts = opts || {};
+  const entry_style = opts.entry_style || '';
+  const leading_separator = opts.leading_separator || 'none';
+  const trailing_separator = opts.trailing_separator || 'none';
+
+  const groups = _teComputeParagraphs(components);
   const styled = (comp, t) => comp.char_style ? `<CharStyle:${comp.char_style}>${t}<CharStyle:>` : t;
   const lines = [];
   groups.forEach((g, gi) => {
-    const items = _teVisibleItems(g, sample);
+    const items = _teVisibleItems(g, fieldValues);
     if (!items.length) return;
-    const styleName = g.paragraph_style || (gi === 0 ? _te.entry_style : '');
+    const styleName = g.paragraph_style || (gi === 0 ? entry_style : '');
     let line = `<ParaStyle:${styleName}>`;
     const skip = new Set();
     items.forEach(({ comp }, ci) => {
       if (skip.has(ci)) return;
-      const v = sample[comp.field] ?? '';
+      const v = fieldValues[comp.field] ?? '';
       const wrapped = _teWrapValue(comp, v);
       if (wrapped.length > 1 && comp.next_component_position === 'end_of_first_line' && ci + 1 < items.length) {
         const nc = items[ci + 1].comp;
-        const ncVal = sample[nc.field] ?? '';
+        const ncVal = fieldValues[nc.field] ?? '';
         line += styled(comp, wrapped[0]) + _teTaggedSepChars(comp.separator_after) + styled(nc, ncVal)
-              + styled(comp, '\\n' + wrapped.slice(1).join('\\n'));
+              + styled(comp, '\n' + wrapped.slice(1).join('\n'));
         skip.add(ci + 1);
         if (ci + 1 !== items.length - 1) line += _teTaggedSepChars(nc.separator_after);
       } else {
-        line += styled(comp, wrapped.length > 1 ? wrapped.join('\\n') : v);
+        line += styled(comp, wrapped.length > 1 ? wrapped.join('\n') : v);
         if (ci !== items.length - 1) line += _teTaggedSepChars(comp.separator_after);
       }
     });
     lines.push(line);
   });
-  if (_te.leading_separator && _te.leading_separator !== 'none' && lines.length) {
-    lines[0] = lines[0].replace(/^(<ParaStyle:[^>]*>)/, `$1${_teTaggedSepChars(_te.leading_separator)}`);
+  if (leading_separator && leading_separator !== 'none' && lines.length) {
+    lines[0] = lines[0].replace(/^(<ParaStyle:[^>]*>)/, `$1${_teTaggedSepChars(leading_separator)}`);
   }
-  if (_te.trailing_separator && _te.trailing_separator !== 'none' && lines.length) {
-    lines[lines.length - 1] += _teTaggedSepChars(_te.trailing_separator);
+  if (trailing_separator && trailing_separator !== 'none' && lines.length) {
+    lines[lines.length - 1] += _teTaggedSepChars(trailing_separator);
   }
   const text = lines.join('\n');
   return `<div class="taggedtext-wrap"><button type="button" class="copybtn" onclick="_teCopyTagged(this)">Copy</button><pre class="taggedtext"><code>${esc(text)}</code></pre></div>`;
+}
+
+// Thin wrapper used by the Entry-Layout editor's Tagged Text tab --
+// translates the editor's _te state into renderEntryTaggedText parameters.
+function _teTaggedTextHTML() {
+  return renderEntryTaggedText(_te.components, _TE_SAMPLES[_te.sampleVariant], {
+    entry_style: _te.entry_style,
+    leading_separator: _te.leading_separator,
+    trailing_separator: _te.trailing_separator,
+  });
 }
 
 // --- State mutations ------------------------------------------------------
@@ -4314,9 +4339,10 @@ function _saveDisplayCfg(currency_symbol, thousands_separator, decimal_places, e
 // Import detail
 // ---------------------------------------------------------------------------
 
-let _expandedWorkId = null;
+let _expandedWorkId = null;  // Pack 04b: dead, kept to avoid touching unrelated references
 let _workCache = {}; // workId -> work object, populated when sections render
 let _currentLowImportId = null; // set when a LoW detail page is rendered
+let _currentLowSections = null; // Pack 04b -- the loaded sections, used by drawer pager + venue lookup
 
 /** Restore override button text when closing the form. */
 function _restoreOverrideBtn(btn) {
@@ -4705,9 +4731,10 @@ function scrollToWork(workId) {
   void row.offsetWidth;
   row.classList.add('row-highlight');
   setTimeout(() => row.classList.remove('row-highlight'), 2500);
-  // Auto-open the detail panel if not already expanded for this work
-  if (_currentLowImportId && _expandedWorkId !== workId) {
-    toggleOverrideForm(_currentLowImportId, workId);
+  // Pack 04b -- auto-open the drawer for this work (replaces the old
+  // toggleOverrideForm inline-expansion path).
+  if (_currentLowImportId && _drawer.workId !== workId) {
+    _openDrawer(_currentLowImportId, workId);
   }
 }
 
@@ -4798,6 +4825,7 @@ function _wireStickySections() {
 
 function renderSections(importId, sections, cfg) {
   _currentLowImportId = importId;
+  _currentLowSections = sections;   // Pack 04b -- drawer pager needs the flat work list
   const container = document.getElementById('sections-container');
   if (!sections.length) {
     container.innerHTML = '<p class="muted">No sections found.</p>';
@@ -4862,6 +4890,16 @@ function renderSections(importId, sections, cfg) {
     </details>`;
   }).join('');
   _wireStickySections();
+  // Pack 04b -- deep-link: if URL has ?work={cat_no}, open the drawer for it.
+  // The auto-open runs after the sections render so _workCache is populated.
+  const wantCatNo = _hashParam('work');
+  if (wantCatNo) {
+    const match = Object.values(_workCache).find(w => String(w.raw_cat_no ?? '') === String(wantCatNo));
+    if (match && _drawer.workId !== match.id) _openDrawer(importId, match.id);
+  } else if (_drawer.workId) {
+    // URL has no ?work= but drawer is open from a previous page -- close it.
+    _closeDrawer();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -5034,60 +5072,375 @@ function _workWarningsBadges(workId) {
   return `<div class="norm-reasons"><strong>Warnings:</strong> ${badges}${detailHtml}</div>`;
 }
 
-function _showWorkDetailPanel(importId, workId) {
-  const w = _workCache[workId];
+// =========================================================================
+// Works drawer -- Pack 04b (2026-05-30)
+// =========================================================================
+// Right-docked drawer replacing the inline expand-and-edit row. Read mode
+// is implemented here (hero + output preview + What changed); full mode is
+// stubbed -- Pack 04c will reuse showOverrideForm + _buildWorkDetailTable
+// inside the drawer's wide variant.
+//
+// State + URL contract:
+//   _drawer.workId !== null  <=>  drawer is open  <=>  URL has ?work={cat_no}
+// _openDrawer / _closeDrawer mutate state, re-render the drawer, and
+// replaceState the URL (no hashchange fire -- the existing router would
+// otherwise re-fetch the import).
+//
+// Body-glide: when the drawer opens, JS sets --drawer-shift on #app and
+// adds .drawer-shifted; CSS transitions the transform. Per Luke's decision
+// (2026-05-30), sticky positioning breaking while the drawer is open is
+// acceptable -- scrolling priority drops once the user is in drawer mode.
+
+let _drawer = {
+  importId: null,
+  workId: null,
+  mode: 'read',        // 'read' | 'full'
+  workIds: [],         // flat ordered list across all sections, for the pager
+  templates: null,     // cached LoW templates (lazy-fetched on first open)
+  tplId: null,         // selected template id for the output preview
+  tab: 'struct',       // 'struct' | 'tagged'
+};
+
+function _drawerMount() {
+  if (document.getElementById('works-drawer')) return; // idempotent
+  const scrim = document.createElement('div');
+  scrim.id = 'works-scrim';
+  scrim.className = 'scrim';
+  scrim.addEventListener('click', _closeDrawer);
+  const drawer = document.createElement('aside');
+  drawer.id = 'works-drawer';
+  drawer.className = 'drawer';
+  drawer.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(scrim);
+  document.body.appendChild(drawer);
+}
+
+function _drawerSetupKeyboard() {
+  if (window.__drawerKbWired) return;
+  window.__drawerKbWired = true;
+  window.addEventListener('keydown', (e) => {
+    if (!_drawer.workId) return; // drawer closed
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      if (_drawer.mode === 'full') _drawerSetMode('read');
+      else _closeDrawer();
+      return;
+    }
+    const tag = (e.target?.tagName || '').toUpperCase();
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+    if (e.key === 'ArrowLeft')  { e.preventDefault(); _drawerPage(-1); }
+    if (e.key === 'ArrowRight') { e.preventDefault(); _drawerPage(+1); }
+  });
+}
+
+function _drawerFlatWorkIds() {
+  if (!_currentLowSections) return [];
+  return _currentLowSections.flatMap(s => s.works.map(w => w.id));
+}
+
+async function _openDrawer(importId, workId) {
+  _drawer.importId = importId;
+  _drawer.workId = workId;
+  _drawer.workIds = _drawerFlatWorkIds();
+  if (_drawer.workIds.indexOf(workId) < 0) { _closeDrawer(); return; }
+  if (!_drawer.templates) {
+    try { _drawer.templates = await api('GET', '/templates'); }
+    catch { _drawer.templates = []; }
+  }
+  if (!_drawer.tplId && _drawer.templates.length) {
+    _drawer.tplId = (_drawer.templates.find(t => t.is_default) || _drawer.templates[0]).id;
+  }
+  _drawerRefreshView();
+  const drawerWidth = Math.min(640, window.innerWidth * 0.94);
+  const leftMargin = Math.max(0, (window.innerWidth - 1240) / 2);
+  const shift = -Math.min(drawerWidth / 2, leftMargin);
+  document.documentElement.style.setProperty('--drawer-shift', shift + 'px');
+  document.getElementById('app')?.classList.add('drawer-shifted');
+  _drawerUpdateActiveRow();
+  _drawerUpdateURL();
+}
+
+function _closeDrawer() {
+  if (!_drawer.workId) return;
+  _drawer.workId = null;
+  _drawer.mode = 'read';
+  const aside = document.getElementById('works-drawer');
+  const scrim = document.getElementById('works-scrim');
+  if (aside) { aside.classList.remove('show', 'full'); aside.setAttribute('aria-hidden', 'true'); }
+  if (scrim) scrim.classList.remove('show');
+  document.getElementById('app')?.classList.remove('drawer-shifted');
+  document.querySelectorAll('.works-table tbody tr.is-active').forEach(tr => tr.classList.remove('is-active'));
+  const url = new URL(window.location.href);
+  if (url.hash.includes('?')) {
+    const [path, query] = url.hash.split('?');
+    const params = new URLSearchParams(query);
+    params.delete('work');
+    const q = params.toString();
+    url.hash = q ? `${path}?${q}` : path;
+    history.replaceState(null, '', url.toString());
+  }
+}
+
+function _drawerPage(delta) {
+  if (!_drawer.workId || !_drawer.workIds.length) return;
+  const idx = _drawer.workIds.indexOf(_drawer.workId);
+  if (idx < 0) return;
+  const next = idx + delta;
+  if (next < 0 || next >= _drawer.workIds.length) return; // clamp
+  _drawer.workId = _drawer.workIds[next];
+  _drawerRefreshView();
+  _drawerUpdateActiveRow();
+  _drawerUpdateURL();
+  const row = document.getElementById(`wr-${_drawer.workIds[next]}`);
+  if (row) row.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+function _drawerSetMode(mode) {
+  _drawer.mode = mode;
+  _drawerRefreshView();
+}
+
+function _drawerUpdateActiveRow() {
+  document.querySelectorAll('.works-table tbody tr.is-active').forEach(tr => tr.classList.remove('is-active'));
+  if (_drawer.workId) {
+    const row = document.getElementById(`wr-${_drawer.workId}`);
+    if (row) row.classList.add('is-active');
+  }
+}
+
+function _drawerUpdateURL() {
+  if (!_drawer.workId) return;
+  const w = _workCache[_drawer.workId];
   if (!w) return;
-  const cell = document.getElementById(`ovc-${workId}`);
-  if (!cell) return;
-  const hasOvr = !!w.override;
-  const included = w.include_in_export !== false;
-  const inclLabel = included ? 'Exclude from export' : 'Include in export';
-  const inclBtnClass = included ? 'btn btn-sm btn-secondary' : 'btn btn-sm btn-danger';
-  cell.innerHTML = `
-    <div class="work-detail">
-      ${_workNormBadges(w)}
-      ${_workWarningsBadges(workId)}
-      ${_buildWorkDetailTable(w)}
-      <div class="work-detail-actions">
-        ${ifEditor(`<button class="btn btn-sm ${hasOvr ? 'btn-warning' : ''}" id="wk-ov-btn-${esc(workId)}"
-          onclick="event.stopPropagation(); toggleWorkOverrideForm('${esc(importId)}','${esc(workId)}')">
-          ${hasOvr ? 'Edit Override \u270e' : 'Override\u2026'}</button>`)}
-        ${ifEditor(`<button class="${inclBtnClass}" id="wk-incl-btn-${esc(workId)}"
-          onclick="event.stopPropagation(); toggleIncludeFromDetail('${esc(importId)}','${esc(workId)}')">
-          ${esc(inclLabel)}</button>`)}
-        <button class="btn btn-sm btn-secondary" onclick="event.stopPropagation(); toggleOverrideForm('${esc(importId)}','${esc(workId)}')">Close &#x2715;</button>
+  const url = new URL(window.location.href);
+  const [path, query] = url.hash.split('?');
+  const params = new URLSearchParams(query || '');
+  params.set('work', String(w.raw_cat_no ?? ''));
+  url.hash = `${path}?${params.toString()}`;
+  history.replaceState(null, '', url.toString());
+}
+
+function _drawerRefreshView() {
+  if (!_drawer.workId) return;
+  const aside = document.getElementById('works-drawer');
+  const scrim = document.getElementById('works-scrim');
+  if (!aside || !scrim) return;
+  aside.innerHTML = _renderDrawer();
+  aside.classList.toggle('full', _drawer.mode === 'full');
+  aside.classList.add('show');
+  aside.setAttribute('aria-hidden', 'false');
+  scrim.classList.add('show');
+  aside.querySelector('.drawer__close')?.addEventListener('click', _closeDrawer);
+  aside.querySelector('[data-drawer-prev]')?.addEventListener('click', () => _drawerPage(-1));
+  aside.querySelector('[data-drawer-next]')?.addEventListener('click', () => _drawerPage(+1));
+  aside.querySelectorAll('[data-drawer-mode]').forEach(btn => {
+    btn.addEventListener('click', () => _drawerSetMode(btn.dataset.drawerMode));
+  });
+  aside.querySelector('[data-drawer-exclude]')?.addEventListener('click', _drawerToggleExclude);
+  aside.querySelector('[data-drawer-tpl]')?.addEventListener('change', (e) => {
+    _drawer.tplId = e.target.value;
+    _drawerRefreshView();
+  });
+  aside.querySelectorAll('[data-drawer-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      _drawer.tab = btn.dataset.drawerTab;
+      _drawerRefreshView();
+    });
+  });
+}
+
+async function _drawerToggleExclude() {
+  const w = _workCache[_drawer.workId];
+  if (!w) return;
+  const wasIncluded = w.include_in_export !== false;
+  try {
+    await api('PATCH', `/imports/${_drawer.importId}/works/${_drawer.workId}/exclude?exclude=${wasIncluded}`);
+    w.include_in_export = !wasIncluded;
+    _refreshWorkRow(_drawer.importId, _drawer.workId);
+    _drawerUpdateActiveRow();
+    _drawerRefreshView();
+    showToast(wasIncluded ? 'Excluded from export' : 'Re-included in export', 'success');
+  } catch (err) {
+    showToast(`Toggle failed: ${err.message}`, 'error');
+  }
+}
+
+// Effective field values for renderEntryPreview / renderEntryTaggedText.
+// Applies override on top of normalised values, with the same display
+// formatting as workRowHTML uses for the row.
+function _workEffectiveFieldValues(w, cfg) {
+  const o = w.override || {};
+  cfg = cfg || _getDisplayCfg();
+  const title       = o.title_override        ?? w.title        ?? '';
+  const title_cased = o.title_cased_override  ?? w.title_cased  ?? '';
+  const artist      = o.artist_name_override  ?? w.artist_name  ?? '';
+  const hon         = o.artist_honorifics_override ?? w.artist_honorifics ?? '';
+  const artistFull  = hon ? `${artist} ${hon}`.trim() : artist;
+  const priceText   = o.price_text_override   ?? w.price_text   ?? '';
+  const priceNum    = o.price_numeric_override ?? w.price_numeric;
+  const priceDisplay = priceText || (priceNum != null ? formatPrice(priceNum, null, cfg) : '');
+  const eTotal = o.edition_total_override ?? w.edition_total;
+  const ePrice = o.edition_price_numeric_override ?? w.edition_price_numeric;
+  const prefix = (cfg.edition_prefix ?? 'edition of').trim();
+  const brackets = cfg.edition_brackets !== false;
+  let edition = '';
+  if (eTotal && ePrice != null) {
+    const inner = `${prefix} ${eTotal} at ${formatPrice(ePrice, null, cfg)}`;
+    edition = brackets ? `(${inner})` : inner;
+  } else if (eTotal) {
+    const inner = `${prefix} ${eTotal}`;
+    edition = brackets ? `(${inner})` : inner;
+  }
+  const medium = o.medium_override ?? w.medium ?? '';
+  const artwork = o.artwork_override ?? w.artwork;
+  return {
+    work_number: String(w.raw_cat_no ?? ''),
+    artist:      artistFull,
+    title,
+    title_cased,
+    edition,
+    price:       priceDisplay,
+    medium,
+    artwork:     artwork != null ? String(artwork) : '',
+  };
+}
+
+function _renderDrawer() {
+  const w = _workCache[_drawer.workId];
+  if (!w) return '';
+  const cfg = _getDisplayCfg();
+  const idx = _drawer.workIds.indexOf(_drawer.workId);
+  const pos = idx >= 0 ? `${idx + 1} of ${_drawer.workIds.length}` : '';
+  const positionLabel = _drawer.mode === 'full'
+    ? `All changes &amp; override · No. ${esc(String(w.raw_cat_no ?? ''))}`
+    : esc(pos);
+  const prevDisabled = idx <= 0 ? ' disabled' : '';
+  const nextDisabled = idx < 0 || idx >= _drawer.workIds.length - 1 ? ' disabled' : '';
+  const top = `
+    <div class="drawer__top">
+      <div class="drawer__pager">
+        <button type="button" data-drawer-prev title="Previous (←)"${prevDisabled}>‹</button>
+        <button type="button" data-drawer-next title="Next (→)"${nextDisabled}>›</button>
       </div>
-      <div id="wk-ovc-${esc(workId)}"></div>
+      <span class="drawer__pos">${positionLabel}</span>
+      <button type="button" class="drawer__close" title="Close (Esc)">×</button>
+    </div>`;
+  if (_drawer.mode === 'full') {
+    return top + `
+      <div class="drawer__ovr-stub">
+        Full mode (untruncated diff + override form + pinned live preview)
+        lands in Pack 04c. For now, back to read mode and use the existing
+        controls there.
+        <div style="margin-top:14px"><button type="button" class="btn btn-sm" data-drawer-mode="read">← Back to read mode</button></div>
+      </div>`;
+  }
+  return top + `
+    <div class="drawer__scroll">
+      ${_drawerRenderHeroHTML(w, cfg)}
+      <div class="drawer__sec">
+        <div class="drawer__sec-lab"><span class="star">★</span> Output preview</div>
+        ${_drawerRenderOutputPreviewHTML(w, cfg)}
+      </div>
+      <div class="drawer__sec">
+        <div class="drawer__sec-lab">What changed</div>
+        ${_drawerRenderWhatChangedHTML(w, cfg)}
+      </div>
+      <div class="drawer__ovr">
+        ${ifEditor('<button type="button" class="btn btn-sm btn-primary" data-drawer-mode="full">View all changes &amp; edit override →</button>')}
+        ${ifEditor(`<button type="button" class="btn btn-sm" data-drawer-exclude>${w.include_in_export !== false ? 'Exclude from export' : 'Re-include'}</button>`)}
+      </div>
     </div>`;
 }
 
-async function toggleWorkOverrideForm(importId, workId) {
-  const cell = document.getElementById(`wk-ovc-${workId}`);
-  if (!cell) return;
-
-  // Toggle off if already showing
-  if (cell.innerHTML.trim()) {
-    cell.innerHTML = '';
-    const btn = document.getElementById(`wk-ov-btn-${workId}`);
-    if (btn) {
-      const w = _workCache[workId];
-      const hasOvr = !!w?.override;
-      btn.textContent = hasOvr ? 'Edit Override \u270e' : 'Override\u2026';
-      btn.className = `btn btn-sm ${hasOvr ? 'btn-warning' : ''}`;
-    }
-    return;
+function _drawerRenderHeroHTML(w, cfg) {
+  let venue = '';
+  if (_currentLowSections) {
+    const sec = _currentLowSections.find(s => s.works.some(x => x.id === w.id));
+    if (sec) venue = sec.name || '';
   }
-
-  let existing = null;
-  try {
-    existing = await api('GET', `/imports/${importId}/works/${workId}/override`);
-  } catch (err) {
-    if (err.httpStatus !== 404) {
-      cell.innerHTML = `<p class="error" style="padding:12px">${esc(err.message)}</p>`;
-      return;
-    }
+  const eff = _workEffectiveFieldValues(w, cfg);
+  const hon = (w.artist_honorifics ?? '').trim();
+  const pills = [];
+  if (w.override) pills.push('<span class="pill pill--edit" title="Has a user override">Override</span>');
+  if (hon && _isRaMember(hon)) pills.push('<span class="pill pill--id is-ra" title="RA honorific extracted from artist name">RA</span>');
+  const warns = _warningsByWorkId[w.id] || [];
+  const warnTypes = [...new Set(warns.filter(ww => !_LOW_CHANGED_TYPES.has(ww.warning_type)).map(ww => ww.warning_type))];
+  for (const wt of warnTypes) {
+    const matching = warns.find(ww => ww.warning_type === wt);
+    pills.push(`<span class="${_lowWarnBadgeClass(wt)}" title="${esc(matching?.message ?? wt)}">${esc(_lowWarnLabel(wt))}</span>`);
   }
-  showOverrideForm(importId, workId, existing);
+  // Pack 04b decision (Luke 2026-05-30): inline warning detail messages
+  // under the pills -- busier, readable. Details is what this view is for.
+  const detailMessages = warns
+    .filter(ww => _LOW_DETAIL_TYPES.has(ww.warning_type) && ww.message)
+    .map(ww => `<small>${esc(ww.message)}</small>`)
+    .join('');
+  const detailsBlock = detailMessages
+    ? `<div class="drawer__warning-details">${detailMessages}</div>`
+    : '';
+  const isRaInline = hon && _isRaMember(hon) ? ' <span class="pill pill--id is-ra">RA</span>' : '';
+  return `
+    <div class="drawer__hero">
+      ${venue ? `<div class="drawer__venue">${esc(venue)}</div>` : ''}
+      <div class="drawer__cat">No. ${esc(eff.work_number)}</div>
+      <div class="drawer__title">${esc(eff.title || '(untitled)')}</div>
+      <div class="drawer__artist">${esc(eff.artist || '(no artist)')}${isRaInline}</div>
+      ${pills.length ? `<div class="drawer__flags">${pills.join('')}</div>` : ''}
+      ${detailsBlock}
+    </div>`;
+}
+
+function _drawerRenderOutputPreviewHTML(w, cfg) {
+  const templates = _drawer.templates || [];
+  const tpl = templates.find(t => t.id === _drawer.tplId) || templates[0];
+  const optionsHTML = templates.length
+    ? templates.map(t => `<option value="${esc(t.id)}"${tpl && t.id === tpl.id ? ' selected' : ''}>${esc(t.name || 'Untitled')}</option>`).join('')
+    : '<option value="">(no templates)</option>';
+  const tplBar = `
+    <div class="opv__bar">
+      <label class="opv__tmpl">Template
+        <select data-drawer-tpl>${optionsHTML}</select>
+      </label>
+      <div class="opv__tabs">
+        <button type="button" data-drawer-tab="struct" class="${_drawer.tab === 'struct' ? 'on' : ''}">Structure</button>
+        <button type="button" data-drawer-tab="tagged" class="${_drawer.tab === 'tagged' ? 'on' : ''}">Tagged Text</button>
+      </div>
+    </div>`;
+  if (!tpl || !Array.isArray(tpl.components)) {
+    return tplBar + '<p class="cmpl-none">No template available for preview.</p>';
+  }
+  const fieldValues = _workEffectiveFieldValues(w, cfg);
+  const opts = {
+    entry_style: tpl.entry_style || '',
+    leading_separator: tpl.leading_separator || 'none',
+    trailing_separator: tpl.trailing_separator || 'none',
+  };
+  const body = _drawer.tab === 'tagged'
+    ? renderEntryTaggedText(tpl.components, fieldValues, opts)
+    : renderEntryPreview(tpl.components, fieldValues, { ...opts, mode: 'works' });
+  return tplBar + body;
+}
+
+function _drawerRenderWhatChangedHTML(w, cfg) {
+  const eff = _workEffectiveFieldValues(w, cfg);
+  const rows = [
+    ['Title',  w.raw_title ?? '',  eff.title],
+    ['Artist', w.raw_artist ?? '', eff.artist],
+    ['Price',  w.raw_price ?? '',  eff.price],
+    ['Medium', w.raw_medium ?? '', eff.medium],
+  ];
+  const changed = rows.filter(([, from, to]) => (from || '').trim() !== (to || '').trim());
+  if (!changed.length) return '<p class="cmpl-none">No changes — exports exactly as imported.</p>';
+  return `
+    <table class="cmpl"><tbody>
+      ${changed.map(([label, from, to]) => `
+        <tr class="is-chg">
+          <td class="cmpl-f">${esc(label)}</td>
+          <td class="cmpl-from">${esc(from || '—')}</td>
+          <td class="cmpl-ar">→</td>
+          <td class="cmpl-to">${esc(to || '—')}</td>
+        </tr>`).join('')}
+    </tbody></table>`;
 }
 
 function workRowHTML(importId, w, cfg) {
@@ -5130,7 +5483,6 @@ function workRowHTML(importId, w, cfg) {
   }
   const _rawAFull = w.raw_artist ?? '';
   if (_rawAFull && _normA && _rawAFull !== (w.artist_name ?? '')) {
-    // Check if the difference is fully explained by honorific extraction
     const nameMatchesAfterHon = _hon && _rawA === (_normA + ' ' + _hon).trim();
     const nameCloseAfterHon = _hon && _rawA.includes(_hon) &&
       _rawA.replace(_hon, '').replace(/\s+/g, ' ').trim().replace(/,\s*$/, '').trim() === _normA;
@@ -5144,7 +5496,7 @@ function workRowHTML(importId, w, cfg) {
   }
   if (_wsTrimmed.length) flags.push(`<span class="pill pill--info" title="Whitespace trimmed: ${esc(_wsTrimmed.join(', '))}">${esc('Trimmed')}</span>`);
   if (_normDiffs.length) flags.push(`<span class="pill pill--info" title="Normalised: ${esc(_normDiffs.join(', '))}">${esc('Norm')}</span>`);
-  // Warnings from the per-work lookup (exclude "changed" types — those are normalisations)
+  // Warnings from the per-work lookup (exclude "changed" types -- those are normalisations)
   const wWarns = _warningsByWorkId[w.id];
   if (wWarns && wWarns.length) {
     const warnTypes = [...new Set(wWarns.filter(ww => !_LOW_CHANGED_TYPES.has(ww.warning_type)).map(ww => ww.warning_type))];
@@ -5184,9 +5536,10 @@ function workRowHTML(importId, w, cfg) {
     editionDisplay = brackets ? `(${inner})` : inner;
   }
 
+  // Pack 04b -- row click opens the drawer; no longer an inline-expansion row.
   return `
     <tr id="wr-${esc(w.id)}" class="work-row ${included ? '' : 'row-excluded'}"
-      onclick="toggleOverrideForm('${esc(importId)}','${esc(w.id)}')">
+      onclick="_openDrawer('${esc(importId)}','${esc(w.id)}')">
       <td class="col-no">${esc(w.raw_cat_no ?? '')}</td>
       <td class="${hasOverride && o?.artist_name_override ? 'cell-overridden' : ''}">${esc(eff.artist_name ?? '')}${honorifics}</td>
       <td class="${hasOverride && o?.title_override ? 'cell-overridden' : ''}">${esc(eff.title ?? '')}${cfg.show_title_cased && eff.title_cased ? `<div class="title-cased-scan">${esc(eff.title_cased)}</div>` : ''}</td>
@@ -5196,9 +5549,6 @@ function workRowHTML(importId, w, cfg) {
       <td class="col-medium ${hasOverride && o?.medium_override ? 'cell-overridden' : ''}">${esc(eff.medium ?? '')}</td>
       <td class="col-flags"><div class="cell-flags">${flags.join('')}</div></td>
       <td class="col-chev" aria-hidden="true"><span class="works-row-chev">&rsaquo;</span></td>
-    </tr>
-    <tr id="ovr-${esc(w.id)}" class="override-form-row" style="display:none">
-      <td colspan="${cfg.show_artwork_column ? 9 : 8}" id="ovc-${esc(w.id)}"></td>
     </tr>`;
 }
 
@@ -5221,57 +5571,6 @@ async function toggleInclude(importId, workId, checkbox) {
   } finally {
     checkbox.disabled = false;
   }
-}
-
-async function toggleIncludeFromDetail(importId, workId) {
-  const w = _workCache[workId];
-  if (!w) return;
-  const wasIncluded = w.include_in_export !== false;
-  const btn = document.getElementById(`wk-incl-btn-${workId}`);
-  if (btn) btn.disabled = true;
-  try {
-    await api('PATCH', `/imports/${importId}/works/${workId}/exclude?exclude=${wasIncluded}`);
-    const nowIncluded = !wasIncluded;
-    w.include_in_export = nowIncluded;
-    const row = document.getElementById(`wr-${workId}`);
-    if (row) row.className = `work-row ${nowIncluded ? '' : 'row-excluded'}`;
-    if (btn) {
-      btn.textContent = nowIncluded ? 'Exclude from export' : 'Include in export';
-      btn.className = nowIncluded ? 'btn btn-sm btn-secondary' : 'btn btn-sm btn-danger';
-    }
-  } catch (err) {
-    showToast(`Toggle failed: ${err.message}`, 'error');
-  } finally {
-    if (btn) btn.disabled = false;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Override form
-// ---------------------------------------------------------------------------
-
-function toggleOverrideForm(importId, workId) {
-  const formRow = document.getElementById(`ovr-${workId}`);
-
-  // If this row is already open, close it
-  if (_expandedWorkId === workId) {
-    formRow.style.display = 'none';
-    document.getElementById(`ovc-${workId}`).innerHTML = '';
-    _expandedWorkId = null;
-    return;
-  }
-
-  // Close any other open panel
-  if (_expandedWorkId) {
-    const prev = document.getElementById(`ovr-${_expandedWorkId}`);
-    if (prev) prev.style.display = 'none';
-    const prevCell = document.getElementById(`ovc-${_expandedWorkId}`);
-    if (prevCell) prevCell.innerHTML = '';
-  }
-
-  _expandedWorkId = workId;
-  formRow.style.display = '';
-  _showWorkDetailPanel(importId, workId);
 }
 
 function showOverrideForm(importId, workId, existing) {
@@ -5438,7 +5737,9 @@ async function saveOverride(importId, workId) {
     // Update cache so the form re-renders with normalised hints intact
     if (_workCache[workId]) _workCache[workId].override = result;
     _refreshWorkRow(importId, workId);
-    _showWorkDetailPanel(importId, workId);
+    // Pack 04b -- drawer refresh hook lands in Pack 04c (when the override
+    // form lives inside the drawer's full mode). For now the row refresh
+    // above is enough; the user can re-open the drawer to see updated state.
     showOverrideForm(importId, workId, result);
     const s = document.getElementById(`ovs-${workId}`);
     if (s) { s.textContent = '\u2713 Saved'; s.className = 'status-msg success'; }
@@ -5456,7 +5757,9 @@ async function deleteOverride(importId, workId) {
     // Remove from cache
     if (_workCache[workId]) _workCache[workId].override = null;
     _refreshWorkRow(importId, workId);
-    _showWorkDetailPanel(importId, workId);
+    // Pack 04b -- drawer refresh hook lands in Pack 04c (when the override
+    // form lives inside the drawer's full mode). For now the row refresh
+    // above is enough; the user can re-open the drawer to see updated state.
     showToast('Override deleted', 'success');
   } catch (err) {
     if (statusEl) { statusEl.textContent = `Error: ${err.message}`; statusEl.className = 'status-msg error'; }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5419,17 +5419,71 @@ function _drawerRenderHeroHTML(w, cfg) {
   }
   const eff = _workEffectiveFieldValues(w, cfg);
   const hon = (w.artist_honorifics ?? '').trim();
+
+  // ---- Primary flag pills -- mirror workRowHTML so the drawer hero shows
+  // the same row-level flags the user already sees in the table (Override,
+  // RA, honorific, Trimmed, Norm) plus server-side review/error warnings.
   const pills = [];
   if (w.override) pills.push('<span class="pill pill--edit" title="Has a user override">Override</span>');
-  if (hon && _isRaMember(hon)) pills.push('<span class="pill pill--id is-ra" title="RA honorific extracted from artist name">RA</span>');
+  if (hon) {
+    if (_isRaMember(hon)) {
+      pills.push('<span class="pill pill--id is-ra" title="RA honorific extracted from artist name">RA</span>');
+    } else {
+      pills.push(`<span class="pill pill--info" title="Honorific extracted: ${esc(hon)}">${esc(hon)}</span>`);
+    }
+  }
+  // Client-side normalisation detection -- same logic as workRowHTML.
+  const _normDiffs = [];
+  const _wsTrimmed = [];
+  const _normFields = [
+    ['Title',  w.raw_title,  w.title],
+    ['Price',  w.raw_price,  w.price_text ?? (w.price_numeric != null ? String(w.price_numeric) : null)],
+    ['Medium', w.raw_medium, w.medium],
+  ];
+  for (const [label, raw, norm] of _normFields) {
+    const rawStr = raw ?? '';
+    const normStr = norm ?? '';
+    if (!rawStr && !normStr) continue;
+    if (rawStr === normStr) continue;
+    if (rawStr.trim() === normStr.trim()) _wsTrimmed.push(label);
+    else _normDiffs.push(label);
+  }
+  const _rawA = (w.raw_artist ?? '').trim();
+  const _normA = (w.artist_name ?? '').trim();
+  const _rawAFull = w.raw_artist ?? '';
+  if (_rawAFull && _normA && _rawAFull !== _normA) {
+    const nameMatchesAfterHon = hon && _rawA === (_normA + ' ' + hon).trim();
+    const nameCloseAfterHon = hon && _rawA.includes(hon) &&
+      _rawA.replace(hon, '').replace(/\s+/g, ' ').trim().replace(/,\s*$/, '').trim() === _normA;
+    if (!nameMatchesAfterHon && !nameCloseAfterHon) {
+      if (_rawAFull.trim() === _normA) _wsTrimmed.push('Artist');
+      else _normDiffs.push('Artist');
+    }
+  }
+  if (_wsTrimmed.length) pills.push(`<span class="pill pill--info" title="Whitespace trimmed: ${esc(_wsTrimmed.join(', '))}">Trimmed</span>`);
+  if (_normDiffs.length) pills.push(`<span class="pill pill--info" title="Normalised: ${esc(_normDiffs.join(', '))}">Norm</span>`);
+  // Server-side review/error warnings (excluding auto-normalisation
+  // info types -- those go in the info row below).
   const warns = _warningsByWorkId[w.id] || [];
-  const warnTypes = [...new Set(warns.filter(ww => !_LOW_CHANGED_TYPES.has(ww.warning_type)).map(ww => ww.warning_type))];
-  for (const wt of warnTypes) {
+  const reviewTypes = [...new Set(warns.filter(ww => !_LOW_CHANGED_TYPES.has(ww.warning_type)).map(ww => ww.warning_type))];
+  for (const wt of reviewTypes) {
     const matching = warns.find(ww => ww.warning_type === wt);
     pills.push(`<span class="${_lowWarnBadgeClass(wt)}" title="${esc(matching?.message ?? wt)}">${esc(_lowWarnLabel(wt))}</span>`);
   }
-  // Pack 04b decision (Luke 2026-05-30): inline warning detail messages
-  // under the pills -- busier, readable. Details is what this view is for.
+  // ---- Info / auto-normalisation pills (server-side warnings in
+  // _LOW_CHANGED_TYPES) -- shown as a separate row directly below the
+  // primary flags. Per Luke (2026-05-30): info-only normalisations like
+  // "zero edition dropped" / "whitespace trimmed" deserve visibility,
+  // even though they don't require human review.
+  const infoTypes = [...new Set(warns.filter(ww => _LOW_CHANGED_TYPES.has(ww.warning_type)).map(ww => ww.warning_type))];
+  const infoPills = infoTypes.map(wt => {
+    const matching = warns.find(ww => ww.warning_type === wt);
+    return `<span class="${_lowWarnBadgeClass(wt)}" title="${esc(matching?.message ?? wt)}">${esc(_lowWarnLabel(wt))}</span>`;
+  });
+
+  // Inline warning detail messages under the pills (Pack 04b decision
+  // 2026-05-30: option a, busier-but-readable). Details for detail-eligible
+  // types regardless of review-vs-info bucket.
   const detailMessages = warns
     .filter(ww => _LOW_DETAIL_TYPES.has(ww.warning_type) && ww.message)
     .map(ww => `<small>${esc(ww.message)}</small>`)
@@ -5445,6 +5499,7 @@ function _drawerRenderHeroHTML(w, cfg) {
       <div class="drawer__title">${esc(eff.title || '(untitled)')}</div>
       <div class="drawer__artist">${esc(eff.artist || '(no artist)')}${isRaInline}</div>
       ${pills.length ? `<div class="drawer__flags">${pills.join('')}</div>` : ''}
+      ${infoPills.length ? `<div class="drawer__flags drawer__flags--info">${infoPills.join('')}</div>` : ''}
       ${detailsBlock}
     </div>`;
 }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3680,7 +3680,7 @@ function _renderPreviewLegendHTML(mode, maps) {
     return `<div class="preview__legend">` +
       `<span class="lg-grp"><b>fill = character style</b>${cs}</span>` +
       `<span class="lg-grp"><b>border = paragraph</b>${pa}</span>` +
-      `<span class="lg-grp"><b>separators</b> ${sg('&middot;')} space ${sg('&rarr;')} tab ${sg('&#8677;')} right-tab ${sg('&#8629;')} return</span></div>`;
+      `<span class="lg-grp"><b>separators</b> ${sg('&middot;')} space ${sg('&rarr;')} tab ${sg('&#8677;')} right-tab ${sg('&#8629;')} soft return ${sg('&para;')} hard return</span></div>`;
   }
   return `<div class="preview__legend">
       <span><i class="lg lg--styled"></i> character-styled</span>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3662,10 +3662,23 @@ function _renderPreviewParagraphHTML(linesHTML, styleName, mode, maps) {
   return `<div class="pv-para"><div class="pv-para__tag"><span class="pv-tag--para">&para; ${styleName ? esc(styleName) : '<em>default</em>'}</span></div>${linesHTML}</div>`;
 }
 
-// Pack 04a — Render the preview legend. mode:'editor' is the existing
-// 5-icon static key; mode:'works' is the colour-swatch map from
-// _buildStyleMaps plus the canonical separator key.
+// Pack 04a / Pack 04b QA refactor (2026-05-30) -- Unified legend for
+// both modes. Shared structure + shared separator key (same .pv-sep__glyph
+// element the preview uses) so the two legends read as variants of the
+// same design system rather than two parallel inventions. The only
+// mode-specific difference is the swatch mapping: works has per-style
+// colours from _buildStyleMaps; editor has one generic orange swatch
+// because every styled token in editor mode wears the same highlight
+// (the inline style-name labels carry the per-style information).
+//
+// The old .lg / .lg--styled / .lg--tab / .lg--rtab / .lg--soft / .lg--para
+// CSS rules are now unreferenced -- Pack 05a will sweep them.
 function _renderPreviewLegendHTML(mode, maps) {
+  const sg = (entity) => `<span class="pv-sep__glyph">${entity}</span>`;
+  const separators =
+    `<span class="lg-grp"><b>separators</b> ` +
+    `${sg('&middot;')} space ${sg('&rarr;')} tab ${sg('&#8677;')} right-tab ` +
+    `${sg('&#8629;')} soft return ${sg('&para;')} hard return</span>`;
   if (mode === 'works' && maps) {
     const cs = maps.cs.length
       ? maps.cs.map((n, i) => `<span class="lg-item"><span class="lg-sw cs-${i % 6}"></span>${esc(n)}</span>`).join('')
@@ -3673,22 +3686,22 @@ function _renderPreviewLegendHTML(mode, maps) {
     const pa = maps.pa.length
       ? maps.pa.map((n, i) => `<span class="lg-item"><span class="lg-sw lg-pa pa-${i % 6}"></span>${esc(n)}</span>`).join('')
       : '<span class="lg-item"><em>none</em></span>';
-    // Separator glyphs reuse .pv-sep__glyph so the legend renders them
-    // with the exact same mono-font / colour / opacity / weight that
-    // the preview itself uses -- visual parity is the whole point.
-    const sg = (entity) => `<span class="pv-sep__glyph">${entity}</span>`;
     return `<div class="preview__legend">` +
       `<span class="lg-grp"><b>fill = character style</b>${cs}</span>` +
       `<span class="lg-grp"><b>border = paragraph</b>${pa}</span>` +
-      `<span class="lg-grp"><b>separators</b> ${sg('&middot;')} space ${sg('&rarr;')} tab ${sg('&#8677;')} right-tab ${sg('&#8629;')} soft return ${sg('&para;')} hard return</span></div>`;
+      `${separators}</div>`;
   }
-  return `<div class="preview__legend">
-      <span><i class="lg lg--styled"></i> character-styled</span>
-      <span><i class="lg lg--tab">&rarr;</i> tab</span>
-      <span><i class="lg lg--rtab">&#8677;</i> right-indent tab</span>
-      <span><i class="lg lg--soft">&#8629;</i> soft return / wrap</span>
-      <span><i class="lg lg--para">&para;</i> new paragraph</span>
-    </div>`;
+  // Editor mode: one generic orange swatch (the colour every styled token
+  // already wears via .pv-tok--styled); paragraph styles are shown inline
+  // as ¶ NAME above each paragraph, so no border-= group is needed.
+  const editorSwatch =
+    `<span class="lg-item">` +
+      `<span class="lg-sw" style="background:var(--tok-bg);border-color:var(--tok-bd)"></span>` +
+      `<em>any styled value</em>` +
+    `</span>`;
+  return `<div class="preview__legend">` +
+    `<span class="lg-grp"><b>fill = character-styled</b>${editorSwatch}</span>` +
+    `${separators}</div>`;
 }
 
 // Pack 04a (2026-05-30) — Pure preview-renderer. Takes a template's

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2676,11 +2676,17 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 }
 .scrim.show { opacity: 1; pointer-events: auto; }
 
-/* The drawer itself. NB: no transition on translate -- cascade-only. */
+/* The drawer itself. Pack 04b QA decision (2026-05-30): the brief's
+   "cascade-only, no transition" caveat was rooted in a specific React
+   prototype scar; for vanilla CSS toggling .show on a fixed-position
+   element the transition is rock-solid. Adding it for visual parity
+   with the body-glide. If a stranded-off-screen symptom ever appears,
+   revert to cascade-only. */
 .drawer {
   position: fixed; top: 0; right: 0; height: 100vh; width: min(640px, 94vw);
   background: var(--card); box-shadow: -16px 0 40px -20px rgba(0,0,0,.4);
   translate: 102% 0; z-index: 210; display: flex; flex-direction: column;
+  transition: translate .22s cubic-bezier(.4,0,.2,1);
 }
 .drawer.show { translate: 0 0; }
 .drawer.full { width: min(1180px, 98vw); }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2654,6 +2654,109 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .lg-sw { width: 14px; height: 14px; border-radius: 3px; border: 1px solid; display: inline-block; }
 .lg-sw.lg-pa { background: transparent !important; border-width: 1.5px; }
 
+/* ------------------------------------------------------------------ */
+/* Works drawer — Pack 04b (2026-05-30)                                */
+/* Ported from artifacts/source/proto.css. The drawer replaces the     */
+/* inline expand-and-edit row that used to appear under each work.     */
+/* Open/close translate is cascade-only (no CSS transition on the      */
+/* drawer itself — a stranded timeline can leave it off-screen). The   */
+/* page-container body-glide IS transitioned because worst-case it     */
+/* just jumps but stays visible.                                       */
+/* ------------------------------------------------------------------ */
+
+/* Body-glide on the SPA mount point. JS sets --drawer-shift and toggles
+   .drawer-shifted when the drawer opens. */
+#app { transition: transform .26s cubic-bezier(.4,0,.2,1); will-change: transform; }
+#app.drawer-shifted { transform: translateX(var(--drawer-shift, 0)); }
+
+/* Scrim behind the drawer. Click-to-close handler is wired in JS. */
+.scrim {
+  position: fixed; inset: 0; background: rgba(20,18,16,.34);
+  opacity: 0; pointer-events: none; transition: opacity .2s; z-index: 200;
+}
+.scrim.show { opacity: 1; pointer-events: auto; }
+
+/* The drawer itself. NB: no transition on translate -- cascade-only. */
+.drawer {
+  position: fixed; top: 0; right: 0; height: 100vh; width: min(640px, 94vw);
+  background: var(--card); box-shadow: -16px 0 40px -20px rgba(0,0,0,.4);
+  translate: 102% 0; z-index: 210; display: flex; flex-direction: column;
+}
+.drawer.show { translate: 0 0; }
+.drawer.full { width: min(1180px, 98vw); }
+@media (max-width: 780px) { .drawer.full { width: 98vw; } }
+
+.drawer__top {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 18px; border-bottom: 1px solid var(--border); background: var(--bg-alt);
+}
+.drawer__pager { display: flex; gap: 4px; }
+.drawer__pager button {
+  width: 30px; height: 30px; border: 1px solid var(--border-strong); background: #fff;
+  border-radius: 6px; cursor: pointer; font-size: 15px; color: var(--muted-2); line-height: 1;
+}
+.drawer__pager button:hover { background: var(--bg); color: var(--ra-dark); }
+.drawer__pager button:disabled { opacity: .35; cursor: not-allowed; }
+.drawer__pos { font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.drawer__close {
+  margin-left: auto; width: 32px; height: 32px; border: none; background: transparent;
+  font-size: 22px; color: var(--muted); cursor: pointer; line-height: 1; border-radius: 6px;
+}
+.drawer__close:hover { background: #eee; color: var(--ra-dark); }
+.drawer__scroll { overflow-y: auto; flex: 1; }
+.drawer__hero { padding: 18px 20px 16px; border-bottom: 1px solid var(--border); }
+.drawer__venue { font-size: 12px; font-weight: 600; color: var(--ra-red); margin-bottom: 3px; }
+.drawer__cat { font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.drawer__title { font-size: 20px; font-weight: 700; line-height: 1.2; margin: 4px 0 6px; }
+.drawer__artist { font-size: 14px; color: var(--muted-2); display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.drawer__flags { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 12px; }
+/* Inline warning detail messages under the flag pills (option a -- busier,
+   readable; details is what this view is for). */
+.drawer__warning-details { margin-top: 10px; font-size: 12px; color: var(--muted-2); line-height: 1.55; }
+.drawer__warning-details small { display: block; }
+.drawer__warning-details small + small { margin-top: 4px; }
+.drawer__sec { padding: 18px 20px; border-bottom: 1px solid var(--border); }
+.drawer__sec-lab {
+  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .07em;
+  color: var(--muted); margin-bottom: 12px; display: flex; align-items: center; gap: 8px;
+}
+.drawer__sec-lab .star { color: var(--ra-red); }
+.drawer__ovr { padding: 18px 20px; display: flex; gap: 8px; flex-wrap: wrap; }
+.drawer__ovr .btn-primary { background: var(--ra-dark); color: #fff; border-color: var(--ra-dark); font-weight: 600; }
+.drawer__ovr .btn-primary:hover { background: #000; }
+.drawer__ovr-stub { padding: 18px 20px; color: var(--muted); font-style: italic; font-size: 13px; }
+
+/* Output preview controls inside the drawer */
+.opv__bar { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; flex-wrap: wrap; }
+.opv__tmpl { display: flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--muted-2); }
+.opv__tmpl select {
+  font: inherit; font-size: 12.5px; padding: 4px 8px; border: 1px solid var(--border);
+  border-radius: 6px; background: #fff;
+}
+.opv__tabs { display: flex; gap: 4px; margin-left: auto; }
+.opv__tabs button {
+  font: inherit; font-size: 12px; font-weight: 600; padding: 5px 11px;
+  border: 1px solid var(--border); background: var(--bg-alt); color: var(--muted-2);
+  border-radius: 6px; cursor: pointer;
+}
+.opv__tabs button.on { background: #fff; color: var(--ra-dark); border-color: var(--border-strong); }
+
+/* "What changed" compact comparison list */
+.cmpl { width: 100%; border-collapse: collapse; font-size: 13px; }
+.cmpl td { padding: 5px 6px; border-bottom: 1px solid #f1f1f1; vertical-align: top; }
+.cmpl tr:last-child td { border-bottom: none; }
+.cmpl-f { color: var(--muted-2); width: 80px; font-size: 11px; text-transform: uppercase; letter-spacing: .03em; padding-top: 7px; }
+.cmpl-from { color: var(--muted); }
+.cmpl-ar { color: var(--muted); width: 18px; text-align: center; }
+.cmpl-to { color: var(--ra-dark); }
+.cmpl tr.is-chg .cmpl-to { font-weight: 600; }
+.cmpl tr:not(.is-chg) .cmpl-to { color: var(--muted); }
+.cmpl-none { font-size: 13px; color: var(--muted); padding: 4px 0; font-style: italic; }
+
+/* Row accent when its work is the drawer's active work */
+.works-table tbody tr.is-active { background: #fdf4f2; box-shadow: inset 3px 0 0 var(--ra-red); }
+.works-table tbody tr.is-active:hover { background: #fdf4f2; }
+
 .taggedtext-wrap { position: relative; }
 .taggedtext {
   background: #1a1a1a; color: #f0f0f0; font-family: var(--mono); font-size: 12px; line-height: 1.6;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2716,6 +2716,7 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .drawer__title { font-size: 20px; font-weight: 700; line-height: 1.2; margin: 4px 0 6px; }
 .drawer__artist { font-size: 14px; color: var(--muted-2); display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .drawer__flags { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 12px; }
+.drawer__flags--info { margin-top: 6px; } /* slightly tighter spacing -- info row sits right below the primary flags */
 /* Inline warning detail messages under the flag pills (option a -- busier,
    readable; details is what this view is for). */
 .drawer__warning-details { margin-top: 10px; font-size: 12px; color: var(--muted-2); line-height: 1.55; }


### PR DESCRIPTION
The big visible cut-over of Pack 04. Replaces the inline expand-and-edit row that used to appear under each work with a right-docked drawer that mirrors the Entry-Layout editor's editor-left / preview-right pattern. Read mode is fully implemented here; full mode is stubbed for Pack 04c.

> ⚡ CI running in parallel to your QA, per the established pattern.

## What changes visibly

Click a work row → drawer slides in from the right with:
- **Hero**: gallery name, No. {cat}, title, artist (+ quiet `pill--id is-ra` if RA), Pack 02 flag pills, and **inline `<small>` warning-detail messages under the pills** (your decision 2026-05-30 — busier-but-readable, details is what this view is for).
- **Output preview** (★): Template `<select>` (LoW / LPG / any saved template) + **Structure / Tagged Text** tabs. Structure calls Pack 04a's `renderEntryPreview(..., {mode:'works'})` — fill = char style, bordered box = paragraph, no inline labels. Tagged Text calls the new pure `renderEntryTaggedText`.
- **What changed**: compact comparison list — raw spreadsheet → effective export value, rows where they differ. Replaces "scan the full matrix to triage."
- **Actions**: "View all changes & edit override →" (toggles full mode — stub for Pack 04c) + "Exclude from export" / "Re-include".

Body-glide: page content translates left when drawer opens so it re-centres in the visible space. Per your decision (sticky breaking while drawer open is acceptable), no DOM gymnastics to preserve sticky — Pack 03's pinned summary will visually release until the drawer closes.

## URL contract

`#/imports/{id}?work={cat_no}` — deep-link round-trips. Refresh-after-save survives, shareable URL, opens the drawer for that work after the page renders. State updates use `history.replaceState` so the existing hashchange router doesn't re-fetch the import.

## Keyboard

- `Esc` → if full mode, return to read; else close drawer
- `←` / `→` → page between works (gated on `INPUT` / `TEXTAREA` / `SELECT` focus so typing in the override form doesn't paginate — per your confirmation)

## Sub-extraction (in scope per Luke 2026-05-30)

`_teTaggedTextHTML` factored into pure `renderEntryTaggedText(components, fieldValues, opts)` matching Pack 04a's pattern. Editor calls via a thin wrapper preserving its current behaviour; drawer's Tagged Text tab calls directly.

## Repointed

- `workRowHTML` row `onclick` → `_openDrawer` (was `toggleOverrideForm`).
- `workRowHTML` no longer emits the hidden `<tr id="ovr-...">` sibling.
- `scrollToWork`'s auto-open path → `_openDrawer`.
- `renderSections` stashes `_currentLowSections` (pager + venue lookup) and honours `?work=` on initial render.
- `DOMContentLoaded` calls `_drawerMount()` + `_drawerSetupKeyboard()` before `_initAuth`.
- `saveOverride` / `deleteOverride`: removed the `_showWorkDetailPanel` calls (function no longer exists; Pack 04c will add a drawer-refresh hook in their place).

## Removed (dead with the inline-expansion path)

- `_showWorkDetailPanel`
- `toggleWorkOverrideForm`
- `toggleIncludeFromDetail`
- `toggleOverrideForm`

## Kept for Pack 04c

- `_buildWorkDetailTable` — full-mode diff table will reuse.
- `showOverrideForm` — full-mode form will reuse.
- `_refreshWorkRow`.
- `_expandedWorkId` var (dead, kept to avoid touching unrelated references).

## CSS

Ported from `artifacts/source/proto.css`, scoping adjusted. No CSS transition on the drawer's open translate (cascade-only, per the brief's scar-tissue warning that a time-based interpolation can strand the drawer off-screen). The body-glide on `#app` IS transitioned because worst case it just jumps but stays visible.

## Verification

| Check | Result |
|---|---|
| `pytest tests/ -q` | 965 passed |
| `ruff check backend/ tests/` | clean |
| Docker rebuild, `/health` | ok |
| Data preserved across rebuild | 2 LoW + 2 Index intact |
| Container logs after rebuild | no JS syntax / reference errors |
| MCP browser probe — `_openDrawer` for a real work | drawer opens, hero shows "The Annenberg Courtyard / No. 1 / WHAT DO ANIMALS DREAM OF? / Ryan Gander RA + RA pill", output preview has selector + tabs, what-changed renders, pager buttons present, active row marked (`activeRowCount: 1`), body-glide active (`--drawer-shift: -280px`), URL has `?work=1` |

## What's NOT in this PR

- Full mode body (untruncated diff + override form + pinned live preview) — **Pack 04c**.
- Re-render hook in `saveOverride` / `deleteOverride` to refresh the drawer after a save — **Pack 04c**.
- Reconcile-snapshot integration in the full-mode diff column — **Pack 04c**.