### PR TITLE
Pack 05b-3: apply --sp-* tokens to single-value card paddings (tiny)

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -385,7 +385,7 @@ a:hover { text-decoration: underline; }
   flex-shrink: 0;
 }
 .ka-card-body {
-  padding: 16px;
+  padding: var(--sp-4);
 }
 .ka-check-label {
   font-size: 13px;
@@ -1382,7 +1382,7 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .tool-block {
   border: 1px solid #e5e5e5;
   border-radius: 6px;
-  padding: 14px;
+  padding: var(--sp-4);
   background: #fcfcfc;
 }
 .tool-block h4 { margin: 0 0 10px; font-size: var(--t-body); }
@@ -2518,7 +2518,7 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .te-rightcol__sub { display: flex; align-items: center; gap: 8px; background: #fff; border: 1px solid var(--border); border-top: none; padding: 8px 14px; font-size: var(--t-label); color: var(--muted); }
 .te-rightcol__sub select { padding: 3px 6px; border: 1px solid var(--border); border-radius: 3px; background: #fff; font-size: var(--t-label); }
 
-.preview { background: #fff; border: 1px solid var(--border); border-top: none; border-radius: 0 0 6px 6px; padding: 22px; }
+.preview { background: #fff; border: 1px solid var(--border); border-top: none; border-radius: 0 0 6px 6px; padding: var(--sp-5); }
 .preview__paper {
   background: #fff; padding: 22px 20px; border: 1px solid #efefef; border-radius: 4px;
   background-image: linear-gradient(to right, rgba(0,0,0,0) 0, rgba(0,0,0,0) 32px, rgba(192,57,43,.05) 32px, rgba(192,57,43,.05) 33px, rgba(0,0,0,0) 33px);
@@ -2691,7 +2691,7 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 @media (max-width: 780px) { .full-cols { grid-template-columns: 1fr; } }
 .full-form { padding: 18px 22px; }
 .full-prev {
-  padding: 18px; background: #faf8f4; border-left: 1px solid var(--border);
+  padding: var(--sp-4); background: #faf8f4; border-left: 1px solid var(--border);
   position: sticky; top: 0; align-self: start;
   max-height: calc(100vh - 60px); overflow-y: auto;
 }


### PR DESCRIPTION
Third sub-pack of Pack 05b. Tiny (4 lines). The audit revealed that the file has only **4 single-value padding declarations** — everything else is asymmetric `padding: X Y`, which you explicitly asked me to leave alone in the pre-implementation scope discussion ("let's be conservative initially... easily tweaked later if we encounter something that needs it. But let's do that on seeing things rather than to risk breaking unseen things").

## The four substitutions (airier-bias rounding)

| Selector | Was | Is | Visual delta |
|---|---|---|---|
| `.tool-block` (line 1385) | `padding: 14px` | `var(--sp-4)` | +2px |
| `.ka-card-body` (line 388) | `padding: 16px` | `var(--sp-4)` | none (tokenify) |
| `.full-prev` (line 2694) | `padding: 18px` | `var(--sp-4)` | −2px |
| `.preview` (line 2521) | `padding: 22px` | `var(--sp-5)` | +2px |

The `.full-prev` case is the one deviation from strict airier-bias: 18px is equidistant between 16 and 24, but its asymmetric-padded sibling `.full-form` is `padding: 18px 22px`, suggesting 18 was chosen for visual harmony rather than for generosity. Rounded down so the inner edge of `.full-prev` still feels contained. If it looks wrong, easy single-line revert.

## What this PR achieves vs doesn't

**Does:** Establishes that the spacing-token layer (added in Pack 05b-1) is actually used in the call sites, not just defined. Tokenises the only canonical-value single-padding (16px on `.ka-card-body`). Folds three off-scale values onto the scale.

**Doesn't:** Touch any asymmetric padding. The brief's "card padding 12–22px" complaint is real, but all that drift lives inside `padding: X Y` shorthand on table cells, buttons, chips, and inline elements — sweeping those is the aggressive scope you declined ("easily tweaked later if we encounter something that needs it"). Spacing tokens stay available for opportunistic use whenever a specific selector demands attention.

## Verification

Local app already rebuilt for Pack 05b-2; the 05b-3 diff is 4 lines and will be picked up on the next `docker compose build app`. CSS only.
