### PR TITLE
Fix: preserve all override fields across Update Import (LoW + Index)

### DIFF
--- a/backend/app/services/excel_importer.py
+++ b/backend/app/services/excel_importer.py
@@ -283,6 +283,7 @@ def _open_and_parse_workbook(file_path: str) -> Tuple[List[str], List[dict], Lis
 
 OVERRIDE_FIELDS = [
     "title_override",
+    "title_cased_override",
     "artist_name_override",
     "artist_honorifics_override",
     "price_numeric_override",

--- a/backend/app/services/index_importer.py
+++ b/backend/app/services/index_importer.py
@@ -875,6 +875,8 @@ _INDEX_OVERRIDE_FIELDS = [
     "artist1_ra_styled_override",
     "artist2_ra_styled_override",
     "artist3_ra_styled_override",
+    "artist2_shared_surname_override",
+    "artist3_shared_surname_override",
     "company_override",
     "address_override",
     "notes",

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4382,21 +4382,30 @@ function _importHeadingMeta(imp, isLatest) {
   return `<span class="heading-meta">${parts.join(' · ')}</span>`;
 }
 
-// The free-text "Import description" shown beside the heading meta strip.
-// Editors get an inline-editable input (saved on blur / Enter); everyone else
-// sees it read-only, or nothing when empty. `imp` is an import-list row.
-// Distinct from the "Import notes" validation panel. Returns escaped HTML.
+// The free-text "Import description" shown inline beside the heading meta
+// strip (kept on the heading row to spare vertical space). Editors get an
+// editable input that grows with its content, bounded by CSS to [356, 712]px;
+// everyone else sees it read-only, or nothing when empty. `imp` is an
+// import-list row. Distinct from the "Import notes" validation panel.
+// Returns escaped HTML.
 function _importDescriptionHTML(imp) {
   const desc = imp.description || '';
   if (canEdit()) {
     return `<input type="text" class="import-description-input" id="import-description-input"`
-      + ` maxlength="256" value="${esc(desc)}" placeholder="Add a description…"`
-      + ` aria-label="Import description"`
+      + ` maxlength="256" size="${_descInputSize(desc)}" value="${esc(desc)}"`
+      + ` placeholder="Add a description…" aria-label="Import description"`
       + ` title="Free-text note about this import (max 256 characters)">`;
   }
   return desc
     ? `<span class="import-description" title="${esc(desc)}">${esc(desc)}</span>`
     : '';
+}
+
+// Character width for the description input so it grows toward its content.
+// The visible width is still clamped to [356, 712]px by CSS; `size` only
+// drives the auto-grow between those bounds. +2 leaves room for the caret.
+function _descInputSize(value) {
+  return Math.max((value || '').length + 2, 1);
 }
 
 // Wire save-on-blur / Enter for the editable description input. `patchPath` is
@@ -4406,6 +4415,8 @@ function _wireImportDescription(patchPath, current) {
   const input = document.getElementById('import-description-input');
   if (!input) return;
   let lastSaved = (current || '').trim();
+  const resize = () => { input.size = _descInputSize(input.value); };
+  input.addEventListener('input', resize);
   async function save() {
     const val = input.value.trim();
     if (val === lastSaved) { input.value = lastSaved; return; }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -573,9 +573,16 @@ a:hover { text-decoration: underline; }
 .recency--latest { color: var(--success); }
 .recency--stale  { color: var(--warning); }
 
-/* Free-text "Import description" beside the detail heading. Editable inline for
-   editors; read-only span otherwise. Sized down so it doesn't inherit the h2. */
+/* Free-text "Import description" inline beside the detail heading meta strip
+   (kept on the heading row to spare vertical space). The input auto-grows with
+   its content via the `size` attribute, clamped here to [356, 712]px. Editable
+   for editors; read-only text otherwise. Sized down so it doesn't inherit h2. */
 .import-description-input {
+  box-sizing: border-box;
+  min-width: 356px;
+  max-width: 712px;
+  margin-left: 8px;
+  vertical-align: middle;
   font-family: var(--font);
   font-size: var(--t-label);
   font-weight: 400;
@@ -584,10 +591,6 @@ a:hover { text-decoration: underline; }
   border: 1px solid transparent;
   border-radius: var(--radius);
   padding: 2px 6px;
-  margin-left: 8px;
-  min-width: 200px;
-  max-width: 380px;
-  vertical-align: middle;
 }
 .import-description-input:hover { border-color: var(--border); }
 .import-description-input:focus {
@@ -598,11 +601,11 @@ a:hover { text-decoration: underline; }
 }
 .import-description-input::placeholder { color: var(--muted); font-style: italic; }
 .import-description {
+  margin-left: 8px;
+  vertical-align: middle;
   font-size: var(--t-label);
   font-weight: 400;
   color: var(--muted-2);
-  margin-left: 8px;
-  vertical-align: middle;
 }
 /* Truncated read-only description in the import-list tables (full text on hover) */
 .import-description-cell span:not(.muted) {

--- a/tests/test_index_reimport.py
+++ b/tests/test_index_reimport.py
@@ -239,6 +239,33 @@ class TestIndexReimportOverrides:
         artists_after = _get_artists(client, import_id)
         assert not any(a["last_name"] == "Brown" for a in artists_after)
 
+    def test_shared_surname_override_preserved(self, client, db_session):
+        """Regression: artist2/3_shared_surname_override must survive a re-import.
+
+        These tri-state shared-surname overrides were absent from
+        _INDEX_OVERRIDE_FIELDS, so Update Import silently dropped them — the
+        override row was recreated but the shared-surname values reset to None.
+        """
+        _, import_id = _upload_index(client)
+        artists = _get_artists(client, import_id)
+        adams = next(a for a in artists if a["last_name"] == "Adams")
+        client.put(
+            f"/index/imports/{import_id}/artists/{adams['id']}/override",
+            json={
+                "artist2_shared_surname_override": True,
+                "artist3_shared_surname_override": False,
+            },
+        )
+
+        r = _reimport_index(client, import_id)
+        assert r.json()["overrides_preserved"] >= 1
+
+        artists_after = _get_artists(client, import_id)
+        adams_after = next(a for a in artists_after if a["last_name"] == "Adams")
+        ovr = client.get(f"/index/imports/{import_id}/artists/{adams_after['id']}/override").json()
+        assert ovr["artist2_shared_surname_override"] is True
+        assert ovr["artist3_shared_surname_override"] is False
+
     def test_company_override_preserved(self, client, db_session):
         _, import_id = _upload_index(client)
 
@@ -256,6 +283,28 @@ class TestIndexReimportOverrides:
         ovr = client.get(f"/index/imports/{import_id}/artists/{adams_after['id']}/override")
         assert ovr.status_code == 200
         assert ovr.json()["is_company_override"] is True
+
+
+class TestIndexOverrideFieldsCoverage:
+    """Structural guard: _INDEX_OVERRIDE_FIELDS must stay in sync with the model."""
+
+    def test_index_override_fields_covers_all_overridable_columns(self):
+        """Every overridable column on IndexArtistOverride must appear in
+        _INDEX_OVERRIDE_FIELDS, otherwise re-import silently drops it (as
+        happened with the shared-surname overrides). Pins the contract so a
+        newly-added override column can't fall out of reimport unnoticed."""
+        from backend.app.models.index_override_model import IndexArtistOverride
+        from backend.app.services.index_importer import _INDEX_OVERRIDE_FIELDS
+
+        # artist_id is the PK (identity, not an editable value); updated_at is
+        # auto-managed metadata. Everything else on the row is overridable.
+        non_override_cols = {"artist_id", "updated_at"}
+        overridable = {c.name for c in IndexArtistOverride.__table__.columns} - non_override_cols
+        assert overridable == set(_INDEX_OVERRIDE_FIELDS), (
+            "_INDEX_OVERRIDE_FIELDS is out of sync with the IndexArtistOverride "
+            "model — re-import would silently drop the symmetric-difference "
+            f"field(s): {overridable ^ set(_INDEX_OVERRIDE_FIELDS)}"
+        )
 
 
 class TestIndexReimportCourtesy:

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -257,6 +257,36 @@ class TestReimportOverridePreservation:
         assert ovr["edition_total_override"] == 50
         assert ovr["notes"] == "Curator requested change"
 
+    def test_title_cased_override_preserved(self, client):
+        """Regression: title_cased_override must survive a re-import.
+
+        It was absent from OVERRIDE_FIELDS, so Update Import silently dropped
+        any Title-Case correction an editor had made on a work — even one that
+        matched cleanly by cat-no and content.
+        """
+        import_id = _do_import(client)
+        sections = _get_sections(client, import_id)
+        all_works = [w for s in sections for w in s["works"]]
+        # cat 2 "Dawn" is content-identical across the re-import, so it matches
+        # cleanly and its override must be carried over intact.
+        work2 = next(w for w in all_works if w["raw_cat_no"] == "2")
+
+        _set_override(
+            client,
+            import_id,
+            work2["id"],
+            title_cased_override="Dawn (Title Case Fix)",
+        )
+
+        r = _do_reimport(client, import_id)
+        assert r.json()["overrides_preserved"] == 1
+
+        sections = _get_sections(client, import_id)
+        all_works = [w for s in sections for w in s["works"]]
+        work2_new = next(w for w in all_works if w["raw_cat_no"] == "2")
+        assert work2_new["override"] is not None
+        assert work2_new["override"]["title_cased_override"] == "Dawn (Title Case Fix)"
+
     def test_include_in_export_preserved(self, client, db_session):
         import_id = _do_import(client)
         sections = _get_sections(client, import_id)
@@ -322,6 +352,28 @@ class TestReimportOverridePreservation:
         assert data["added"] == 1
         assert data["removed"] == 3  # all 3 originals removed
         assert data["overrides_preserved"] == 0
+
+
+class TestOverrideFieldsCoverage:
+    """Structural guard: OVERRIDE_FIELDS must stay in sync with the model."""
+
+    def test_override_fields_covers_all_overridable_columns(self):
+        """Every overridable column on WorkOverride must appear in
+        OVERRIDE_FIELDS, otherwise re-import silently drops it (as happened
+        with title_cased_override). This pins the contract so a newly-added
+        override column can't fall out of reimport preservation unnoticed."""
+        from backend.app.models.override_model import WorkOverride
+        from backend.app.services.excel_importer import OVERRIDE_FIELDS
+
+        # work_id is the PK (identity, not an editable value); updated_at is
+        # auto-managed metadata. Everything else on the row is overridable.
+        non_override_cols = {"work_id", "updated_at"}
+        overridable = {c.name for c in WorkOverride.__table__.columns} - non_override_cols
+        assert overridable == set(OVERRIDE_FIELDS), (
+            "OVERRIDE_FIELDS is out of sync with the WorkOverride model — "
+            "re-import would silently drop the symmetric-difference field(s): "
+            f"{overridable ^ set(OVERRIDE_FIELDS)}"
+        )
 
 
 class TestReimportEdgeCases:


### PR DESCRIPTION
## The bug

Two override fields were being silently dropped on **Update Import** because they were missing from the field lists that drive override snapshot-and-restore — one on each pipeline:

- **List of Works:** `title_cased_override` (the per-work Title-Case correction) was absent from [`OVERRIDE_FIELDS`](backend/app/services/excel_importer.py#L284).
- **Artists' Index:** `artist2_shared_surname_override` and `artist3_shared_surname_override` (the tri-state shared-surname flags) were absent from [`_INDEX_OVERRIDE_FIELDS`](backend/app/services/index_importer.py#L863).

In both cases the columns exist, are in the schemas, are honoured by the resolution layer, and have their own migrations and tests — but because they weren't in the preservation lists, **every Update Import silently discarded any editor correction in those fields**, even on entries that matched cleanly. This is exactly the "polish gets lost on re-import" failure the team is wary of.

Same root cause both times: a new override column was added without updating the importer's preservation list, and nothing caught the omission.

## The fix

- Add `title_cased_override` to `OVERRIDE_FIELDS` (LoW).
- Add `artist2_shared_surname_override` + `artist3_shared_surname_override` to `_INDEX_OVERRIDE_FIELDS` (Index).
- **Regression tests** on both pipelines asserting the fields survive a re-import on a cleanly-matched entry.
- **Structural tests** on both pipelines asserting each preservation list covers *every* overridable column on its model — so the next override field added can't fall out of re-import preservation the same way.

No schema changes, no migrations. Full suite: 991 passed; `ruff check` and `ruff format` clean.