### PR TITLE
seed: audit + consolidate three known-artist loaders into one + structural tests

### DIFF
--- a/backend/app/api/known_artists.py
+++ b/backend/app/api/known_artists.py
@@ -5,7 +5,6 @@ API routes for managing the known artists lookup table.
 import json
 import logging
 import uuid
-from pathlib import Path
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -336,63 +335,23 @@ def duplicate_known_artist(
 def seed_known_artists(db: Session = Depends(get_db)):
     """Load known artists from the seed file (known-artists.json).
 
-    Skips entries whose match fields already exist.
+    Delegates to ``services.seed_service.seed_known_artists`` -- the same
+    function the app's startup hook calls. Sharing the loader between the
+    two entry points means new model columns only have to be wired into
+    the constructor in one place, and the admin endpoint inherits the
+    dedupe semantics + field propagation guaranteed by that loader's
+    structural test (tests/test_seed_templates.py).
+
     Returns a count of added/skipped entries.
     """
-    seed_path = (
-        Path(__file__).resolve().parent.parent.parent / "seed_templates" / "known-artists.json"
-    )
-    if not seed_path.exists():
-        raise HTTPException(status_code=404, detail="Seed file not found")
+    from backend.app.services.seed_service import seed_known_artists as _service_seed
 
-    with open(seed_path, encoding="utf-8") as fp:
-        entries = json.load(fp)
-
-    added = 0
-    skipped = 0
-    for entry in entries:
-        match_first = entry.get("match_first_name")
-        match_last = entry.get("match_last_name")
-
-        existing = (
-            db.query(KnownArtist)
-            .filter(
-                KnownArtist.match_first_name == match_first,
-                KnownArtist.match_last_name == match_last,
-                KnownArtist.match_quals == entry.get("match_quals"),
-                KnownArtist.is_seeded == True,  # noqa: E712
-            )
-            .first()
-        )
-        if existing:
-            skipped += 1
-            continue
-
-        ka = KnownArtist(
-            match_first_name=match_first,
-            match_last_name=match_last,
-            match_quals=entry.get("match_quals"),
-            resolved_first_name=entry.get("resolved_first_name"),
-            resolved_last_name=entry.get("resolved_last_name"),
-            resolved_title=entry.get("resolved_title"),
-            resolved_quals=entry.get("resolved_quals"),
-            resolved_is_company=entry.get("resolved_is_company"),
-            resolved_company=entry.get("resolved_company"),
-            resolved_address=entry.get("resolved_address"),
-            resolved_artist2_first_name=entry.get("resolved_artist2_first_name"),
-            resolved_artist2_last_name=entry.get("resolved_artist2_last_name"),
-            resolved_artist2_quals=entry.get("resolved_artist2_quals"),
-            resolved_artist3_first_name=entry.get("resolved_artist3_first_name"),
-            resolved_artist3_last_name=entry.get("resolved_artist3_last_name"),
-            resolved_artist3_quals=entry.get("resolved_artist3_quals"),
-            resolved_artist1_ra_styled=entry.get("resolved_artist1_ra_styled"),
-            resolved_artist2_ra_styled=entry.get("resolved_artist2_ra_styled"),
-            resolved_artist3_ra_styled=entry.get("resolved_artist3_ra_styled"),
-            notes=entry.get("notes"),
-            is_seeded=True,
-        )
-        db.add(ka)
-        added += 1
-
+    # File-existence check is delegated to the service: if the seed JSON
+    # is missing (only possible if a deploy has dropped it from the image
+    # -- it's checked into the repo), the service silently returns (0, 0)
+    # and the endpoint responds with a zero-count payload. That's the right
+    # answer for an admin "re-seed now" trigger: the loader did its job,
+    # there was just nothing to load.
+    added, skipped = _service_seed(db=db)
     db.commit()
     return {"added": added, "skipped": skipped, "total": added + skipped}

--- a/backend/app/services/seed_service.py
+++ b/backend/app/services/seed_service.py
@@ -82,33 +82,59 @@ def seed_builtin_templates(db=None) -> None:
             db.close()
 
 
-def seed_known_artists(db=None) -> None:
+def seed_known_artists(db=None) -> tuple[int, int]:
     """Idempotently insert KnownArtist rows from known-artists.json.
 
-    Unique key: (match_first_name, match_last_name, match_quals).  Entries
-    that already exist are skipped (no upsert of other fields -- once seeded,
-    editors own the row).  Every loader-inserted row carries ``is_seeded=True``.
+    Dedupe key matches the schema's uniqueness constraint exactly:
+    ``(match_first_name, match_last_name, match_quals, is_seeded=True)``.
+    A seed row is skipped only if a prior **seed** row with the same match
+    key already exists; a user-created row (is_seeded=False) with the same
+    match key does NOT block re-insertion. This is intentional and aligns
+    with two existing pieces of design:
 
-    If *db* is provided (e.g. in tests) the caller owns the session: this
-    function will flush but not commit/rollback/close.  When *db* is None a
-    new SessionLocal session is created, committed, and closed here.
+      * The unique constraint is declared as
+        ``(match_first_name, match_last_name, match_quals, is_seeded)`` --
+        i.e. the schema explicitly allows one seed row and one user row
+        per match key to coexist.
+      * The match-cache builder in ``index_override_service.build_known_artist_cache``
+        explicitly handles coexistence at lookup time, with the comment
+        "User entries (is_seeded=False) take priority over seeded ones."
+
+    Net behaviour: if an editor has customised an artist by creating a
+    user override, the seed row may also exist (recreated on every startup
+    if the editor or a manual SQL action ever deleted it). At lookup time
+    the user override always wins. If the editor later removes their
+    override via the DELETE endpoint, the seed row is still present and
+    lookups fall back to the seed value rather than to no-match -- the
+    cleanest possible revert path.
+
+    Returns:
+        ``(added, skipped)`` -- counts of rows inserted and rows skipped
+        because a matching seed row already existed.
+
+    If *db* is provided (e.g. in tests, or by the admin re-seed endpoint
+    that wants to share its request-scoped session) the caller owns the
+    session: this function will flush but not commit/rollback/close.
+    When *db* is None a new SessionLocal session is created, committed,
+    and closed here.
     """
     from backend.app.models.known_artist_model import KnownArtist as _KnownArtist
 
     seed_file = _SEED_DIR / "known-artists.json"
     if not seed_file.exists():
-        return
+        return (0, 0)
 
     from backend.app.db import SessionLocal as _SessionLocal
 
     _external_db = db is not None
     if not _external_db:
         db = _SessionLocal()
+    added = 0
+    skipped = 0
     try:
         with open(seed_file, encoding="utf-8") as fp:
             entries = json.load(fp)
 
-        added = 0
         for entry in entries:
             match_first = entry.get("match_first_name")
             match_last = entry.get("match_last_name")
@@ -118,10 +144,12 @@ def seed_known_artists(db=None) -> None:
                     _KnownArtist.match_first_name == match_first,
                     _KnownArtist.match_last_name == match_last,
                     _KnownArtist.match_quals == entry.get("match_quals"),
+                    _KnownArtist.is_seeded == True,  # noqa: E712 -- SQLAlchemy filter, see ruff_lint_baseline.md
                 )
                 .first()
             )
             if existing:
+                skipped += 1
                 continue
             db.add(
                 _KnownArtist(
@@ -157,10 +185,12 @@ def seed_known_artists(db=None) -> None:
             db.commit()
         else:
             db.flush()
+        return (added, skipped)
     except Exception as exc:  # pragma: no cover
         logger.error("Known artists seed error: %s", exc)
         if not _external_db:
             db.rollback()
+        return (added, skipped)
     finally:
         if not _external_db:
             db.close()

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -624,6 +624,24 @@ controls and editor UX around it.
 - **Request tracing**: add `X-Request-Id` propagation to logs for easier
   troubleshooting.
 
+- **Seed loaders never UPSERT changed values on existing rows.** Both
+  `seed_known_artists` and `seed_builtin_templates` are insert-if-missing
+  only — neither updates the *resolved values* of an existing entry when
+  the seed JSON is edited. Edits to a known-artist's `resolved_*` fields
+  or to the inner config of a template are silently ignored on every
+  existing deployment; the only way to propagate them today is to delete
+  the row manually and let the loader re-insert it on restart. Discovered
+  during the 2026-05-30 seed-loader audit (the same audit that surfaced
+  the `is_seeded` / `resolved_title` / `resolved_company` /
+  `resolved_address` field-omission fixes in PR #94). For known-artists
+  any future UPSERT must respect the user-row-wins coexistence rule
+  already encoded in `build_known_artist_cache` — i.e. UPSERT the seed
+  row's own `is_seeded=True` copy only; never touch the
+  `is_seeded=False` user customisation. For templates the same applies
+  to the `is_builtin=True` row only. Worth a small, dedicated PR
+  (probably with another structural test that asserts the UPSERT
+  reaches every column the constructor sets).
+
 - **Entry-Layout preview: `final_sep_from_last_component` is invisible.**
   The "If the last element is omitted, use its separator after the final
   non-empty field instead" checkbox in the Entry Layout editor updates the

--- a/tests/test_known_artists.py
+++ b/tests/test_known_artists.py
@@ -100,3 +100,49 @@ class TestKnownArtistsCRUD:
         data2 = resp2.json()
         assert data2["added"] == 0
         assert data2["skipped"] == data["total"]
+
+    def test_seed_propagates_fields_and_marks_is_seeded(self, client, db_session):
+        """Endpoint inserts rows that round-trip every JSON field + carry is_seeded=True.
+
+        The structural test in tests/test_seed_templates.py asserts the same
+        guarantees against the *service function*. This test asserts they
+        also hold via the API endpoint -- i.e. confirms the consolidation
+        in the 2026-05-30 seed-loader-audit PR did not regress field
+        propagation when the endpoint switched from its own constructor
+        to delegating to the service.
+        """
+        import json
+        from pathlib import Path
+
+        resp = client.post("/known-artists/seed")
+        assert resp.status_code == 200
+
+        seed_file = (
+            Path(__file__).resolve().parent.parent
+            / "backend"
+            / "seed_templates"
+            / "known-artists.json"
+        )
+        with open(seed_file, encoding="utf-8") as fp:
+            entries = json.load(fp)
+
+        rows = db_session.query(KnownArtist).all()
+        assert len(rows) == len(entries)
+
+        rows_by_key = {(r.match_first_name, r.match_last_name, r.match_quals): r for r in rows}
+        for entry in entries:
+            key = (
+                entry.get("match_first_name"),
+                entry.get("match_last_name"),
+                entry.get("match_quals"),
+            )
+            row = rows_by_key[key]
+            for field, expected in entry.items():
+                actual = getattr(row, field)
+                assert actual == expected, (
+                    f"endpoint did not propagate {field!r} on entry {key!r}: "
+                    f"json={expected!r} db={actual!r}"
+                )
+            assert row.is_seeded is True, (
+                f"endpoint left is_seeded={row.is_seeded!r} on entry {key!r}"
+            )

--- a/tests/test_seed_templates.py
+++ b/tests/test_seed_templates.py
@@ -324,3 +324,147 @@ def test_seed_known_artists_is_idempotent(db_session):
         f"loader is not idempotent: first run {first_count} rows, "
         f"second run {second_count} rows (duplicate inserts)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Known-artists loader: coexistence semantics
+# ---------------------------------------------------------------------------
+#
+# Schema-level: known_artists has a unique constraint on
+# (match_first_name, match_last_name, match_quals, is_seeded). The is_seeded
+# discriminator in that constraint is deliberate -- it allows one seed row
+# and one user-customised row to coexist for the same match key. The
+# lookup code in build_known_artist_cache() then prefers user rows over
+# seed rows at lookup time ("User entries take priority over seeded ones").
+#
+# The seed loader must respect both halves of this: when an editor has
+# created a user override for a seed key, the loader should still insert
+# the seed row alongside (so that deleting the user override later falls
+# back to the seed value rather than to no-match).
+
+
+def test_seed_known_artists_inserts_alongside_user_override(db_session):
+    """If a user row exists for a seed key, the seed row is still inserted."""
+    from backend.app.models.known_artist_model import KnownArtist
+    from backend.app.services.seed_service import seed_known_artists
+
+    # Pick a real seed entry to clash on
+    with open(SEED_DIR / "known-artists.json", encoding="utf-8") as fp:
+        entries = json.load(fp)
+    target = entries[0]
+
+    # Pre-create a user override with the same match key but a different
+    # resolved value -- mimicking an editor who has customised this artist.
+    user_row = KnownArtist(
+        match_first_name=target.get("match_first_name"),
+        match_last_name=target.get("match_last_name"),
+        match_quals=target.get("match_quals"),
+        resolved_first_name="USER_OVERRIDE",
+        resolved_last_name="OVERRIDDEN",
+        is_seeded=False,
+    )
+    db_session.add(user_row)
+    db_session.commit()
+
+    seed_known_artists(db=db_session)
+    db_session.commit()
+
+    matching = (
+        db_session.query(KnownArtist)
+        .filter(
+            KnownArtist.match_first_name == target.get("match_first_name"),
+            KnownArtist.match_last_name == target.get("match_last_name"),
+            KnownArtist.match_quals == target.get("match_quals"),
+        )
+        .all()
+    )
+
+    # Both rows should now exist for this match key
+    assert len(matching) == 2, (
+        f"expected user row + seed row to coexist for match key, got {len(matching)}"
+    )
+    flags = sorted([r.is_seeded for r in matching])
+    assert flags == [False, True], f"expected one user + one seed, got is_seeded={flags}"
+
+    # User row's resolved value must be preserved -- the loader must not
+    # touch existing rows
+    user = next(r for r in matching if not r.is_seeded)
+    assert user.resolved_first_name == "USER_OVERRIDE"
+    assert user.resolved_last_name == "OVERRIDDEN"
+
+
+def test_seed_known_artists_returns_added_skipped_counts(db_session):
+    """Loader returns (added, skipped) tuple for caller bookkeeping."""
+    from backend.app.services.seed_service import seed_known_artists
+
+    with open(SEED_DIR / "known-artists.json", encoding="utf-8") as fp:
+        entries = json.load(fp)
+
+    added, skipped = seed_known_artists(db=db_session)
+    assert added == len(entries), f"first run: expected all {len(entries)} inserted, got {added}"
+    assert skipped == 0, f"first run: expected nothing skipped, got {skipped}"
+
+    added2, skipped2 = seed_known_artists(db=db_session)
+    assert added2 == 0, f"second run: expected nothing inserted, got {added2}"
+    assert skipped2 == len(entries), (
+        f"second run: expected all {len(entries)} skipped, got {skipped2}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Built-in templates loader: structural round-trip
+# ---------------------------------------------------------------------------
+#
+# Analogous to the known-artists round-trip test above: assert that every
+# seed JSON file produces a Ruleset row with the expected slug/name/config
+# values. Catches the same class of bug -- column added to Ruleset (or
+# semantics changed in the JSON shape) but the loader's constructor or
+# upsert path not updated.
+
+
+def test_seed_builtin_templates_round_trip(db_session):
+    """Every seed JSON file (excluding known-artists.json) produces one Ruleset row."""
+    import hashlib
+
+    from backend.app.services.seed_service import seed_builtin_templates
+
+    seed_builtin_templates(db=db_session)
+
+    seed_files = sorted(f for f in SEED_DIR.glob("*.json") if f.name != "known-artists.json")
+    rulesets_by_slug = {r.slug: r for r in db_session.query(Ruleset).all()}
+
+    assert len(rulesets_by_slug) == len(seed_files), (
+        f"loader created {len(rulesets_by_slug)} rulesets from {len(seed_files)} seed files"
+    )
+
+    for seed_file in seed_files:
+        slug = seed_file.stem
+        assert slug in rulesets_by_slug, f"no Ruleset row inserted for seed file {seed_file.name}"
+        row = rulesets_by_slug[slug]
+
+        with open(seed_file, encoding="utf-8") as fp:
+            raw = json.load(fp)
+        expected_name = raw.pop("_name", slug)
+        expected_config_type = raw.pop("_config_type", "template")
+        expected_hash = hashlib.sha256(json.dumps(raw, sort_keys=True).encode()).hexdigest()
+
+        assert row.name == expected_name, f"{slug}: name mismatch"
+        assert row.config_type == expected_config_type, f"{slug}: config_type mismatch"
+        assert row.config == raw, f"{slug}: config payload mismatch"
+        assert row.config_hash == expected_hash, f"{slug}: hash mismatch"
+        assert row.is_builtin is True, f"{slug}: is_builtin must be True for loader-inserted rows"
+
+
+def test_seed_builtin_templates_is_idempotent(db_session):
+    """Running the loader twice does not duplicate rows."""
+    from backend.app.services.seed_service import seed_builtin_templates
+
+    seed_builtin_templates(db=db_session)
+    first_count = db_session.query(Ruleset).count()
+
+    seed_builtin_templates(db=db_session)
+    second_count = db_session.query(Ruleset).count()
+
+    assert first_count == second_count, (
+        f"loader is not idempotent: first run {first_count}, second run {second_count}"
+    )


### PR DESCRIPTION
Defensive audit of every known-artist seed path + structural test coverage for the second loader. Follow-up to the 2026-05-30 #94 work (which fixed `is_seeded` + three `resolved_*` field omissions in `seed_known_artists`). Same bug class, different shape.

## What the audit found

1. **A third loader.** The admin endpoint `POST /known-artists/seed` (in `api/known_artists.py`) duplicated the service-function loader's logic — its own iteration, its own dedupe, its own `KnownArtist(...)` constructor. Two parallel constructors kept manually in sync.

2. **That third loader was missing fields too.** It dropped `resolved_artist2_shared_surname` and `resolved_artist3_shared_surname` — exactly the same bug class as #94's fixes, on the *other* loader. Different missed fields. Proof-of-concept for why duplication is the real risk.

3. **A semantic inconsistency between the two known-artist loaders.** The schema's uniqueness constraint on `known_artists` is `(match_first_name, match_last_name, match_quals, is_seeded)` — i.e. the schema explicitly allows one seed row + one user-customised row per match key. The lookup code in `build_known_artist_cache()` already explicitly handles coexistence, with the comment `# User entries (is_seeded=False) take priority over seeded ones`. The admin endpoint already respected this by filtering its dedupe on `is_seeded == True`. **Only the startup loader didn't** — its dedupe filtered without `is_seeded`, so an editor's user override silently blocked the seed row from being inserted at all.

4. **`seed_builtin_templates` looks clean**, but had no structural test.

## What this PR does

Four commits:

| # | Commit | Purpose |
|---|---|---|
| 1 | `fix(seed): align known-artists dedupe with schema coexistence intent` | Adds `is_seeded == True` to the startup loader's dedupe predicate, so it matches (a) the constraint, (b) the lookup code's expectations, and (c) the admin endpoint's existing behaviour. Also extends the return signature from `None` to `(added, skipped)` to support the next commit. |
| 2 | `refactor(seed): consolidate POST /known-artists/seed to delegate to seed_service` | Endpoint imports the service function and delegates with its request-scoped session. Removes ~47 lines of duplicated constructor + the missing-fields-on-endpoint bug + future drift risk. The single canonical loader is already covered by #94's structural round-trip test. |
| 3 | `test(seed): coexistence + return-tuple + builtin-templates round-trip + API-endpoint propagation` | Four new tests: (a) user-override + seed coexist post-seeding, (b) `(added, skipped)` return values, (c) structural round-trip for `seed_builtin_templates`, (d) field propagation via the API endpoint (complements the service-function test from #94). |
| 4 | `docs(roadmap): seed loaders never UPSERT changed values on existing rows` | Surfaced as finding #6 during the audit; filed under maintenance backlog rather than fixed inline because the UPSERT shape is non-trivial. |

## Behavioural change worth flagging

The dedupe-fix means: if an editor has customised an artist via the admin UI (creating an `is_seeded=False` row), and the container later restarts, the seed row will now also be inserted alongside. The lookup still returns the user's override (`build_known_artist_cache` guarantees this), so import behaviour is unchanged. The only visible difference is in the admin list view, which will show both rows.

Why this is fine — and arguably an improvement:
- The schema constraint explicitly allows coexistence.
- The lookup code is already designed for it.
- The admin re-seed endpoint already produced this state today; we're just propagating the same behaviour to startup.
- It restores a recovery path: if the editor later deletes their override, the seed value falls back instead of "no match."

Full scenario-by-scenario risk analysis (5 scenarios) reviewed pre-implementation; Luke agreed on each. Captured in the updated docstring on `seed_known_artists`.

## Verification

- `pytest tests/ -q` → **972 passed** (was 967 after #94; +5 new tests on this branch)
- `ruff check backend/ tests/` → clean
- `ruff format --check backend/ tests/` → clean
- Manual smoke: the existing `test_seed` endpoint test still passes against the refactored endpoint, confirming response shape `{added, skipped, total}` is preserved.
