### PR TITLE
Pack 05b-4: retire inline button styles + remove orphan .btn-success

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1750,9 +1750,9 @@ async function _loadUsersTable() {
         <td>${statusBadge}</td>
         <td>
           ${u.enabled
-            ? `<button class="btn btn-sm" onclick="_toggleUser('${esc(u.username)}', false)" style="font-size:0.75rem">Disable</button>`
-            : `<button class="btn btn-sm" onclick="_toggleUser('${esc(u.username)}', true)" style="font-size:0.75rem">Enable</button>`}
-          <button class="btn btn-sm" onclick="_showResetPassword('${esc(u.username)}')" style="font-size:0.75rem;margin-left:4px">Reset PW</button>
+            ? `<button class="btn btn-sm" onclick="_toggleUser('${esc(u.username)}', false)">Disable</button>`
+            : `<button class="btn btn-sm" onclick="_toggleUser('${esc(u.username)}', true)">Enable</button>`}
+          <button class="btn btn-sm" onclick="_showResetPassword('${esc(u.username)}')" style="margin-left:4px">Reset PW</button>
         </td>
       </tr>`;
     }).join('');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -613,9 +613,6 @@ a:hover { text-decoration: underline; }
 .btn-warning   { background: #fff; color: var(--warning); border-color: var(--warning); }
 .btn-warning:hover { background: #fdf8f0; }
 
-.btn-success   { background: #fff; color: var(--success); border-color: var(--success); }
-.btn-success:hover { background: #f0fdf4; }
-
 .btn-sm  { padding: 4px 10px; font-size: var(--t-label); }
 .btn-xs  { padding: 2px 8px;  font-size: var(--t-mini); }
 


### PR DESCRIPTION
Final sub-pack of the 05b token sweep series. Smaller than the brief implied: the audit found the codebase is **already consistent** on the colour conventions the brief targeted.

## Audit findings (no changes needed for these)

| Class | Usage | Verdict |
|---|---|---|
| `.btn-primary` (black) | All 16 instances are primary actions (Sign In, Save *, Create User, Export, etc.) | Consistent ✓ |
| `.btn-danger` (red) | All instances are destructive (Delete *, Unmerge artist) | Consistent ✓ |
| `.btn-warning` (amber) | 3 instances, all on "has override" toggles | Semantically appropriate ✓ |

The brief's "primary is black in places, red in others" complaint appears to have been overstated or already-fixed. No colour re-wiring needed.

## What this PR does change

1. **Three buttons in the Users admin panel** had `style="font-size:0.75rem"` inline. 0.75rem = 12px, which is exactly what `.btn-sm` already sets via `var(--t-label)`. Pure redundancy — the inline declarations changed nothing. Removed.

2. **`.btn-success`** was defined in `style.css` (white bg, green border/text, hover variant) but had **zero callers** in `app.js`. Same orphan pattern as Pack 05a's badge cleanup. Removed.

## What I left intact

Two inline `margin-left:Xpx` styles deliberately left:
- Reset PW button (`margin-left:4px` to gap from Enable/Disable)
- `reimport-cancel` button (`margin-left:8px` to gap from preceding)

These are real layout, not redundant. Refactoring to flex-gap on the parent containers is its own concern — bigger diff, touches the parent containers' layout shape, and has no visual benefit beyond cleanliness.

## Pack 05b series complete after this

After this lands:
- ✅ 05b-1: token infra + hover restoration + focus-visible ring
- ✅ 05b-2: type token application
- ✅ 05b-3: spacing token application (tiny)
- ✅ 05b-4: button consolidation (this PR)
- → 05c (deferred): nav demotion + shared empty/loading partial — both independently shippable polish, no critical path

## QA

Trivial: rebuilt locally, `.btn-success` confirmed gone from served CSS, 3 user-admin buttons still render at 12px (via `.btn-sm` rather than via redundant inline style).
