### PR TITLE
Pack 05c-2: shared .empty-state class for loading/empty messages

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -622,7 +622,7 @@ async function _runComparison() {
   const btn = document.getElementById('cmp-run-btn');
   const restore = btnLoading(btn, 'Comparing');
   const container = document.getElementById('cmp-result');
-  container.innerHTML = '<p class="loading" style="padding:20px 0">Comparing datasets\u2026</p>';
+  container.innerHTML = '<p class="empty-state">Comparing datasets\u2026</p>';
 
   try {
     const result = await api('POST', `/compare?low_import_id=${lowId}&index_import_id=${idxId}`);
@@ -747,7 +747,7 @@ function _renderCompareTable() {
   });
 
   if (!entries.length) {
-    wrap.innerHTML = '<p class="muted" style="padding:8px 0">No entries match this filter.</p>';
+    wrap.innerHTML = '<p class="empty-state empty-state--compact">No entries match this filter.</p>';
     return;
   }
 
@@ -1008,7 +1008,7 @@ function renderAuditPanel(logs) {
   const panel = document.getElementById('audit-panel');
   if (!panel) return;
   if (!logs.length) {
-    panel.innerHTML = '<p class="muted" style="padding:4px 0">No audit log entries yet.</p>';
+    panel.innerHTML = '<p class="empty-state empty-state--compact">No audit log entries yet.</p>';
     return;
   }
   panel.innerHTML = `
@@ -1126,7 +1126,7 @@ function _reconcileRulesPanel(rc) {
 
 async function renderSettings(initialTab) {
   const app = document.getElementById('app');
-  app.innerHTML = '<p class="loading" style="padding:40px 0">Loading settings&hellip;</p>';
+  app.innerHTML = '<p class="empty-state">Loading settings&hellip;</p>';
   let cfg, knownArtists, reconcileCfg;
   try {
     [cfg, knownArtists, reconcileCfg] = await Promise.all([
@@ -2535,7 +2535,7 @@ function moveComponent(btn, dir) {
 
 async function renderTemplates() {
   const app = document.getElementById('app');
-  app.innerHTML = '<p class="loading" style="padding:40px 0">Loading templates&hellip;</p>';
+  app.innerHTML = '<p class="empty-state">Loading templates&hellip;</p>';
 
   let lowTemplates, idxTemplates;
   try {
@@ -2708,7 +2708,7 @@ async function exportTemplate(id, kind, btnEl) {
 
 async function renderIndexTemplateEdit(id) {
   const app = document.getElementById('app');
-  app.innerHTML = '<p class="loading" style="padding:40px 0">Loading&hellip;</p>';
+  app.innerHTML = '<p class="empty-state">Loading&hellip;</p>';
 
   const isNew = id === 'new';
   let cfg = {};
@@ -3210,7 +3210,7 @@ function _teNormalize() {
 
 async function renderTemplateEdit(id) {
   const app = document.getElementById('app');
-  app.innerHTML = '<p class="loading" style="padding:40px 0">Loading&hellip;</p>';
+  app.innerHTML = '<p class="empty-state">Loading&hellip;</p>';
   const isNew = id === 'new';
   let cfg = {};
   let isBuiltin = false;
@@ -4397,7 +4397,7 @@ async function renderDetail(importId) {
       <div class="tools-body">
         <section class="tool-block">
           <h4>Export</h4>
-          <div id="export-panel-${esc(importId)}"><p class="loading" style="padding:4px 0">Loading templates\u2026</p></div>
+          <div id="export-panel-${esc(importId)}"><p class="empty-state empty-state--compact">Loading templates\u2026</p></div>
         </section>
         ${ifEditor(`<section class="tool-block reimport-panel">
           <h4>Update Import</h4>
@@ -6515,7 +6515,7 @@ function _paintReconGroups() {
     return true;
   });
   if (!filtered.length) {
-    host.innerHTML = '<p class="muted" style="margin:8px 0">No differences match the current filter.</p>';
+    host.innerHTML = '<p class="empty-state empty-state--compact">No differences match the current filter.</p>';
     return;
   }
   const structural = filtered.filter(f => f.fix_channel === 'spreadsheet');
@@ -6894,7 +6894,7 @@ async function renderIndexDetail(importId) {
     </section>`)}
     <section class="panel">
       <h3>Export</h3>
-      <div id="index-export-panel"><p class="loading" style="padding:4px 0">Loading templates…</p></div>
+      <div id="index-export-panel"><p class="empty-state empty-state--compact">Loading templates…</p></div>
     </section>
     <section class="panel" id="index-warnings-panel"><p class="loading">Loading flagged issues\u2026</p></section>
     <section class="panel">
@@ -6994,7 +6994,7 @@ function renderIndexAuditPanel(logs) {
   const panel = document.getElementById('index-audit-panel');
   if (!panel) return;
   if (!logs.length) {
-    panel.innerHTML = '<p class="muted" style="padding:4px 0">No audit log entries yet.</p>';
+    panel.innerHTML = '<p class="empty-state empty-state--compact">No audit log entries yet.</p>';
     return;
   }
   panel.innerHTML = `

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1468,6 +1468,19 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 .loading  { color: var(--muted); font-style: italic; }
 .error    { color: var(--danger); }
 
+/* Shared empty / loading state — Pack 05c-2 (2026-05-30).
+   Use in place of ad-hoc <p class="muted" style="padding:Xpx 0">No X</p>
+   or <p class="loading" style="padding:Xpx 0">Loading…</p> blocks.
+   The text content carries the semantic ("Loading…" vs "No X yet") --
+   the class just handles the visual register. */
+.empty-state {
+  color: var(--muted);
+  font-style: italic;
+  padding: var(--sp-6) 0;
+  text-align: center;
+}
+.empty-state--compact { padding: var(--sp-1) 0; }
+
 /* ------------------------------------------------------------------ */
 /* Toast notifications                                                 */
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Second half of Pack 05c. Closes out the design refresh.

## What it does

**One new CSS partial** in `style.css`, sitting next to the existing `.muted`/`.loading` utilities:

```css
.empty-state {
  color: var(--muted);
  font-style: italic;
  padding: var(--sp-6) 0;     /* 32px */
  text-align: center;
}
.empty-state--compact { padding: var(--sp-1) 0; }    /* 4px */
```

Both consume the Pack 05b-1 spacing tokens.

**11 call-site substitutions** in `app.js`, all of them previously inline-styled:

| Was | Variant | Visual delta |
|---|---|---|
| `style="padding:40px 0"` x4 (loading) | `.empty-state` | −8px padding, now centered |
| `style="padding:20px 0"` x1 (loading) | `.empty-state` | +12px padding, now centered |
| `style="padding:4px 0"` x2 (loading) | `.empty-state--compact` | none |
| `style="padding:8px 0"` x1 (muted) | `.empty-state--compact` | −4px |
| `style="padding:4px 0"` x2 (muted) | `.empty-state--compact` | none |
| `style="margin:8px 0"` x1 (muted) | `.empty-state--compact` | none |

## What it deliberately doesn't touch

(Each is a different concern; sweeping them in would risk visual regressions for negligible gain.)

- `<span class="muted">—</span>` em-dash placeholders for missing cell values (different visual register — inline span, not block)
- `<p class="muted">No X</p>` and `<p class="loading">Loading…</p>` bare paragraphs with no inline padding (converting them would shift from 0-pad/left-aligned to 32-pad/centered — too risky)
- `<option value="">Loading…</option>` select-option placeholders
- `<h2 class="page-heading">Loading…</h2>` heading-style loading
- Naked `<div>Loading…</div>` divs that get replaced fast
- The `.loading` and `.muted` utility classes themselves (used elsewhere as general utilities, not just for empty states)

## QA

Anywhere you see "Loading…" or "No X yet" / "No matches" at a moment when something would otherwise show — should look the same (or marginally airier in the 5 cases that gained padding). The cleanup is mostly invisible; the win is that future "no X" / "loading X" messages can use a single class instead of an ad-hoc inline-styled paragraph.

## Pack 05c + design refresh complete

After this merges, the original handoff's structural work is fully shipped. Standing deferred items (none on critical path):
- Seed loaders never UPSERT on existing rows (roadmap, not design-refresh related)
- Sticky-shadow revival if anyone wants to crack the compositing puzzle (roadmap, with investigation notes as a head start)
