### PR TITLE
Add editable free-text "Import description" to imports

### DIFF
--- a/backend/alembic/versions/m3e5g7i9k1d2_rename_import_notes_to_description.py
+++ b/backend/alembic/versions/m3e5g7i9k1d2_rename_import_notes_to_description.py
@@ -1,0 +1,31 @@
+"""rename imports.notes to imports.description
+
+The ``imports.notes`` column has existed (nullable) but was never written to:
+it surfaced in the import-list responses yet had no way to be set. It is being
+promoted to a user-editable free-text "description" field, renamed here to
+avoid colliding conceptually with the unrelated "Import notes" validation
+panel in the UI. The column is empty in practice, so the rename is data-safe.
+
+Revision ID: m3e5g7i9k1d2
+Revises: l2d4f6h8j0c1
+Create Date: 2026-06-06
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "m3e5g7i9k1d2"
+down_revision: Union[str, Sequence[str], None] = "l2d4f6h8j0c1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("imports", "notes", new_column_name="description")
+
+
+def downgrade() -> None:
+    op.alter_column("imports", "description", new_column_name="notes")

--- a/backend/app/api/index.py
+++ b/backend/app/api/index.py
@@ -17,6 +17,8 @@ from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
 from backend.app.api.schemas import (
     AutoResolvedFields,
+    ImportDescriptionOut,
+    ImportDescriptionUpdate,
     IndexArtistOut,
     IndexArtistOverrideIn,
     IndexArtistOverrideOut,
@@ -138,12 +140,33 @@ def list_index_imports(db: Session = Depends(get_db)):
             id=str(i.id),
             filename=i.filename,
             uploaded_at=i.uploaded_at.isoformat(),
-            notes=i.notes,
+            description=i.description,
             product_type=i.product_type,
             artist_count=artist_counts.get(str(i.id), 0),
         )
         for i in imports
     ]
+
+
+@router.patch(
+    "/imports/{import_id}",
+    response_model=ImportDescriptionOut,
+    dependencies=[Depends(require_role("editor"))],
+)
+def update_index_import_description(
+    import_id: UUID,
+    body: ImportDescriptionUpdate,
+    db: Session = Depends(get_db),
+):
+    """Set or clear the free-text description for an Artists' Index import.
+
+    Whitespace is trimmed; an empty value clears the field (stored as NULL).
+    The 256-character cap is enforced by ``ImportDescriptionUpdate``.
+    """
+    import_record = _get_index_import_or_404(import_id, db)
+    import_record.description = body.description
+    db.commit()
+    return ImportDescriptionOut(id=str(import_id), description=import_record.description)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/low_imports.py
+++ b/backend/app/api/low_imports.py
@@ -16,6 +16,8 @@ from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
 from backend.app.api.normalisation_config import load_normalisation_settings
 from backend.app.api.schemas import (
+    ImportDescriptionOut,
+    ImportDescriptionUpdate,
     ImportOut,
     PreviewSectionOut,
     PreviewWorkOut,
@@ -215,7 +217,7 @@ def list_imports(db: Session = Depends(get_db)):
                 "id": iid,
                 "filename": i.filename,
                 "uploaded_at": i.uploaded_at.isoformat(),
-                "notes": i.notes,
+                "description": i.description,
                 "sections": section_counts.get(iid, 0),
                 "works": work_counts.get(iid, 0),
                 "override_count": ovr.override_count if ovr else 0,
@@ -226,6 +228,35 @@ def list_imports(db: Session = Depends(get_db)):
         )
 
     return result
+
+
+@router.patch(
+    "/imports/{import_id}",
+    response_model=ImportDescriptionOut,
+    dependencies=[Depends(require_role("editor"))],
+)
+def update_import_description(
+    import_id: UUID,
+    body: ImportDescriptionUpdate,
+    db: Session = Depends(get_db),
+):
+    """Set or clear the free-text description for a list-of-works import.
+
+    Whitespace is trimmed; an empty value clears the field (stored as NULL).
+    The 256-character cap is enforced by ``ImportDescriptionUpdate``.
+    """
+    import_record = (
+        db.query(Import)
+        .filter(Import.id == import_id, Import.product_type == "list_of_works")
+        .first()
+    )
+    if not import_record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Import not found")
+
+    import_record.description = body.description
+    db.commit()
+
+    return ImportDescriptionOut(id=str(import_id), description=import_record.description)
 
 
 @router.get("/imports/{import_id}/sections", response_model=List[SectionOut])

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -15,13 +15,44 @@ class ImportOut(BaseModel):
     id: str
     filename: str
     uploaded_at: str
-    notes: str | None
+    description: str | None
     sections: int
     works: int
     override_count: int
     last_override_at: str | None
 
     model_config = {"from_attributes": True}
+
+
+# Max length for the free-text import description. Mirrored client-side as the
+# input's maxlength; enforced authoritatively here.
+IMPORT_DESCRIPTION_MAX_LEN = 256
+
+
+class ImportDescriptionUpdate(BaseModel):
+    """Request body for setting/clearing an import's free-text description."""
+
+    description: str | None = None
+
+    @field_validator("description")
+    @classmethod
+    def _normalise(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if len(v) > IMPORT_DESCRIPTION_MAX_LEN:
+            raise ValueError(
+                f"Description must be {IMPORT_DESCRIPTION_MAX_LEN} characters or fewer"
+            )
+        # Empty / whitespace-only is stored as NULL (clears the field).
+        return v or None
+
+
+class ImportDescriptionOut(BaseModel):
+    """Lightweight response after updating a description."""
+
+    id: str
+    description: str | None
 
 
 class GallerySummaryOut(BaseModel):
@@ -562,7 +593,7 @@ class IndexImportOut(BaseModel):
     id: str
     filename: str
     uploaded_at: str
-    notes: str | None = None
+    description: str | None = None
     product_type: str
     artist_count: int
     override_count: int = 0

--- a/backend/app/models/import_model.py
+++ b/backend/app/models/import_model.py
@@ -14,7 +14,9 @@ class Import(Base):
 
     filename = Column(Text, nullable=False)
     disk_filename = Column(Text, nullable=True)  # UUID-prefixed name on disk
-    notes = Column(Text, nullable=True)
+    # Free-text, user-editable note about this import (max 256 chars, enforced
+    # at the API layer). Distinct from the "Import notes" validation panel.
+    description = Column(Text, nullable=True)
 
     # 'list_of_works' | 'artists_index'
     product_type = Column(Text, nullable=False, server_default="list_of_works")

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4051,6 +4051,7 @@ async function loadImportList() {
         <td><code class="import-id" title="${esc(i.id)}">${esc(i.id.slice(0, 8))}&hellip;</code></td>
         <td><a class="link" href="#/import/${esc(i.id)}">${esc(i.filename)}</a></td>
         <td>${esc(formatDate(i.uploaded_at))}</td>
+        <td class="import-description-cell">${i.description ? `<span title="${esc(i.description)}">${esc(i.description)}</span>` : '<span class="muted">&mdash;</span>'}</td>
         <td class="num">${i.sections}</td>
         <td class="num">${i.works}</td>
         <td class="num">${ovrCell}</td>
@@ -4063,7 +4064,7 @@ async function loadImportList() {
     container.innerHTML = `
       <table class="data-table">
         <thead><tr>
-          <th>ID</th><th>Filename</th><th>Uploaded</th>
+          <th>ID</th><th>Filename</th><th>Uploaded</th><th>Description</th>
           <th class="num">Sections</th><th class="num">Works</th>
           <th class="num">Overrides</th>
           <th>Actions</th>
@@ -4381,6 +4382,50 @@ function _importHeadingMeta(imp, isLatest) {
   return `<span class="heading-meta">${parts.join(' · ')}</span>`;
 }
 
+// The free-text "Import description" shown beside the heading meta strip.
+// Editors get an inline-editable input (saved on blur / Enter); everyone else
+// sees it read-only, or nothing when empty. `imp` is an import-list row.
+// Distinct from the "Import notes" validation panel. Returns escaped HTML.
+function _importDescriptionHTML(imp) {
+  const desc = imp.description || '';
+  if (canEdit()) {
+    return `<input type="text" class="import-description-input" id="import-description-input"`
+      + ` maxlength="256" value="${esc(desc)}" placeholder="Add a description…"`
+      + ` aria-label="Import description"`
+      + ` title="Free-text note about this import (max 256 characters)">`;
+  }
+  return desc
+    ? `<span class="import-description" title="${esc(desc)}">${esc(desc)}</span>`
+    : '';
+}
+
+// Wire save-on-blur / Enter for the editable description input. `patchPath` is
+// the PATCH endpoint for this import; `current` is its saved description.
+// Reverts on error and treats blank input as a clear (NULL).
+function _wireImportDescription(patchPath, current) {
+  const input = document.getElementById('import-description-input');
+  if (!input) return;
+  let lastSaved = (current || '').trim();
+  async function save() {
+    const val = input.value.trim();
+    if (val === lastSaved) { input.value = lastSaved; return; }
+    try {
+      const res = await api('PATCH', patchPath, { description: val || null });
+      lastSaved = res?.description || '';
+      input.value = lastSaved;
+      showToast('Description saved', 'success', 2500);
+    } catch (err) {
+      input.value = lastSaved;  // revert on failure
+      showToast(`Couldn’t save description: ${err.message}`, 'error');
+    }
+  }
+  input.addEventListener('blur', save);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
+    else if (e.key === 'Escape') { input.value = lastSaved; input.blur(); }
+  });
+}
+
 function formatPrice(price_numeric, price_text, cfg) {
   if (price_numeric != null) {
     const dp  = (cfg?.decimal_places    ?? 0);
@@ -4517,7 +4562,9 @@ async function renderDetail(importId) {
   const detailHeadingEl = document.getElementById('detail-heading');
   if (thisImport) {
     detailHeadingEl.innerHTML =
-      `Import \u2013 ${esc(originalFilename)} ${_importHeadingMeta(thisImport, isLatest)}`;
+      `Import \u2013 ${esc(originalFilename)} ${_importHeadingMeta(thisImport, isLatest)}`
+      + ` ${_importDescriptionHTML(thisImport)}`;
+    _wireImportDescription(`/imports/${importId}`, thisImport.description || '');
   } else {
     detailHeadingEl.textContent = `Import \u2013 ${importId.slice(0, 8)}\u2026`;
   }
@@ -6831,6 +6878,7 @@ async function loadIndexImportList() {
         <td><code class="import-id" title="${esc(i.id)}">${esc(i.id.slice(0, 8))}\u2026</code></td>
         <td><a class="link" href="#/index/${esc(i.id)}">${esc(i.filename)}</a></td>
         <td>${esc(formatDate(i.uploaded_at))}</td>
+        <td class="import-description-cell">${i.description ? `<span title="${esc(i.description)}">${esc(i.description)}</span>` : '<span class="muted">&mdash;</span>'}</td>
         <td class="num">${i.artist_count}</td>
         <td>
           <button class="btn btn-sm btn-secondary" onclick="navigate('#/index/${esc(i.id)}')">View</button>
@@ -6840,7 +6888,7 @@ async function loadIndexImportList() {
     container.innerHTML = `
       <table class="data-table">
         <thead><tr>
-          <th>ID</th><th>Filename</th><th>Uploaded</th>
+          <th>ID</th><th>Filename</th><th>Uploaded</th><th>Description</th>
           <th class="num">Artists</th>
           <th>Actions</th>
         </tr></thead>
@@ -6990,7 +7038,9 @@ async function renderIndexDetail(importId) {
   const idxHeadingEl = document.getElementById('index-detail-heading');
   if (thisImport) {
     idxHeadingEl.innerHTML =
-      `Artists Index \u2013 ${esc(importFilename)} ${_importHeadingMeta(thisImport, isLatest)}`;
+      `Artists Index \u2013 ${esc(importFilename)} ${_importHeadingMeta(thisImport, isLatest)}`
+      + ` ${_importDescriptionHTML(thisImport)}`;
+    _wireImportDescription(`/index/imports/${importId}`, thisImport.description || '');
   } else {
     idxHeadingEl.textContent = `Artists Index \u2013 ${importId.slice(0, 8)}\u2026`;
   }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -573,6 +573,47 @@ a:hover { text-decoration: underline; }
 .recency--latest { color: var(--success); }
 .recency--stale  { color: var(--warning); }
 
+/* Free-text "Import description" beside the detail heading. Editable inline for
+   editors; read-only span otherwise. Sized down so it doesn't inherit the h2. */
+.import-description-input {
+  font-family: var(--font);
+  font-size: var(--t-label);
+  font-weight: 400;
+  color: var(--muted-2);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  padding: 2px 6px;
+  margin-left: 8px;
+  min-width: 200px;
+  max-width: 380px;
+  vertical-align: middle;
+}
+.import-description-input:hover { border-color: var(--border); }
+.import-description-input:focus {
+  outline: none;
+  border-color: var(--info);
+  background: var(--card);
+  color: var(--ra-dark);
+}
+.import-description-input::placeholder { color: var(--muted); font-style: italic; }
+.import-description {
+  font-size: var(--t-label);
+  font-weight: 400;
+  color: var(--muted-2);
+  margin-left: 8px;
+  vertical-align: middle;
+}
+/* Truncated read-only description in the import-list tables (full text on hover) */
+.import-description-cell span:not(.muted) {
+  display: inline-block;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
 .breadcrumb {
   margin-bottom: 12px;
   font-size: 13px;

--- a/tests/test_import_description.py
+++ b/tests/test_import_description.py
@@ -1,0 +1,117 @@
+"""Tests for the editable free-text "Import description" field.
+
+Covers both product types (list-of-works and Artists' Index): set/clear,
+whitespace normalisation, the 256-character cap, editor gating, and 404s
+(including cross-product-type rejection). The description is shown read-only
+in the import lists and edited only on the detail pages.
+"""
+
+from backend.app.models.import_model import Import
+
+VIEWER = {"X-User-Role": "viewer"}
+
+
+def _make_import(db, product_type: str) -> str:
+    imp = Import(filename=f"{product_type}.xlsx", product_type=product_type)
+    db.add(imp)
+    db.commit()
+    db.refresh(imp)
+    return str(imp.id)
+
+
+class TestLowImportDescription:
+    def test_default_is_none(self, client, db_session):
+        iid = _make_import(db_session, "list_of_works")
+        row = next(r for r in client.get("/imports").json() if r["id"] == iid)
+        assert row["description"] is None
+
+    def test_set_then_appears_in_list(self, client, db_session):
+        iid = _make_import(db_session, "list_of_works")
+
+        r = client.patch(f"/imports/{iid}", json={"description": "Curator's working copy"})
+        assert r.status_code == 200
+        assert r.json() == {"id": iid, "description": "Curator's working copy"}
+
+        row = next(r for r in client.get("/imports").json() if r["id"] == iid)
+        assert row["description"] == "Curator's working copy"
+
+    def test_whitespace_trimmed(self, client, db_session):
+        iid = _make_import(db_session, "list_of_works")
+        r = client.patch(f"/imports/{iid}", json={"description": "  padded  "})
+        assert r.json()["description"] == "padded"
+
+    def test_blank_clears_to_null(self, client, db_session):
+        iid = _make_import(db_session, "list_of_works")
+        client.patch(f"/imports/{iid}", json={"description": "something"})
+        r = client.patch(f"/imports/{iid}", json={"description": "   "})
+        assert r.status_code == 200
+        assert r.json()["description"] is None
+
+    def test_max_length_256_ok_257_rejected(self, client, db_session):
+        iid = _make_import(db_session, "list_of_works")
+        assert client.patch(f"/imports/{iid}", json={"description": "x" * 256}).status_code == 200
+        assert client.patch(f"/imports/{iid}", json={"description": "x" * 257}).status_code == 422
+
+    def test_unknown_id_404(self, client):
+        r = client.patch(
+            "/imports/00000000-0000-0000-0000-000000000000",
+            json={"description": "x"},
+        )
+        assert r.status_code == 404
+
+    def test_index_import_not_reachable_via_low_route(self, client, db_session):
+        idx = _make_import(db_session, "artists_index")
+        r = client.patch(f"/imports/{idx}", json={"description": "x"})
+        assert r.status_code == 404
+
+    def test_requires_editor(self, client, db_session):
+        iid = _make_import(db_session, "list_of_works")
+        r = client.patch(f"/imports/{iid}", json={"description": "x"}, headers=VIEWER)
+        assert r.status_code == 403
+
+
+class TestIndexImportDescription:
+    def test_default_is_none(self, client, db_session):
+        iid = _make_import(db_session, "artists_index")
+        row = next(r for r in client.get("/index/imports").json() if r["id"] == iid)
+        assert row["description"] is None
+
+    def test_set_then_appears_in_list(self, client, db_session):
+        iid = _make_import(db_session, "artists_index")
+
+        r = client.patch(f"/index/imports/{iid}", json={"description": "Final index pass"})
+        assert r.status_code == 200
+        assert r.json() == {"id": iid, "description": "Final index pass"}
+
+        row = next(r for r in client.get("/index/imports").json() if r["id"] == iid)
+        assert row["description"] == "Final index pass"
+
+    def test_blank_clears_to_null(self, client, db_session):
+        iid = _make_import(db_session, "artists_index")
+        client.patch(f"/index/imports/{iid}", json={"description": "something"})
+        r = client.patch(f"/index/imports/{iid}", json={"description": ""})
+        assert r.json()["description"] is None
+
+    def test_max_length_257_rejected(self, client, db_session):
+        iid = _make_import(db_session, "artists_index")
+        assert (
+            client.patch(f"/index/imports/{iid}", json={"description": "x" * 257}).status_code
+            == 422
+        )
+
+    def test_unknown_id_404(self, client):
+        r = client.patch(
+            "/index/imports/00000000-0000-0000-0000-000000000000",
+            json={"description": "x"},
+        )
+        assert r.status_code == 404
+
+    def test_low_import_not_reachable_via_index_route(self, client, db_session):
+        low = _make_import(db_session, "list_of_works")
+        r = client.patch(f"/index/imports/{low}", json={"description": "x"})
+        assert r.status_code == 404
+
+    def test_requires_editor(self, client, db_session):
+        iid = _make_import(db_session, "artists_index")
+        r = client.patch(f"/index/imports/{iid}", json={"description": "x"}, headers=VIEWER)
+        assert r.status_code == 403


### PR DESCRIPTION
Promote the dormant `imports.notes` column to a user-editable free-text description (max 256 chars), shown for both list-of-works and Artists' Index imports. Renamed to `description` to avoid colliding with the unrelated "Import notes" validation panel.

Backend:
- Migration m3e5g7i9k1d2 renames imports.notes -> imports.description (column was empty in practice; rename is data-safe).
- ImportDescriptionUpdate body schema: trims whitespace, blank -> NULL, 256-char cap (-> 422). Lightweight ImportDescriptionOut response.
- PATCH /imports/{id} and PATCH /index/imports/{id}, editor-gated, with 404 on unknown id or cross-product-type. Both list endpoints now return `description`. No audit-log entry (no history kept).

Frontend:
- Inline-editable field beside the heading meta strip on both detail pages (save on blur/Enter, Esc reverts; read-only for viewers).
- Read-only, truncated Description column in both import-list tables.

Tests: 15 new cases (set/clear, trim, 256-vs-257, editor gating, 404s incl. cross-type) for both product types.