### PR TITLE
Reimport snapshots + attributed 'what changed' diff (PR A: read-only)

### DIFF
--- a/backend/alembic/versions/n4f6h8j0l2e3_create_import_snapshots.py
+++ b/backend/alembic/versions/n4f6h8j0l2e3_create_import_snapshots.py
@@ -1,0 +1,48 @@
+"""create import_snapshots table
+
+Revision ID: n4f6h8j0l2e3
+Revises: m3e5g7i9k1d2
+Create Date: 2026-06-06
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "n4f6h8j0l2e3"
+down_revision: Union[str, Sequence[str], None] = "m3e5g7i9k1d2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "import_snapshots",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "import_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("imports.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.Text(), nullable=False, server_default="pre_reimport"),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("state", JSONB, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("idx_import_snapshots_import", "import_snapshots", ["import_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_import_snapshots_import", table_name="import_snapshots")
+    op.drop_table("import_snapshots")

--- a/backend/app/api/import_routes.py
+++ b/backend/app/api/import_routes.py
@@ -18,6 +18,7 @@ from backend.app.api import (
     low_imports,
     low_overrides,
     low_reconcile,
+    low_snapshots,
     low_templates,
     normalisation_config,
     users,
@@ -31,6 +32,7 @@ router.include_router(low_imports.router)
 router.include_router(low_overrides.router)
 router.include_router(low_exports.router)
 router.include_router(low_reconcile.router)
+router.include_router(low_snapshots.router)
 router.include_router(low_templates.router)
 router.include_router(normalisation_config.router)
 router.include_router(audit.router)

--- a/backend/app/api/low_snapshots.py
+++ b/backend/app/api/low_snapshots.py
@@ -1,0 +1,76 @@
+"""Read-only routes for pre-reimport snapshots and the attributed before/after
+diff of what an Update Import changed.
+
+Snapshots are created automatically inside the re-import (see
+``services/import_snapshot.py``); these endpoints expose them and the diff of a
+snapshot against the current state. Mutating restore/undo is a separate change.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.app.api.deps import get_db
+from backend.app.models.import_model import Import
+from backend.app.services.import_diff import diff_states
+from backend.app.services.import_snapshot import (
+    get_latest_snapshot,
+    get_snapshot,
+    list_snapshots,
+    serialize_import_state,
+)
+
+router = APIRouter(tags=["snapshots"])
+
+
+def _snapshot_meta(snap) -> dict:
+    return {
+        "id": str(snap.id),
+        "kind": snap.kind,
+        "note": snap.note,
+        "created_at": snap.created_at.isoformat() if snap.created_at else None,
+    }
+
+
+def _require_import(import_id: UUID, db: Session) -> None:
+    if not db.query(Import.id).filter(Import.id == import_id).first():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Import not found")
+
+
+@router.get("/imports/{import_id}/snapshots")
+def list_import_snapshots(import_id: UUID, db: Session = Depends(get_db)):
+    """List pre-reimport snapshots for an import, newest first."""
+    _require_import(import_id, db)
+    return [_snapshot_meta(s) for s in list_snapshots(import_id, db)]
+
+
+@router.get("/imports/{import_id}/reimport-diff")
+def get_reimport_diff(import_id: UUID, db: Session = Depends(get_db)):
+    """Attributed before/after diff of the most recent Update Import — the
+    latest pre-reimport snapshot vs the current state."""
+    _require_import(import_id, db)
+    snap = get_latest_snapshot(import_id, db)
+    if snap is None:
+        return {"no_snapshot": True, "has_changes": False}
+    current = serialize_import_state(import_id, db)
+    return {
+        "no_snapshot": False,
+        "snapshot": _snapshot_meta(snap),
+        **diff_states(snap.state, current),
+    }
+
+
+@router.get("/imports/{import_id}/snapshots/{snapshot_id}/diff")
+def get_snapshot_diff(import_id: UUID, snapshot_id: UUID, db: Session = Depends(get_db)):
+    """Diff a specific snapshot against the current state."""
+    _require_import(import_id, db)
+    snap = get_snapshot(snapshot_id, db)
+    if snap is None or snap.import_id != import_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Snapshot not found")
+    current = serialize_import_state(import_id, db)
+    return {
+        "no_snapshot": False,
+        "snapshot": _snapshot_meta(snap),
+        **diff_states(snap.state, current),
+    }

--- a/backend/app/models/import_snapshot_model.py
+++ b/backend/app/models/import_snapshot_model.py
@@ -1,0 +1,51 @@
+import uuid
+
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Index, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import func
+
+from backend.app.db import Base
+
+
+class ImportSnapshot(Base):
+    """Append-only snapshot of an import's full mutable state.
+
+    Captured automatically immediately before a re-import (Update Import)
+    rewrites the data, so the prior state can be diffed against the new one
+    ("what changed, and why") and, if needed, restored wholesale.
+
+    ``state`` is the serialised tree of sections -> works (raw + normalised
+    columns) -> override + validation warnings, plus import-level warnings
+    (see ``services/import_snapshot.serialize_import_state``). Nothing is ever
+    mutated in place; each re-import adds a new row. This mirrors the existing
+    ExportSnapshot / LowTagSnapshot append-only pattern.
+    """
+
+    __tablename__ = "import_snapshots"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    import_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("imports.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Why the snapshot was taken. Currently always "pre_reimport"; kept as a
+    # column so future snapshot kinds (manual save, pre-restore) can coexist.
+    kind = Column(Text, nullable=False, server_default="pre_reimport")
+
+    # Optional human-readable label for the snapshot list — e.g. the name of
+    # the file the subsequent re-import pulled in.
+    note = Column(Text, nullable=True)
+
+    # The full serialised mutable state captured before the re-import.
+    state = Column(JSONB, nullable=False)
+
+    created_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (Index("idx_import_snapshots_import", "import_id"),)

--- a/backend/app/services/excel_importer.py
+++ b/backend/app/services/excel_importer.py
@@ -12,6 +12,7 @@ from backend.app.models.override_model import WorkOverride
 from backend.app.models.section_model import Section
 from backend.app.models.validation_warning_model import ValidationWarning
 from backend.app.models.work_model import Work
+from backend.app.services.import_snapshot import create_snapshot
 from backend.app.services.normalisation_service import (
     collect_work_warnings,
     normalise_work,
@@ -410,6 +411,12 @@ def reimport_excel(
         # Roll back any implicit reads so the next call sees a clean session.
         db.rollback()
         return import_record, plan
+
+    # 5a. Capture an append-only snapshot of the full pre-reimport state
+    # (the whole import, regardless of gallery scope) so the change can be
+    # diffed after the fact and restored if needed. This is part of the
+    # re-import transaction, so a failed re-import discards the snapshot too.
+    create_snapshot(import_id, db, note=display_name)
 
     # 6. Delete the scope. Two paths:
     #    - Full re-import (scope None): wipe everything for this import.

--- a/backend/app/services/import_diff.py
+++ b/backend/app/services/import_diff.py
@@ -1,0 +1,294 @@
+"""Attributed before/after diff between two List-of-Works import states.
+
+Given two serialised import states (see ``import_snapshot.serialize_import_state``),
+pair their works and report, for each matched pair, the field-level changes —
+each attributed to *why* it changed:
+
+  - ``source``        : the raw spreadsheet value changed
+  - ``normalisation`` : raw identical, but the normalised value changed
+                        (i.e. the normalisation rules drifted between the two states)
+  - ``override``      : the editorial override changed
+
+This is the generalisable core. The re-import diff feeds (pre-reimport snapshot,
+current state); a future "compare two imports" tool feeds two live import states.
+Both call :func:`diff_states`.
+
+Pairing vs. the re-import matcher
+---------------------------------
+This shares the *fingerprint primitive* with ``reimport_matcher`` but inverts the
+pass order, because a diff's goal is the opposite of override preservation's.
+
+``reimport_matcher`` pairs **cat-no first, gated on fingerprint** — deliberately
+conservative, so an override is never transplanted onto changed content.
+
+A diff wants to *surface* changes, so it pairs **fingerprint first** (same
+content, even if renumbered — catches renumbers and unchanged works), then
+**catalogue number** for the remainder (same slot, edited content — catches a
+typo fix that the conservative matcher would otherwise show as a remove + add).
+What neither pass can confidently pair becomes added / removed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from backend.app.services.override_service import resolve_effective_work
+from backend.app.services.reimport_matcher import compute_fingerprint
+
+
+@dataclass(frozen=True)
+class _FieldSpec:
+    """One resolved (export-facing) field and the columns used to attribute a
+    change in it to source / normalisation / override."""
+
+    name: str  # EffectiveWork attribute and output key
+    norm_col: str  # Work column holding the normalised (pre-override) value
+    raw_cols: tuple  # raw Work columns that feed it (source attribution)
+    override_cols: tuple  # WorkOverride columns that can drive it
+
+
+# Resolved fields compared per matched work, in display order. ``include_in_export``
+# is handled separately (it's a flag, not a resolved value with raw/override layers).
+_FIELDS = [
+    _FieldSpec("title", "title", ("raw_title",), ("title_override",)),
+    _FieldSpec("title_cased", "title_cased", ("raw_title",), ("title_cased_override",)),
+    _FieldSpec("artist_name", "artist_name", ("raw_artist",), ("artist_name_override",)),
+    _FieldSpec(
+        "artist_honorifics",
+        "artist_honorifics",
+        ("raw_artist",),
+        ("artist_honorifics_override",),
+    ),
+    # price_text can suppress price_numeric, so both override cols attribute a numeric change.
+    _FieldSpec(
+        "price_numeric",
+        "price_numeric",
+        ("raw_price",),
+        ("price_numeric_override", "price_text_override"),
+    ),
+    _FieldSpec("price_text", "price_text", ("raw_price",), ("price_text_override",)),
+    _FieldSpec("edition_total", "edition_total", ("raw_edition",), ("edition_total_override",)),
+    _FieldSpec(
+        "edition_price_numeric",
+        "edition_price_numeric",
+        ("raw_edition",),
+        ("edition_price_numeric_override",),
+    ),
+    _FieldSpec("artwork", "artwork", ("raw_artwork",), ("artwork_override",)),
+    _FieldSpec("medium", "medium", ("raw_medium",), ("medium_override",)),
+]
+
+
+def _flatten(state: dict) -> list[dict]:
+    """Flatten a state's sections into a list of work dicts, tagging each with
+    its section name under ``_section``."""
+    works = []
+    for section in state.get("sections", []):
+        for w in section.get("works", []):
+            wd = dict(w)
+            wd["_section"] = section.get("name", "")
+            works.append(wd)
+    return works
+
+
+def _effective(work: dict):
+    """Resolve a serialised work dict (normalised columns + optional override)
+    to its export-facing values, reusing the production resolver."""
+    work_obj = SimpleNamespace(
+        **{k: v for k, v in work.items() if k not in ("override", "warnings")}
+    )
+    ovr = work.get("override")
+    override_obj = SimpleNamespace(**ovr) if ovr else None
+    return resolve_effective_work(work_obj, override_obj)
+
+
+def _summary(work: dict) -> dict:
+    """Compact identifier for a work in the diff output."""
+    eff = _effective(work)
+    return {
+        "cat_no": work.get("raw_cat_no"),
+        "section": work.get("_section"),
+        "title": eff.title,
+        "artist": eff.artist_name,
+    }
+
+
+def _cat_key(work: dict) -> str:
+    raw = work.get("raw_cat_no")
+    return str(raw).strip() if raw is not None else ""
+
+
+def _fp_key(work: dict):
+    return compute_fingerprint(
+        work.get("raw_title"), work.get("raw_artist"), work.get("raw_medium")
+    )
+
+
+def _pair_works(old_works: list[dict], new_works: list[dict]):
+    """Pair old↔new works for diffing.
+
+    Pass 1 — **fingerprint** (content identity): pairs unchanged and renumbered
+    works. Pass 2 — **catalogue number** on the remainder: pairs same-slot works
+    whose content was edited. Greedy one-to-one within each key bucket; whatever
+    is left over is added / removed.
+
+    Returns ``(pairs, added, removed)`` where ``pairs`` is a list of
+    ``(old, new, via)`` and ``via`` is ``"fingerprint"`` or ``"cat_no"``.
+    """
+    consumed_new: set = set()
+    pairs: list[tuple] = []
+
+    # Pass 1: fingerprint
+    new_by_fp: dict = {}
+    for w in new_works:
+        new_by_fp.setdefault(_fp_key(w), []).append(w)
+    remaining_old: list[dict] = []
+    for ow in old_works:
+        nw = next((w for w in new_by_fp.get(_fp_key(ow), []) if w["id"] not in consumed_new), None)
+        if nw is not None:
+            consumed_new.add(nw["id"])
+            pairs.append((ow, nw, "fingerprint"))
+        else:
+            remaining_old.append(ow)
+
+    # Pass 2: catalogue number (non-empty only)
+    new_by_cat: dict = {}
+    for w in new_works:
+        k = _cat_key(w)
+        if k:
+            new_by_cat.setdefault(k, []).append(w)
+    removed: list[dict] = []
+    for ow in remaining_old:
+        k = _cat_key(ow)
+        nw = (
+            next((w for w in new_by_cat.get(k, []) if w["id"] not in consumed_new), None)
+            if k
+            else None
+        )
+        if nw is not None:
+            consumed_new.add(nw["id"])
+            pairs.append((ow, nw, "cat_no"))
+        else:
+            removed.append(ow)
+
+    added = [w for w in new_works if w["id"] not in consumed_new]
+    return pairs, added, removed
+
+
+def _field_changes(old: dict, new: dict) -> list[dict]:
+    """Field-level attributed changes between a matched old/new work pair."""
+    old_eff, new_eff = _effective(old), _effective(new)
+    old_ovr = old.get("override") or {}
+    new_ovr = new.get("override") or {}
+
+    changes: list[dict] = []
+
+    # Catalogue number can change without a content change (a renumber); the
+    # spreadsheet is the source of truth for it, so attribute to source.
+    if _cat_key(old) != _cat_key(new):
+        changes.append(
+            {
+                "field": "cat_no",
+                "old": old.get("raw_cat_no"),
+                "new": new.get("raw_cat_no"),
+                "causes": ["source"],
+            }
+        )
+
+    for spec in _FIELDS:
+        old_val = getattr(old_eff, spec.name)
+        new_val = getattr(new_eff, spec.name)
+        if old_val == new_val:
+            continue
+
+        causes: list[str] = []
+        if any(old_ovr.get(c) != new_ovr.get(c) for c in spec.override_cols):
+            causes.append("override")
+        if any(old.get(c) != new.get(c) for c in spec.raw_cols):
+            causes.append("source")
+        elif old.get(spec.norm_col) != new.get(spec.norm_col):
+            # Raw identical but the normalised value moved → rules drifted.
+            causes.append("normalisation")
+
+        changes.append(
+            {
+                "field": spec.name,
+                "old": old_val,
+                "new": new_val,
+                # Resolved value changed, so at least one layer must have moved;
+                # "unknown" is a defensive fallback that shouldn't occur.
+                "causes": causes or ["unknown"],
+            }
+        )
+
+    if bool(old.get("include_in_export")) != bool(new.get("include_in_export")):
+        changes.append(
+            {
+                "field": "include_in_export",
+                "old": bool(old.get("include_in_export")),
+                "new": bool(new.get("include_in_export")),
+                "causes": ["override"],
+            }
+        )
+
+    if old.get("_section") != new.get("_section"):
+        changes.append(
+            {
+                "field": "section",
+                "old": old.get("_section"),
+                "new": new.get("_section"),
+                "causes": ["source"],
+            }
+        )
+
+    return changes
+
+
+def diff_states(old_state: dict, new_state: dict) -> dict:
+    """Compute the attributed before/after diff between two import states.
+
+    Returns::
+
+        {
+          "has_changes": bool,
+          "changed": [{"old": <summary>, "new": <summary>, "via": "fingerprint"|"cat_no",
+                       "fields": [{"field", "old", "new", "causes": [...]}, ...]}, ...],
+          "added":   [<summary>, ...],   # in new but not paired to any old work
+          "removed": [<summary>, ...],   # in old but not paired to any new work
+          "unchanged_count": int,
+          "counts": {"changed", "added", "removed", "unchanged"},
+        }
+    """
+    old_works = _flatten(old_state)
+    new_works = _flatten(new_state)
+
+    pairs, added_works, removed_works = _pair_works(old_works, new_works)
+
+    changed: list[dict] = []
+    unchanged = 0
+    for old_w, new_w, via in pairs:
+        fields = _field_changes(old_w, new_w)
+        if fields:
+            changed.append(
+                {"old": _summary(old_w), "new": _summary(new_w), "via": via, "fields": fields}
+            )
+        else:
+            unchanged += 1
+
+    added = [_summary(w) for w in added_works]
+    removed = [_summary(w) for w in removed_works]
+
+    return {
+        "has_changes": bool(changed or added or removed),
+        "changed": changed,
+        "added": added,
+        "removed": removed,
+        "unchanged_count": unchanged,
+        "counts": {
+            "changed": len(changed),
+            "added": len(added),
+            "removed": len(removed),
+            "unchanged": unchanged,
+        },
+    }

--- a/backend/app/services/import_snapshot.py
+++ b/backend/app/services/import_snapshot.py
@@ -1,0 +1,157 @@
+"""Pre-reimport snapshots of an import's full mutable state.
+
+A snapshot is captured automatically just before a re-import rewrites the
+works/overrides, so the team can see an after-the-fact before/after diff of
+what an Update Import changed — and why (source vs normalisation vs override) —
+and, if needed, restore the prior state wholesale.
+
+Append-only: each re-import adds a row; nothing is mutated in place. This
+mirrors the export-snapshot / low-tag-snapshot pattern already in the codebase
+and the project's defensibility principle (every aggregate claim drillable back
+to the underlying source state).
+
+The serialised ``state`` stores *every* column of each Work and WorkOverride
+row (not a hand-maintained subset), so a newly-added field can never silently
+fall out of the snapshot the way override fields fell out of reimport
+preservation. Decimal values are stored as strings to preserve precision.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.app.models.import_snapshot_model import ImportSnapshot
+from backend.app.models.override_model import WorkOverride
+from backend.app.models.section_model import Section
+from backend.app.models.validation_warning_model import ValidationWarning
+from backend.app.models.work_model import Work
+
+# Bump when the on-disk shape of ``state`` changes in a non-additive way.
+STATE_VERSION = 1
+
+
+def _col_to_json(value):
+    """Convert a single SQLAlchemy column value to a JSON-safe primitive.
+
+    Decimal -> str (never float) so monetary precision survives the round-trip;
+    UUID/datetime -> str; primitives pass through unchanged.
+    """
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, _uuid.UUID):
+        return str(value)
+    return str(value)
+
+
+def _row_to_dict(obj) -> dict:
+    """Serialise every mapped column of an ORM row to a JSON-safe dict."""
+    return {c.name: _col_to_json(getattr(obj, c.name)) for c in obj.__table__.columns}
+
+
+def serialize_import_state(import_id: _uuid.UUID, db: Session) -> dict:
+    """Build the full mutable-state tree for an import.
+
+    Structure::
+
+        {
+          "version": 1,
+          "sections": [
+            {"id", "name", "position",
+             "works": [
+               {<all Work columns>,
+                "override": {<all WorkOverride columns>} | None,
+                "warnings": [{"warning_type", "message"}, ...]}
+             ]}
+          ],
+          "import_warnings": [{"warning_type", "message"}, ...]   # work_id IS NULL
+        }
+
+    Works are grouped under their section and ordered by
+    ``position_in_section``; sections are ordered by ``position`` — so the
+    snapshot preserves document order for both diffing and restore.
+    """
+    sections = (
+        db.query(Section).filter(Section.import_id == import_id).order_by(Section.position).all()
+    )
+    works = db.query(Work).filter(Work.import_id == import_id).all()
+    work_ids = [w.id for w in works]
+
+    overrides_by_work: dict = {}
+    if work_ids:
+        overrides_by_work = {
+            o.work_id: o
+            for o in db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).all()
+        }
+
+    # Validation warnings: split into per-work and import-level (work_id NULL).
+    warnings_by_work: dict = {}
+    import_warnings: list = []
+    for w in db.query(ValidationWarning).filter(ValidationWarning.import_id == import_id).all():
+        entry = {"warning_type": w.warning_type, "message": w.message}
+        if w.work_id is None:
+            import_warnings.append(entry)
+        else:
+            warnings_by_work.setdefault(w.work_id, []).append(entry)
+
+    works_by_section: dict = {}
+    for w in works:
+        works_by_section.setdefault(w.section_id, []).append(w)
+    for lst in works_by_section.values():
+        lst.sort(key=lambda x: x.position_in_section)
+
+    section_dicts = []
+    for s in sections:
+        work_dicts = []
+        for w in works_by_section.get(s.id, []):
+            wd = _row_to_dict(w)
+            ovr = overrides_by_work.get(w.id)
+            wd["override"] = _row_to_dict(ovr) if ovr else None
+            wd["warnings"] = warnings_by_work.get(w.id, [])
+            work_dicts.append(wd)
+        section_dicts.append(
+            {
+                "id": str(s.id),
+                "name": s.name,
+                "position": s.position,
+                "works": work_dicts,
+            }
+        )
+
+    return {
+        "version": STATE_VERSION,
+        "sections": section_dicts,
+        "import_warnings": import_warnings,
+    }
+
+
+def create_snapshot(
+    import_id: _uuid.UUID,
+    db: Session,
+    *,
+    kind: str = "pre_reimport",
+    note: Optional[str] = None,
+) -> ImportSnapshot:
+    """Capture and persist the current full mutable state of an import.
+
+    The caller owns the surrounding transaction: this adds and flushes the row
+    but does **not** commit, so the snapshot participates in the re-import's
+    atomic unit — if the re-import rolls back, the snapshot is discarded too.
+    """
+    snap = ImportSnapshot(
+        import_id=import_id,
+        kind=kind,
+        note=note,
+        state=serialize_import_state(import_id, db),
+    )
+    db.add(snap)
+    db.flush()
+    return snap

--- a/backend/app/services/import_snapshot.py
+++ b/backend/app/services/import_snapshot.py
@@ -133,6 +133,31 @@ def serialize_import_state(import_id: _uuid.UUID, db: Session) -> dict:
     }
 
 
+def list_snapshots(import_id: _uuid.UUID, db: Session) -> list[ImportSnapshot]:
+    """All snapshots for an import, newest first."""
+    return (
+        db.query(ImportSnapshot)
+        .filter(ImportSnapshot.import_id == import_id)
+        .order_by(ImportSnapshot.created_at.desc())
+        .all()
+    )
+
+
+def get_latest_snapshot(import_id: _uuid.UUID, db: Session) -> Optional[ImportSnapshot]:
+    """The most recent snapshot for an import, or None."""
+    return (
+        db.query(ImportSnapshot)
+        .filter(ImportSnapshot.import_id == import_id)
+        .order_by(ImportSnapshot.created_at.desc())
+        .first()
+    )
+
+
+def get_snapshot(snapshot_id: _uuid.UUID, db: Session) -> Optional[ImportSnapshot]:
+    """A snapshot by id, or None."""
+    return db.query(ImportSnapshot).filter(ImportSnapshot.id == snapshot_id).first()
+
+
 def create_snapshot(
     import_id: _uuid.UUID,
     db: Session,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4352,6 +4352,11 @@ async function _commitReimport() {
     document.getElementById('reimport-file').value = '';
     _resetReimportPreview();
     await renderDetail(importId);
+    // Surface what the update just changed, right where the user is: open the
+    // Tools panel and auto-expand the attributed diff.
+    document.querySelector('.tools-panel')?.setAttribute('open', '');
+    const diffBtn = document.getElementById('reimport-diff-btn');
+    if (diffBtn) toggleReimportDiff(importId, diffBtn);
   } catch (err) {
     if (err.message === 'Auth') return;
     statusEl.textContent = `Re-import failed: ${err.message}`;
@@ -4514,6 +4519,12 @@ async function renderDetail(importId) {
           <p id="reimport-status" class="status-msg" style="margin-top:8px"></p>
           <div id="reimport-preview" style="display:none;margin-top:14px"></div>
         </section>`)}
+        <section class="tool-block" id="reimport-diff-block">
+          <h4>What the last update changed</h4>
+          <p class="muted" style="font-size:12px;margin-bottom:10px">Compares the data now against the snapshot taken automatically just before the most recent Update Import — including <em>why</em> each value changed.</p>
+          <button type="button" class="btn btn-secondary" id="reimport-diff-btn">Show what changed</button>
+        </section>
+        <div id="reimport-diff-panel-${esc(importId)}" class="reimport-diff-output" data-visible=""></div>
         ${ifEditor(`<section class="tool-block" id="reconcile-panel">
           <h4>Reconcile corrected LOW</h4>
           <p class="muted" style="font-size:12px;margin-bottom:10px">Upload a corrected InDesign LOW tags export to find data changes made downstream that aren\u2019t yet in this data. Detection only \u2014 nothing is changed automatically.</p>
@@ -4554,6 +4565,11 @@ async function renderDetail(importId) {
     } else {
       _resetReimportPreview();
     }
+  });
+
+  // "What the last update changed" — toggle the attributed before/after diff.
+  document.getElementById('reimport-diff-btn')?.addEventListener('click', (e) => {
+    toggleReimportDiff(importId, e.currentTarget);
   });
 
   // Fetch import metadata for filename mismatch detection + heading
@@ -6424,6 +6440,235 @@ function _renderDiffPanel(diff) {
     for (const w of diff.removed) {
       parts.push(`<tr class="diff-row-removed"><td>${esc(w.cat_no ?? '\u2014')}</td><td>${esc(w.section)}</td><td>${esc(w.artist ?? '')}</td><td>${esc(w.title ?? '')}</td><td>${esc(w.price_text ?? '')}</td></tr>`);
     }
+    parts.push('</tbody></table>');
+  }
+
+  parts.push('</div>');
+  return parts.join('');
+}
+
+// ---------------------------------------------------------------------------
+// Reimport diff — "what the last Update Import changed", attributed by cause
+// ---------------------------------------------------------------------------
+
+// Maps a change cause to its [badge class, short label]. The diff engine tags
+// every field change as source (spreadsheet), normalisation (rules drift), or
+// override (editorial).
+const _CAUSE_BADGE = {
+  source: ['badge-source', 'Spreadsheet'],
+  normalisation: ['badge-rules', 'Rules'],
+  override: ['badge-override', 'Override'],
+  unknown: ['badge-unchanged', '?'],
+};
+
+function _causeBadges(causes) {
+  return (causes || [])
+    .map(c => {
+      const [cls, label] = _CAUSE_BADGE[c] || _CAUSE_BADGE.unknown;
+      return `<span class="badge ${cls}" title="${esc(c)}">${esc(label)}</span>`;
+    })
+    .join(' ');
+}
+
+// Plain-English labels for the diff's resolved fields.
+const _DIFF_FIELD_LABEL = {
+  cat_no: 'Cat No',
+  title: 'Title',
+  title_cased: 'Title (Title Case)',
+  artist_name: 'Artist',
+  artist_honorifics: 'Honorifics',
+  artwork: 'Artwork (pieces)',
+  medium: 'Medium',
+  section: 'Section',
+  include_in_export: 'Included in export',
+};
+
+// Price and Edition each span two resolved columns. We group them under one
+// label so the diff reads as a single logical field — but we still COMPARE the
+// columns separately (no information loss): a change to the underlying number
+// that a 'display' price (e.g. "POA") masks in print still surfaces here.
+const _PRICE_MEMBERS = [['price_numeric', 'number'], ['price_text', 'display']];
+const _EDITION_MEMBERS = [['edition_total', 'of'], ['edition_price_numeric', 'at £']];
+
+// True when price number and display text carry the same value on BOTH sides —
+// i.e. the two columns are just two representations of one edit, so showing one
+// line loses nothing. Diverging values (text masking a number) return false.
+function _samePriceValue(byField) {
+  const n = byField['price_numeric'];
+  const t = byField['price_text'];
+  if (!n || !t) return false;
+  const eq = (a, b) =>
+    a != null && b != null && a !== '' && b !== '' && Number(a) === Number(b);
+  return eq(n.old, t.old) && eq(n.new, t.new);
+}
+
+// Transform a changed work's flat field list into display rows, grouping
+// Price/Edition. Returns [{label, lines:[{sub,old,new}], causes:[...]}].
+function _groupChangeFields(fields) {
+  const byField = {};
+  for (const f of fields) byField[f.field] = f;
+  const rows = [];
+
+  const pushField = (field) => {
+    const f = byField[field];
+    if (!f) return;
+    rows.push({
+      label: _DIFF_FIELD_LABEL[field] || field,
+      lines: [{ sub: null, old: f.old, new: f.new }],
+      causes: f.causes || [],
+    });
+  };
+
+  const pushGroup = (label, members, dedup) => {
+    const present = members.filter(([fld]) => byField[fld]);
+    if (!present.length) return;
+    const causes = new Set();
+    present.forEach(([fld]) => (byField[fld].causes || []).forEach(c => causes.add(c)));
+    let lines;
+    if (dedup) {
+      const t = byField['price_text'];
+      lines = [{ sub: null, old: t.old, new: t.new }];
+    } else {
+      lines = present.map(([fld, sub]) => ({
+        sub: present.length > 1 ? sub : null,
+        old: byField[fld].old,
+        new: byField[fld].new,
+      }));
+    }
+    rows.push({ label, lines, causes: [...causes] });
+  };
+
+  pushField('cat_no');
+  pushField('title');
+  pushField('title_cased');
+  pushField('artist_name');
+  pushField('artist_honorifics');
+  pushGroup('Price', _PRICE_MEMBERS, _samePriceValue(byField));
+  pushGroup('Edition', _EDITION_MEMBERS, false);
+  pushField('artwork');
+  pushField('medium');
+  pushField('section');
+  pushField('include_in_export');
+
+  // Safety net: surface any field not covered by the ordered list above.
+  const handled = new Set([
+    'cat_no', 'title', 'title_cased', 'artist_name', 'artist_honorifics',
+    'price_numeric', 'price_text', 'edition_total', 'edition_price_numeric',
+    'artwork', 'medium', 'section', 'include_in_export',
+  ]);
+  for (const f of fields) if (!handled.has(f.field)) pushField(f.field);
+
+  return rows;
+}
+
+// Render the stacked before/after lines of one display row for the given side.
+function _diffLines(lines, side) {
+  return lines
+    .map(l => {
+      const v = l[side];
+      const val = v != null && v !== '' ? esc(String(v)) : '<span class="muted">—</span>';
+      const sub = l.sub ? `<span class="diff-sub">${esc(l.sub)}</span>` : '';
+      return `<div>${sub}${val}</div>`;
+    })
+    .join('');
+}
+
+async function toggleReimportDiff(importId, btnEl) {
+  const panel = document.getElementById(`reimport-diff-panel-${importId}`);
+  if (!panel) return;
+
+  // Toggle off if already showing
+  if (panel.dataset.visible === '1') {
+    panel.innerHTML = '';
+    panel.dataset.visible = '';
+    return;
+  }
+
+  const restore = btnLoading(btnEl, 'Loading');
+  try {
+    const diff = await api('GET', `/imports/${importId}/reimport-diff`);
+    panel.dataset.visible = '1';
+    panel.innerHTML = _renderReimportDiffPanel(diff);
+  } catch (err) {
+    if (err.message === 'Auth') return;
+    panel.innerHTML = `<p class="error" style="margin-top:8px">${esc(err.message)}</p>`;
+  } finally {
+    restore();
+  }
+}
+
+function _diffSummaryRows(works) {
+  return works
+    .map(w =>
+      `<tr><td>${esc(String(w.cat_no ?? '—'))}</td><td>${esc(w.section ?? '')}</td>` +
+      `<td>${esc(w.artist ?? '')}</td><td>${esc(w.title ?? '')}</td></tr>`
+    )
+    .join('');
+}
+
+function _renderReimportDiffPanel(diff) {
+  if (diff.no_snapshot) {
+    return `<div class="diff-result diff-info"><p>No Update Import has been run on this import yet, so there’s nothing to compare. Run <strong>Update Import</strong> above and this will show what it changed.</p></div>`;
+  }
+
+  const snap = diff.snapshot;
+  const snapMeta = snap
+    ? `<span class="muted">(before re-import${snap.note ? ` of ${esc(snap.note)}` : ''}, ${esc(formatDate(snap.created_at))})</span>`
+    : '';
+
+  if (!diff.has_changes) {
+    return `<div class="diff-result diff-ok"><p>✓ No differences from the pre-update snapshot ${snapMeta}</p></div>`;
+  }
+
+  const parts = ['<div class="diff-result">'];
+  parts.push(`<p class="diff-summary">Changes since the last Update Import ${snapMeta}:</p>`);
+
+  const badges = [];
+  if (diff.changed.length) badges.push(`<span class="badge badge-changed">${diff.changed.length} changed</span>`);
+  if (diff.added.length) badges.push(`<span class="badge badge-added">${diff.added.length} added</span>`);
+  if (diff.removed.length) badges.push(`<span class="badge badge-removed">${diff.removed.length} removed</span>`);
+  if (diff.unchanged_count) badges.push(`<span class="badge badge-unchanged">${diff.unchanged_count} unchanged</span>`);
+  parts.push(`<div class="diff-badges">${badges.join(' ')}</div>`);
+
+  // Cause legend so the "Why" column reads clearly.
+  parts.push(
+    `<p class="diff-cause-legend muted">Why each value changed: ` +
+    `${_causeBadges(['source'])} spreadsheet · ${_causeBadges(['normalisation'])} normalisation rules · ${_causeBadges(['override'])} editorial override</p>`
+  );
+
+  // Changed works — field-level detail with cause attribution
+  if (diff.changed.length) {
+    parts.push('<h4 class="diff-heading">Changed works</h4>');
+    parts.push('<table class="data-table diff-table"><thead><tr><th>Cat No</th><th>Section</th><th>Field</th><th>Before</th><th>After</th><th>Why</th></tr></thead><tbody>');
+    for (const w of diff.changed) {
+      const drows = _groupChangeFields(w.fields);
+      const rowspan = drows.length;
+      const cat = w.new?.cat_no ?? w.old?.cat_no ?? '—';
+      const section = w.new?.section ?? w.old?.section ?? '';
+      drows.forEach((row, i) => {
+        parts.push('<tr>');
+        if (i === 0) parts.push(`<td rowspan="${rowspan}" class="diff-catno">${esc(String(cat))}</td><td rowspan="${rowspan}">${esc(section)}</td>`);
+        parts.push(`<td>${esc(row.label)}</td>`);
+        parts.push(`<td class="diff-old">${_diffLines(row.lines, 'old')}</td>`);
+        parts.push(`<td class="diff-new">${_diffLines(row.lines, 'new')}</td>`);
+        parts.push(`<td>${_causeBadges(row.causes)}</td>`);
+        parts.push('</tr>');
+      });
+    }
+    parts.push('</tbody></table>');
+  }
+
+  if (diff.added.length) {
+    parts.push('<h4 class="diff-heading">Added works</h4>');
+    parts.push('<table class="data-table diff-table"><thead><tr><th>Cat No</th><th>Section</th><th>Artist</th><th>Title</th></tr></thead><tbody class="diff-row-added">');
+    parts.push(_diffSummaryRows(diff.added));
+    parts.push('</tbody></table>');
+  }
+
+  if (diff.removed.length) {
+    parts.push('<h4 class="diff-heading">Removed works</h4>');
+    parts.push('<table class="data-table diff-table"><thead><tr><th>Cat No</th><th>Section</th><th>Artist</th><th>Title</th></tr></thead><tbody class="diff-row-removed">');
+    parts.push(_diffSummaryRows(diff.removed));
     parts.push('</tbody></table>');
   }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1421,6 +1421,14 @@ details.section-block[open] > .section-summary::before {
 .diff-new { color: #27ae60; font-weight: 600; }
 .diff-row-added td { background: #f0faf0; }
 .diff-row-removed td { background: #fde8e8; text-decoration: line-through; color: #999; }
+/* Reimport-diff cause badges (why a value changed) */
+.badge-source   { background: #e7f0fb; color: #1b4f8a; border: 1px solid #a9cdf0; }
+.badge-rules    { background: #f0e9fb; color: #5b3b9a; border: 1px solid #c9b3ec; }
+.badge-override { background: #e1f5f3; color: #176f66; border: 1px solid #8fd3cb; }
+.diff-cause-legend { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin: 0 0 10px; }
+/* Sub-label for grouped diff fields (e.g. Price → number / display). inline-block
+   so the strikethrough on a changed "before" cell doesn't strike the label. */
+.diff-sub { display: inline-block; color: #888; text-decoration: none; font-size: 11px; margin-right: 4px; }
 
 /* Tools panel (collapsed by default to keep the Works list near the top) */
 details.tools-panel[open] > .section-summary::before { transform: rotate(90deg); }
@@ -1441,6 +1449,10 @@ details.tools-panel[open] > .section-summary::before { transform: rotate(90deg);
 /* Reconcile results span the full width below the three tool cards */
 .tool-output { grid-column: 1 / -1; }
 .tool-output:empty { display: none; }
+/* The reimport-diff renders as a full-width band below the tool cards (a wide
+   changes table needs the room), collapsing away when there's nothing to show. */
+.reimport-diff-output { grid-column: 1 / -1; }
+.reimport-diff-output:empty { display: none; }
 
 /* Reconcile corrected LOW */
 .recon-cosmetic { margin-top: 16px; }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from sqlalchemy.pool import StaticPool
 import backend.app.models.audit_log_model  # noqa: F401
 import backend.app.models.export_snapshot_model  # noqa: F401
 import backend.app.models.import_model  # noqa: F401
+import backend.app.models.import_snapshot_model  # noqa: F401
 import backend.app.models.index_artist_model  # noqa: F401
 import backend.app.models.index_cat_number_model  # noqa: F401
 import backend.app.models.index_override_model  # noqa: F401

--- a/tests/test_import_diff.py
+++ b/tests/test_import_diff.py
@@ -1,0 +1,290 @@
+"""Tests for the attributed import diff engine (services/import_diff.py).
+
+Unit tests drive ``diff_states`` with hand-built state dicts to pin each
+attribution cause (source / normalisation / override) and each pairing case
+(unchanged, content edit, renumber, add/remove). One integration test feeds it
+real serialised states from ``serialize_import_state`` to confirm the live
+shape round-trips.
+"""
+
+import io
+import uuid as _uuid
+
+import pytest
+from openpyxl import Workbook
+
+from backend.app.services.import_diff import diff_states
+
+# --------------------------------------------------------------------------- #
+# Builders for unit tests
+# --------------------------------------------------------------------------- #
+
+_OVERRIDE_COLS = [
+    "title_override",
+    "title_cased_override",
+    "artist_name_override",
+    "artist_honorifics_override",
+    "price_numeric_override",
+    "price_text_override",
+    "edition_total_override",
+    "edition_price_numeric_override",
+    "artwork_override",
+    "medium_override",
+    "notes",
+]
+
+
+def _override(**kw):
+    """A full override dict (all columns present, defaulting to None) — mirrors
+    the full-column serialisation a real snapshot produces."""
+    d = {c: None for c in _OVERRIDE_COLS}
+    d.update(kw)
+    return d
+
+
+def _work(
+    work_id,
+    cat_no,
+    *,
+    raw_title=None,
+    raw_artist=None,
+    raw_medium=None,
+    raw_price=None,
+    raw_edition=None,
+    raw_artwork=None,
+    raw_gallery="G1",
+    title=None,
+    title_cased=None,
+    artist_name=None,
+    artist_honorifics=None,
+    price_numeric=None,
+    price_text=None,
+    edition_total=None,
+    edition_price_numeric=None,
+    artwork=None,
+    medium=None,
+    include_in_export=True,
+    override=None,
+):
+    return {
+        "id": work_id,
+        "raw_cat_no": cat_no,
+        "raw_gallery": raw_gallery,
+        "raw_title": raw_title,
+        "raw_artist": raw_artist,
+        "raw_medium": raw_medium,
+        "raw_price": raw_price,
+        "raw_edition": raw_edition,
+        "raw_artwork": raw_artwork,
+        "title": title,
+        "title_cased": title_cased,
+        "artist_name": artist_name,
+        "artist_honorifics": artist_honorifics,
+        "price_numeric": price_numeric,
+        "price_text": price_text,
+        "edition_total": edition_total,
+        "edition_price_numeric": edition_price_numeric,
+        "artwork": artwork,
+        "medium": medium,
+        "include_in_export": include_in_export,
+        "override": override,
+        "warnings": [],
+    }
+
+
+def _state(*works, section="G1"):
+    return {
+        "version": 1,
+        "sections": [{"id": "s1", "name": section, "position": 1, "works": list(works)}],
+        "import_warnings": [],
+    }
+
+
+def _changed_field(diff, cat_no, field):
+    """Return the change dict for a given field of the work whose NEW cat_no
+    matches, or None."""
+    for c in diff["changed"]:
+        if c["new"]["cat_no"] == cat_no or c["old"]["cat_no"] == cat_no:
+            for f in c["fields"]:
+                if f["field"] == field:
+                    return f
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Unchanged
+# --------------------------------------------------------------------------- #
+
+
+def test_identical_states_no_changes():
+    s = _state(_work("a", "1", raw_title="Sunset", title="Sunset", artist_name="Jane"))
+    diff = diff_states(s, s)
+    assert diff["has_changes"] is False
+    assert diff["unchanged_count"] == 1
+    assert diff["counts"] == {"changed": 0, "added": 0, "removed": 0, "unchanged": 1}
+
+
+# --------------------------------------------------------------------------- #
+# Attribution causes
+# --------------------------------------------------------------------------- #
+
+
+def test_source_change_is_attributed_to_source():
+    # Same cat-no, title typo fixed in the spreadsheet. Fingerprint differs, so
+    # it pairs by cat-no (pass 2) and the title change is attributed to source.
+    old = _state(_work("a", "1", raw_title="Suset", title="Suset", artist_name="Jane"))
+    new = _state(_work("b", "1", raw_title="Sunset", title="Sunset", artist_name="Jane"))
+    diff = diff_states(old, new)
+    assert diff["counts"]["changed"] == 1
+    assert diff["changed"][0]["via"] == "cat_no"
+    f = _changed_field(diff, "1", "title")
+    assert f["old"] == "Suset" and f["new"] == "Sunset"
+    assert f["causes"] == ["source"]
+
+
+def test_normalisation_drift_is_attributed_to_normalisation():
+    # Raw identical (so fingerprint matches, pass 1), but the normalised medium
+    # moved — e.g. a text-substitution rule was added between the two states.
+    old = _state(_work("a", "1", raw_title="X", title="X", raw_medium="oil", medium="oil"))
+    new = _state(_work("b", "1", raw_title="X", title="X", raw_medium="oil", medium="Oil"))
+    diff = diff_states(old, new)
+    assert diff["changed"][0]["via"] == "fingerprint"
+    f = _changed_field(diff, "1", "medium")
+    assert f["old"] == "oil" and f["new"] == "Oil"
+    assert f["causes"] == ["normalisation"]
+
+
+def test_override_change_is_attributed_to_override():
+    old = _state(_work("a", "1", raw_title="X", title="X", artist_name="Jane"))
+    new = _state(
+        _work(
+            "b",
+            "1",
+            raw_title="X",
+            title="X",
+            artist_name="Jane",
+            override=_override(title_override="Custom Title"),
+        )
+    )
+    diff = diff_states(old, new)
+    assert diff["changed"][0]["via"] == "fingerprint"
+    f = _changed_field(diff, "1", "title")
+    assert f["old"] == "X" and f["new"] == "Custom Title"
+    assert f["causes"] == ["override"]
+
+
+def test_include_in_export_toggle_is_reported():
+    old = _state(_work("a", "1", raw_title="X", title="X", include_in_export=True))
+    new = _state(_work("b", "1", raw_title="X", title="X", include_in_export=False))
+    diff = diff_states(old, new)
+    f = _changed_field(diff, "1", "include_in_export")
+    assert f["old"] is True and f["new"] is False
+    assert f["causes"] == ["override"]
+
+
+# --------------------------------------------------------------------------- #
+# Pairing cases
+# --------------------------------------------------------------------------- #
+
+
+def test_added_and_removed():
+    old = _state(
+        _work("a", "1", raw_title="Sunset", title="Sunset"),
+        _work("b", "2", raw_title="Dawn", title="Dawn"),
+    )
+    new = _state(
+        _work("c", "1", raw_title="Sunset", title="Sunset"),
+        _work("d", "3", raw_title="Noon", title="Noon"),
+    )
+    diff = diff_states(old, new)
+    assert diff["counts"]["unchanged"] == 1  # cat 1 unchanged
+    assert [a["cat_no"] for a in diff["added"]] == ["3"]
+    assert [r["cat_no"] for r in diff["removed"]] == ["2"]
+
+
+def test_renumber_pairs_by_fingerprint_and_reports_cat_no_change():
+    # An insertion pushes "Noon" from cat 3 to cat 4; a brand-new work takes
+    # cat 3. Fingerprint pairs Noon 3->4 (renumber); the new work is an add.
+    old = _state(
+        _work("a", "1", raw_title="Sunset", title="Sunset"),
+        _work("b", "3", raw_title="Noon", title="Noon", artist_name="Alice"),
+    )
+    new = _state(
+        _work("c", "1", raw_title="Sunset", title="Sunset"),
+        _work("d", "3", raw_title="Brand New", title="Brand New", artist_name="Bob"),
+        _work("e", "4", raw_title="Noon", title="Noon", artist_name="Alice"),
+    )
+    diff = diff_states(old, new)
+    # Noon paired by fingerprint, cat-no change 3 -> 4 surfaced as source.
+    noon = next(c for c in diff["changed"] if c["new"]["title"] == "Noon")
+    assert noon["via"] == "fingerprint"
+    catf = next(f for f in noon["fields"] if f["field"] == "cat_no")
+    assert catf["old"] == "3" and catf["new"] == "4" and catf["causes"] == ["source"]
+    # The brand-new cat 3 is an addition, nothing removed.
+    assert [a["cat_no"] for a in diff["added"]] == ["3"]
+    assert diff["removed"] == []
+
+
+def test_section_move_is_reported():
+    old = _state(_work("a", "1", raw_title="X", title="X"), section="Gallery A")
+    new = _state(_work("b", "1", raw_title="X", title="X"), section="Gallery B")
+    diff = diff_states(old, new)
+    f = _changed_field(diff, "1", "section")
+    assert f["old"] == "Gallery A" and f["new"] == "Gallery B"
+    assert f["causes"] == ["source"]
+
+
+# --------------------------------------------------------------------------- #
+# Integration: real serialised states
+# --------------------------------------------------------------------------- #
+
+client = pytest.fixture(name="client")(lambda client_lenient: client_lenient)
+
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+HEADERS = ["Cat No", "Gallery", "Title", "Artist", "Price", "Edition", "Artwork", "Medium"]
+
+
+def _xlsx(rows):
+    wb = Workbook()
+    ws = wb.active
+    ws.append(HEADERS)
+    for r in rows:
+        ws.append(r)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_diff_over_real_serialised_states(client, db_session):
+    from backend.app.services.import_snapshot import serialize_import_state
+
+    rows = [
+        [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+        [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+    ]
+    r = client.post("/import", files={"file": ("orig.xlsx", _xlsx(rows), XLSX_MIME)})
+    import_id = r.json()["import_id"]
+    iid = _uuid.UUID(import_id)
+
+    old_state = serialize_import_state(iid, db_session)
+
+    # Apply an override to cat 1 and exclude cat 2.
+    sections = client.get(f"/imports/{import_id}/sections").json()
+    works = {w["raw_cat_no"]: w for s in sections for w in s["works"]}
+    client.put(
+        f"/imports/{import_id}/works/{works['1']['id']}/override",
+        json={"title_override": "Sunset (Revised)"},
+    )
+    client.patch(f"/imports/{import_id}/works/{works['2']['id']}/exclude?exclude=true")
+
+    db_session.expire_all()
+    new_state = serialize_import_state(iid, db_session)
+
+    diff = diff_states(old_state, new_state)
+    assert diff["has_changes"] is True
+    title_change = _changed_field(diff, "1", "title")
+    assert title_change["new"] == "Sunset (Revised)"
+    assert title_change["causes"] == ["override"]
+    incl_change = _changed_field(diff, "2", "include_in_export")
+    assert incl_change["old"] is True and incl_change["new"] is False

--- a/tests/test_import_snapshot.py
+++ b/tests/test_import_snapshot.py
@@ -1,0 +1,150 @@
+"""Tests for pre-reimport import snapshots (services/import_snapshot.py).
+
+Foundation layer for the Update-Import before/after diff + undo: every real
+re-import captures an append-only snapshot of the full prior mutable state
+(sections -> works with raw + normalised columns -> override + warnings).
+"""
+
+import io
+import uuid as _uuid
+
+import pytest
+from openpyxl import Workbook
+
+from backend.app.models.import_snapshot_model import ImportSnapshot
+
+# Re-import uses raise_server_exceptions=False so we can assert on status codes.
+client = pytest.fixture(name="client")(lambda client_lenient: client_lenient)
+
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+ALL_HEADERS = ["Cat No", "Gallery", "Title", "Artist", "Price", "Edition", "Artwork", "Medium"]
+DEFAULT_ROWS = [
+    [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+    [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+]
+
+
+def _make_xlsx(rows):
+    wb = Workbook()
+    ws = wb.active
+    ws.append(ALL_HEADERS)
+    for row in rows:
+        ws.append(row)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def _upload(client, rows, filename="orig.xlsx"):
+    r = client.post("/import", files={"file": (filename, _make_xlsx(rows), XLSX_MIME)})
+    assert r.status_code == 200, r.text
+    return r.json()["import_id"]
+
+
+def _reimport(client, import_id, rows, filename="updated.xlsx", query=""):
+    return client.put(
+        f"/imports/{import_id}/reimport{query}",
+        files={"file": (filename, _make_xlsx(rows), XLSX_MIME)},
+    )
+
+
+def _snapshots(db_session, import_id):
+    return (
+        db_session.query(ImportSnapshot)
+        .filter(ImportSnapshot.import_id == _uuid.UUID(import_id))
+        .order_by(ImportSnapshot.created_at)
+        .all()
+    )
+
+
+def _all_works(state):
+    return [w for s in state["sections"] for w in s["works"]]
+
+
+class TestSnapshotCapture:
+    def test_reimport_creates_snapshot_of_prior_state(self, client, db_session):
+        import_id = _upload(client, DEFAULT_ROWS)
+        assert _snapshots(db_session, import_id) == []  # nothing before a re-import
+
+        r = _reimport(client, import_id, DEFAULT_ROWS)
+        assert r.status_code == 200
+
+        snaps = _snapshots(db_session, import_id)
+        assert len(snaps) == 1
+        # The state captures the PRE-reimport works, not the new file.
+        titles = [w["raw_title"] for w in _all_works(snaps[0].state)]
+        assert sorted(titles) == ["Dawn", "Sunset"]
+        assert snaps[0].kind == "pre_reimport"
+
+    def test_dry_run_creates_no_snapshot(self, client, db_session):
+        import_id = _upload(client, DEFAULT_ROWS)
+        r = _reimport(client, import_id, DEFAULT_ROWS, query="?dry_run=true")
+        assert r.status_code == 200
+        assert _snapshots(db_session, import_id) == []
+
+    def test_snapshots_are_append_only(self, client, db_session):
+        import_id = _upload(client, DEFAULT_ROWS)
+        _reimport(client, import_id, DEFAULT_ROWS)
+        _reimport(client, import_id, DEFAULT_ROWS)
+        assert len(_snapshots(db_session, import_id)) == 2
+
+    def test_note_records_incoming_filename(self, client, db_session):
+        import_id = _upload(client, DEFAULT_ROWS)
+        _reimport(client, import_id, DEFAULT_ROWS, filename="march-update.xlsx")
+        assert _snapshots(db_session, import_id)[0].note == "march-update.xlsx"
+
+    def test_failed_reimport_leaves_no_snapshot(self, client, db_session):
+        """A snapshot must not survive a re-import that rolls back."""
+        import_id = _upload(client, DEFAULT_ROWS)
+        # Corrupt upload → 400, transaction rolled back.
+        r = client.put(
+            f"/imports/{import_id}/reimport",
+            files={"file": ("bad.xlsx", io.BytesIO(b"not excel"), XLSX_MIME)},
+        )
+        assert r.status_code == 400
+        assert _snapshots(db_session, import_id) == []
+
+
+class TestSnapshotContents:
+    def test_snapshot_captures_override_with_all_columns(self, client, db_session):
+        import_id = _upload(client, DEFAULT_ROWS)
+        sections = client.get(f"/imports/{import_id}/sections").json()
+        work2 = next(w for s in sections for w in s["works"] if w["raw_cat_no"] == "2")
+        client.put(
+            f"/imports/{import_id}/works/{work2['id']}/override",
+            json={"title_override": "Custom Dawn", "title_cased_override": "Custom Dawn TC"},
+        )
+
+        _reimport(client, import_id, DEFAULT_ROWS)
+
+        snap = _snapshots(db_session, import_id)[0]
+        snap_work2 = next(w for w in _all_works(snap.state) if w["raw_cat_no"] == "2")
+        ovr = snap_work2["override"]
+        assert ovr is not None
+        assert ovr["title_override"] == "Custom Dawn"
+        assert ovr["title_cased_override"] == "Custom Dawn TC"
+        # Full-column serialisation: every WorkOverride column is present even
+        # when unset, so a newly-added override field can't fall out silently.
+        assert "artwork_override" in ovr
+        assert "notes" in ovr
+
+    def test_snapshot_captures_raw_and_normalised_layers(self, client, db_session):
+        import_id = _upload(client, DEFAULT_ROWS)
+        _reimport(client, import_id, DEFAULT_ROWS)
+        snap = _snapshots(db_session, import_id)[0]
+        work1 = next(w for w in _all_works(snap.state) if w["raw_cat_no"] == "1")
+        assert work1["override"] is None
+        assert work1["raw_artist"] == "Jane Doe"  # raw layer
+        assert work1["title"] == "Sunset"  # normalised layer
+
+    def test_snapshot_captures_section_structure(self, client, db_session):
+        rows = [
+            [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+            [2, "Gallery B", "Noon", "Alice", "NFS", None, None, None],
+        ]
+        import_id = _upload(client, rows)
+        _reimport(client, import_id, rows)
+        snap = _snapshots(db_session, import_id)[0]
+        names = {s["name"] for s in snap.state["sections"]}
+        assert names == {"Gallery A", "Gallery B"}

--- a/tests/test_reimport_diff_api.py
+++ b/tests/test_reimport_diff_api.py
@@ -1,0 +1,131 @@
+"""Tests for the read-only reimport-diff / snapshot API (api/low_snapshots.py).
+
+GET /imports/{id}/reimport-diff           — latest snapshot vs current
+GET /imports/{id}/snapshots               — list snapshots
+GET /imports/{id}/snapshots/{sid}/diff    — a specific snapshot vs current
+"""
+
+import io
+import uuid as _uuid
+
+import pytest
+from openpyxl import Workbook
+
+client = pytest.fixture(name="client")(lambda client_lenient: client_lenient)
+
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+HEADERS = ["Cat No", "Gallery", "Title", "Artist", "Price", "Edition", "Artwork", "Medium"]
+ROWS = [
+    [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+    [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+]
+
+
+def _xlsx(rows):
+    wb = Workbook()
+    ws = wb.active
+    ws.append(HEADERS)
+    for r in rows:
+        ws.append(r)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def _upload(client, rows=ROWS):
+    r = client.post("/import", files={"file": ("orig.xlsx", _xlsx(rows), XLSX_MIME)})
+    assert r.status_code == 200, r.text
+    return r.json()["import_id"]
+
+
+def _reimport(client, import_id, rows, filename="updated.xlsx"):
+    return client.put(
+        f"/imports/{import_id}/reimport",
+        files={"file": (filename, _xlsx(rows), XLSX_MIME)},
+    )
+
+
+def _find_change(diff, cat_no, field):
+    for c in diff["changed"]:
+        if c["new"]["cat_no"] == cat_no or c["old"]["cat_no"] == cat_no:
+            for f in c["fields"]:
+                if f["field"] == field:
+                    return f
+    return None
+
+
+def test_reimport_diff_no_snapshot_before_any_reimport(client):
+    import_id = _upload(client)
+    r = client.get(f"/imports/{import_id}/reimport-diff")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["no_snapshot"] is True
+    assert body["has_changes"] is False
+
+
+def test_reimport_diff_reports_source_change(client):
+    import_id = _upload(client)
+    # cat 1 price 500 -> 600 in the spreadsheet (a source change); cat 2 unchanged.
+    new_rows = [
+        [1, "Gallery A", "Sunset", "Jane Doe", "600", None, None, "Oil"],
+        [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+    ]
+    _reimport(client, import_id, new_rows, filename="march.xlsx")
+
+    body = client.get(f"/imports/{import_id}/reimport-diff").json()
+    assert body["no_snapshot"] is False
+    assert body["has_changes"] is True
+    assert body["snapshot"]["note"] == "march.xlsx"
+    price = _find_change(body, "1", "price_numeric")
+    assert price is not None
+    assert price["causes"] == ["source"]
+
+
+def test_snapshots_list_is_append_only_newest_first(client, db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from backend.app.models.import_snapshot_model import ImportSnapshot
+
+    import_id = _upload(client)
+    _reimport(client, import_id, ROWS, filename="v1.xlsx")
+    _reimport(client, import_id, ROWS, filename="v2.xlsx")
+
+    # SQLite's CURRENT_TIMESTAMP is second-resolution, so two same-second
+    # snapshots tie; force distinct created_at to test ordering deterministically.
+    rows = (
+        db_session.query(ImportSnapshot)
+        .filter(ImportSnapshot.import_id == _uuid.UUID(import_id))
+        .all()
+    )
+    assert len(rows) == 2  # append-only: a row per re-import
+    by_note = {s.note: s for s in rows}
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    by_note["v1.xlsx"].created_at = base
+    by_note["v2.xlsx"].created_at = base + timedelta(minutes=5)
+    db_session.commit()
+
+    snaps = client.get(f"/imports/{import_id}/snapshots").json()
+    assert [s["note"] for s in snaps] == ["v2.xlsx", "v1.xlsx"]  # newest first
+    assert all(s["kind"] == "pre_reimport" for s in snaps)
+
+
+def test_specific_snapshot_diff(client):
+    import_id = _upload(client)
+    _reimport(client, import_id, ROWS, filename="v1.xlsx")
+    snaps = client.get(f"/imports/{import_id}/snapshots").json()
+    sid = snaps[0]["id"]
+    r = client.get(f"/imports/{import_id}/snapshots/{sid}/diff")
+    assert r.status_code == 200
+    assert r.json()["snapshot"]["id"] == sid
+
+
+def test_unknown_snapshot_is_404(client):
+    import_id = _upload(client)
+    r = client.get(f"/imports/{import_id}/snapshots/{_uuid.uuid4()}/diff")
+    assert r.status_code == 404
+
+
+def test_unknown_import_is_404(client):
+    r = client.get(f"/imports/{_uuid.uuid4()}/reimport-diff")
+    assert r.status_code == 404


### PR DESCRIPTION
## What & why

The team polishes an import (normalisation checks, overrides) and then runs **Update Import** to pull in late spreadsheet changes. That action was irreversible and gave no after-the-fact view of what it changed. This adds the foundation for both:

1. A **pre-reimport snapshot** of the full mutable state, captured automatically (append-only) just before every re-import.
2. An **attributed before/after diff** — "what the last Update Import changed, **and why**" (source / normalisation rules / editorial override).

This is **PR A — read-only**: capture + diff + view. The mutating **undo/restore** is deliberately split into a follow-up (PR B).

## Layers

| Layer | Detail |
|---|---|
| Model + migration | `ImportSnapshot` / `import_snapshots` (JSONB `state`, append-only). Migration `n4f6h8j0l2e3`. |
| Capture | Hook in `reimport_excel`, **inside the re-import transaction** (rolled back with it), skipped on dry-run; whole import is snapshot even for gallery-scoped re-imports so undo stays coherent. Serialises **every** Work/WorkOverride column (not a hand-maintained subset), so a new field can't silently fall out; Decimal stored as string to preserve price precision. |
| Diff engine | `import_diff.diff_states(old, new)` — field-level changes each tagged source/normalisation/override, plus added/removed/renumber/section-move/include toggles. **Fingerprint-first** pairing (then catalogue number), the inverse of the re-import matcher's cat-no-first-gated policy — because a diff must *surface* content edits the conservative preservation matcher would show as remove+add. Shares only the `compute_fingerprint` primitive; the attributed renderer is reusable by a future compare-two-imports tool. |
| API | `GET /imports/{id}/reimport-diff`, `…/snapshots`, `…/snapshots/{sid}/diff` (read-only). |
| UI | "What the last update changed" panel on the LoW detail page — full-width band, Before/After with a **Why** column of cause badges; Price/Edition grouped into one row (comparison stays field-level, so a number-behind-stable-text change still surfaces). Auto-expands after a re-import. |

## Tests
1014 passed; `ruff check` + `ruff format` clean. Backend covered by unit (attribution/pairing cases) + integration (real serialised states) + API tests; frontend verified manually in local dev.

## Deploy note
Merging to `main` deploys to production; the migration only **adds** the `import_snapshots` table on startup — no change to existing data.

## Follow-up
PR B: `restore_snapshot` + `POST …/snapshots/{id}/restore` + an "Undo this update" button.