### PR TITLE
docs: refresh test counts (~960 → ~975, 38 → 40 files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ frontend/
   index.html
   app.js
   style.css
-tests/            # pytest suite (~960 tests across 38 test files)
+tests/            # pytest suite (~975 tests across 40 test files)
 .github/workflows/
   ci.yml          # GitHub Actions CI/CD pipeline
 .aws/

--- a/docs/architecture_v1.md
+++ b/docs/architecture_v1.md
@@ -46,7 +46,7 @@ Excel Upload
 | Frontend   | Vanilla JS SPA, served by FastAPI       |
 | Deployment | Docker, ECS Fargate, GitHub Actions     |
 | Storage    | Local disk / Amazon S3                  |
-| Testing    | pytest (900 tests across 37 test files) |
+| Testing    | pytest (~975 tests across 40 test files) |
 
 ---
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -32,7 +32,7 @@ Academy Summer Exhibition catalogue. It handles two products:
 | `backend/alembic/versions/` | Database migrations (auto-run on startup)             |
 | `backend/seed_templates/`   | Default templates and known artist seed data          |
 | `frontend/`                 | Single-page app (`app.js`, `style.css`, `index.html`) |
-| `tests/`                    | Pytest suite (~960 tests, SQLite in-memory)           |
+| `tests/`                    | Pytest suite (~975 tests, SQLite in-memory)           |
 
 ### Data flow
 


### PR DESCRIPTION
Stale numbers in 3 places. Actual count via `pytest --collect-only` is 972 across 40 files; rounded to "~975" to stay an approximation. No app changes.