### PR TITLE
Pack 05c-1: keep utility nav links muted on hover (1-line fix)

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -244,7 +244,7 @@ a:hover { text-decoration: underline; }
   font-weight: 400;
   opacity: 0.7;
 }
-.site-nav a[target="_blank"]:hover { opacity: 1; }
+.site-nav a[target="_blank"]:hover { opacity: 1; color: var(--muted-2); }
 
 /* ------------------------------------------------------------------ */
 /* Settings form                                                       */


### PR DESCRIPTION
First half of Pack 05c. One-line CSS fix; the audit found the rest of the nav-demotion work was already done.

## What it does

`.site-nav a[target="_blank"]:hover` now also sets `color: var(--muted-2)`, so utility links (API docs / ReDoc / Health) stay muted on hover instead of escalating to the same `var(--ra-dark)` colour that core nav links use.

## Before this fix

| State | Utility | Core |
|---|---|---|
| Static | 12px / w400 / #888 / opacity 0.7 | 13px / w500 / #888 / opacity 1 |
| Hover | 12px / w400 / **#1a1a1a / opacity 1** | 13px / w500 / #1a1a1a / opacity 1 |

Utility-on-hover looked visually identical to core-on-hover — defeating the demotion the instant a cursor passed.

## After

| State | Utility | Core |
|---|---|---|
| Static | 12px / w400 / #888 / opacity 0.7 | 13px / w500 / #888 / opacity 1 |
| Hover | 12px / w400 / **#666 / opacity 1** | 13px / w500 / #1a1a1a / opacity 1 |

Utility links still register as interactive on hover (slight colour shift + opacity bump), but never reach core-nav prominence.

## QA

Hover over "API docs" / "API ReDoc" / "Health" links in the top nav. They should darken slightly but remain visibly subordinate to "List of Works" / "Index" / etc.

## Next

05c-2 will be the bigger sweep — unify the ~18 ad-hoc loading/empty-state strings in `app.js` behind shared `.empty-state` / `.loading-state` CSS + small JS helpers. Separate PR.
