### PR TITLE
drop(pack-03): remove sticky-shadow CSS — keep sticky pinning, drop the visual

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -624,6 +624,47 @@ controls and editor UX around it.
 - **Request tracing**: add `X-Request-Id` propagation to logs for easier
   troubleshooting.
 
+- **Sticky-shadow feature dropped 2026-05-30 — unresolved compositing
+  mystery.** Pack 03 (2026-05-29) shipped a stuck-shadow under sticky
+  section headers via `.is-stuck` (toggled by an IntersectionObserver)
+  and a CSS rule `box-shadow: 0 8px 10px -9px rgba(.25)` on either the
+  summary or the thead th. Luke flagged the shadow as invisible in
+  both Firefox and Chrome during Pack 03 QA. On 2026-05-30 we
+  investigated for ~1h:
+
+  Findings (verified via Chrome DevTools driving):
+    * IntersectionObserver wiring works; `.is-stuck` is toggled on the
+      correct summaries when sentinels cross the viewport top.
+    * CSS rule matches: with `.is-stuck` present and the thead pattern,
+      the computed `box-shadow` on the thead th is exactly what the
+      rule specifies (verified with both subtle and DIAGNOSTIC 60%-red
+      values).
+    * No `overflow:hidden` anywhere up the ancestor chain.
+    * TH is sticky-pinned at `top:71px`, z-index:15, sitting visibly
+      above a transparent body. Geometry of where the shadow SHOULD
+      paint (~y=96-128 with the diagnostic value) is well inside the
+      visible viewport.
+
+  Despite all of the above, even the deliberately-obnoxious 60%-red
+  diagnostic shadow did NOT read visibly during real-time inspection.
+  Most likely a stacking-context / sticky-compositing subtlety (the
+  shadow may be rendering "behind" something invisible to
+  `elementsFromPoint` analysis, or paint order between the sticky TH
+  and the section.panel siblings is interacting unexpectedly), but
+  the time budget for the investigation ran out before we could pin
+  it down.
+
+  PR #99 (2026-05-30) removes both shadow CSS rules entirely. The
+  sticky pinning itself (summary + thead) works correctly and stays
+  -- it's a useful affordance even without the visual "you are stuck"
+  cue. The `.is-stuck` class is still toggled by the JS, harmlessly,
+  in case a future fix or alternative use wants the hook.
+
+  To revive: the existing JS scaffolding (sentinel + IO + class) is
+  intact, so a future attempt only needs to add the CSS rule back and
+  diagnose the compositing puzzle in real time. The investigation
+  notes above are the head start.
+
 - **Seed loaders never UPSERT changed values on existing rows.** Both
   `seed_known_artists` and `seed_builtin_templates` are insert-if-missing
   only — neither updates the *resolved values* of an existing entry when

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1319,11 +1319,6 @@ details.section-block[open] > .section-summary::before {
 /* Opt-in sticky section (applied per page in Pack 03 — never on bare .section-block).
    Audit log + Tools keep the base class and are provably unaffected. */
 .section-block--sticky > .section-summary { position:sticky; top:var(--site-header-h,0); z-index:20; background:var(--bg); }
-/* Default stuck-shadow: on the summary itself. Applies whenever the block
-   has no sticky data-table thead beneath (e.g., a hypothetical sticky
-   section with no table). The .has-sticky-thead marker (set in JS at
-   wiring time) overrides this to move the shadow to the thead. */
-.section-block--sticky > .section-summary.is-stuck { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
 /* Pin the table column header below the sticky summary so column meaning
    survives the scroll. Pack 03 (2026-05-29). Applies to any .data-table
    inside a sticky block — covers LoW .works-table AND Index .index-table.
@@ -1337,14 +1332,17 @@ details.section-block[open] > .section-summary::before {
   background: var(--card);
   z-index: 15;
 }
-/* Pack 03 (2026-05-29) — when the section has a sticky data-table thead
-   beneath the summary, the shadow moves DOWN to the bottom of the column
-   header. The summary + thead are functionally one pinned header block
-   while stuck; the shadow should sit below the whole block, not between
-   the two halves. JS adds .has-sticky-thead to qualifying blocks at
-   wiring time. */
-.section-block--sticky.has-sticky-thead > .section-summary.is-stuck { box-shadow:none; }
-.section-block--sticky.has-sticky-thead .section-summary.is-stuck ~ .data-table thead th { box-shadow:0 8px 10px -9px rgba(0,0,0,.25); }
+/* Stuck-shadow feature dropped 2026-05-30 (see docs/roadmap.md maintenance
+   backlog). The shadow rules and the .is-stuck class toggling that fed
+   them were investigated for ~1h after Luke reported the shadow was
+   invisible in two browsers; with a 60% red diagnostic value, the shadow
+   STILL didn't read visibly in real-time browser inspection, suggesting
+   a stacking-context or compositing subtlety we couldn't pin down in
+   the time available. The sticky pinning itself (summary + thead) works
+   correctly and stays. The .is-stuck class is still toggled by the JS
+   IntersectionObserver in _wireStickySections, harmlessly -- no CSS
+   currently references it; the hook stays available for a future fix
+   or alternative use. */
 
 /* Audit log */
 .audit-table .col-ts { width: 140px; font-size: var(--t-label); }


### PR DESCRIPTION
**Dropping the Pack 03 sticky-shadow feature** rather than continuing to spin on an unresolved compositing puzzle.

## What happened

Pack 03 shipped a stuck-shadow under sticky section headers. You flagged it as invisible in both Firefox and Chrome at the time. This PR was opened thinking it was just a too-subtle value (the original `-9px` spread against `10px` blur is mathematically ~1px of effective shadow). Bumping the value didn't fix it.

## What we verified during ~1h of investigation today

| Question | Answer |
|---|---|
| Is `.is-stuck` toggling correctly? | **Yes.** IntersectionObserver works; correct summaries get the class when sentinels cross the viewport top. |
| Does CSS match the DOM? | **Yes.** With `.is-stuck` set and `.has-sticky-thead` in place, the thead th's computed `box-shadow` is exactly the declared value (verified with both subtle and a 60%-red impossible-to-miss diagnostic). |
| Anything clipping it (`overflow:hidden`)? | **No.** Verified all the way up to `<html>`. |
| Geometry? | **Should be visible.** TH sticky-pinned at `top:71px`, z-index:15, shadow paint area at y=96-128 well inside viewport. |

Despite all of that being correct, even the 60%-red diagnostic shadow didn't read visibly. The remaining hypothesis is a stacking-context or sticky-compositing subtlety we couldn't pin down in the time we had.

## What this PR does

- Removes both shadow CSS rules
- Removes the now-unneeded `.has-sticky-thead → box-shadow:none` override
- **Keeps** the sticky pinning itself (summary + thead). It works; the "where am I" affordance survives without the "I'm floating" visual cue.
- **Keeps** the JS scaffolding (`.is-stuck` class toggling via IntersectionObserver). Harmless when no CSS references it; available as a hook for future use.
- Rewrites the roadmap entry from "if shadow still invisible, try X/Y/Z" to "feature dropped, here are the investigation findings as a head start for any future revival attempt".

## QA

Test: scroll any LoW import. Section header still sticks at top; thead still pins below it; column meaning still survives scroll. The shadow that wasn't reading visibly is now genuinely gone.
