### PR TITLE
docs: update Import model section for description rename

### DIFF
--- a/docs/architecture_v1.md
+++ b/docs/architecture_v1.md
@@ -54,9 +54,14 @@ Excel Upload
 
 ### Import
 
-One uploaded Excel file. Immutable after creation.
+One uploaded Excel file. The raw spreadsheet and its parsed records are
+immutable, but the `description` is editable after creation.
 
-- `id` (UUID), `filename`, `uploaded_at`, `notes`
+- `id` (UUID), `filename`, `disk_filename` (UUID-prefixed name on disk),
+  `product_type` (`list_of_works` | `artists_index`), `uploaded_at`
+- `description` — free-text, user-editable note about the import (max 256
+  chars, enforced at the API layer). Distinct from the "Import notes"
+  validation panel.
 
 ### Section
 


### PR DESCRIPTION
## What

[#105](https://github.com/hoyla/RA-SummerExhibition-ListOfWorks/pull/105) renamed `Import.notes` → `Import.description` (an editable free-text note) but left `docs/architecture_v1.md` describing the old field. This brings the Import model section back in sync with `backend/app/models/import_model.py`.

## Changes

- Rename `notes` → `description` in the Import field list
- Correct "Immutable after creation" — the raw spreadsheet and parsed records stay immutable, but `description` is editable (the whole point of #105)
- Document two previously-undocumented columns: `disk_filename` and `product_type`

Docs-only; no code or test impact.