### PR TITLE
Snapshot restore / undo for Update Import (PR B)

### DIFF
--- a/backend/app/api/low_snapshots.py
+++ b/backend/app/api/low_snapshots.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
+from backend.app.api.auth import require_role
 from backend.app.api.deps import get_db
 from backend.app.models.import_model import Import
 from backend.app.services.import_diff import diff_states
@@ -18,6 +19,7 @@ from backend.app.services.import_snapshot import (
     get_latest_snapshot,
     get_snapshot,
     list_snapshots,
+    restore_snapshot,
     serialize_import_state,
 )
 
@@ -74,3 +76,20 @@ def get_snapshot_diff(import_id: UUID, snapshot_id: UUID, db: Session = Depends(
         "snapshot": _snapshot_meta(snap),
         **diff_states(snap.state, current),
     }
+
+
+@router.post(
+    "/imports/{import_id}/snapshots/{snapshot_id}/restore",
+    dependencies=[Depends(require_role("editor"))],
+)
+def restore_import_snapshot(import_id: UUID, snapshot_id: UUID, db: Session = Depends(get_db)):
+    """Restore (undo to) a snapshot: replace the import's current data with the
+    state captured in the snapshot. A pre-restore snapshot of the current state
+    is taken first, so this is itself reversible."""
+    _require_import(import_id, db)
+    snap = get_snapshot(snapshot_id, db)
+    if snap is None or snap.import_id != import_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Snapshot not found")
+    counts = restore_snapshot(import_id, snap, db)
+    db.commit()
+    return {"restored": True, "snapshot_id": str(snapshot_id), **counts}

--- a/backend/app/services/import_snapshot.py
+++ b/backend/app/services/import_snapshot.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
+from backend.app.models.audit_log_model import AuditLog
 from backend.app.models.import_snapshot_model import ImportSnapshot
 from backend.app.models.override_model import WorkOverride
 from backend.app.models.section_model import Section
@@ -180,3 +181,165 @@ def create_snapshot(
     db.add(snap)
     db.flush()
     return snap
+
+
+# ---------------------------------------------------------------------------
+# Restore (undo) — rebuild an import's state from a snapshot
+# ---------------------------------------------------------------------------
+
+# Server-managed timestamps are never restored explicitly — a restored row is
+# genuinely (re-)created now.
+_SKIP_COLS = {"created_at", "updated_at"}
+
+
+def _coerce(col, val):
+    """Coerce a JSON-decoded snapshot value back to the column's Python type
+    (UUID string -> UUID, Decimal string -> Decimal); pass primitives through."""
+    if val is None:
+        return None
+    try:
+        pytype = col.type.python_type
+    except (NotImplementedError, AttributeError):
+        pytype = None
+    if pytype is _uuid.UUID and isinstance(val, str):
+        return _uuid.UUID(val)
+    if pytype is Decimal and not isinstance(val, Decimal):
+        return Decimal(str(val))
+    return val
+
+
+def _instance_from_dict(model, data: dict):
+    """Rebuild an ORM instance from a serialised row dict, restoring every
+    mapped column (so a new column can't silently drop out of restore) except
+    server-managed timestamps."""
+    kwargs = {
+        col.name: _coerce(col, data[col.name])
+        for col in model.__table__.columns
+        if col.name not in _SKIP_COLS and col.name in data
+    }
+    return model(**kwargs)
+
+
+def restore_snapshot(
+    import_id: _uuid.UUID,
+    snapshot: ImportSnapshot,
+    db: Session,
+    *,
+    snapshot_current_first: bool = True,
+) -> dict:
+    """Replace an import's current state with the one captured in ``snapshot``.
+
+    Wipes the import's current sections / works / overrides / validation
+    warnings and rebuilds them verbatim from ``snapshot.state`` — restoring the
+    original row ids so audit-log references stay valid, and the normalised
+    values exactly as they were (no re-normalisation).
+
+    Append-only and itself reversible: by default a ``pre_restore`` snapshot of
+    the *current* state is captured first, so an unwanted restore can be undone
+    too. Writes an audit-log entry. The caller commits.
+
+    Returns counts: ``{"sections", "works", "overrides", "warnings"}``.
+    """
+    # Read everything we need off the snapshot up front: we expunge the session
+    # below, which would detach it.
+    state = snapshot.state or {}
+    snapshot_created_iso = _iso(snapshot.created_at)
+
+    # Capture the current state first so the restore is itself undoable.
+    if snapshot_current_first:
+        create_snapshot(
+            import_id,
+            db,
+            kind="pre_restore",
+            note=f"Before restoring snapshot taken {snapshot_created_iso}",
+        )
+
+    # Wipe current state (overrides -> warnings -> works -> sections).
+    work_ids = [row.id for row in db.query(Work.id).filter(Work.import_id == import_id).all()]
+    if work_ids:
+        db.query(WorkOverride).filter(WorkOverride.work_id.in_(work_ids)).delete(
+            synchronize_session=False
+        )
+    db.query(ValidationWarning).filter(ValidationWarning.import_id == import_id).delete(
+        synchronize_session=False
+    )
+    db.query(Work).filter(Work.import_id == import_id).delete(synchronize_session=False)
+    db.query(Section).filter(Section.import_id == import_id).delete(synchronize_session=False)
+    db.flush()
+
+    # Bulk deletes with synchronize_session=False leave stale instances in the
+    # identity map; clear it so re-inserting rows with their original ids (for
+    # audit continuity) can't collide with those ghosts.
+    db.expunge_all()
+
+    # Recreate sections first (FK targets), then works + overrides + warnings.
+    counts = {"sections": 0, "works": 0, "overrides": 0, "warnings": 0}
+    for sdict in state.get("sections", []):
+        db.add(
+            Section(
+                id=_uuid.UUID(sdict["id"]),
+                import_id=import_id,
+                name=sdict["name"],
+                position=sdict["position"],
+            )
+        )
+        counts["sections"] += 1
+    db.flush()
+
+    for sdict in state.get("sections", []):
+        for wdict in sdict.get("works", []):
+            work = _instance_from_dict(Work, wdict)
+            work.import_id = import_id  # belt-and-braces: pin to this import
+            db.add(work)
+            db.flush()  # work row must exist before its override/warnings (FK)
+            counts["works"] += 1
+
+            ovr = wdict.get("override")
+            if ovr:
+                override = _instance_from_dict(WorkOverride, ovr)
+                override.work_id = work.id
+                db.add(override)
+                counts["overrides"] += 1
+
+            for wn in wdict.get("warnings", []):
+                db.add(
+                    ValidationWarning(
+                        import_id=import_id,
+                        work_id=work.id,
+                        warning_type=wn["warning_type"],
+                        message=wn["message"],
+                    )
+                )
+                counts["warnings"] += 1
+
+    for iw in state.get("import_warnings", []):
+        db.add(
+            ValidationWarning(
+                import_id=import_id,
+                work_id=None,
+                warning_type=iw["warning_type"],
+                message=iw["message"],
+            )
+        )
+        counts["warnings"] += 1
+
+    db.add(
+        AuditLog(
+            import_id=import_id,
+            work_id=None,
+            action="snapshot_restore",
+            field=None,
+            old_value=None,
+            new_value=(
+                f"restored snapshot taken {snapshot_created_iso} "
+                f"(sections={counts['sections']}, works={counts['works']}, "
+                f"overrides={counts['overrides']})"
+            ),
+        )
+    )
+
+    return counts
+
+
+def _iso(dt) -> str:
+    return dt.isoformat() if dt is not None else "?"

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6589,10 +6589,36 @@ async function toggleReimportDiff(importId, btnEl) {
     const diff = await api('GET', `/imports/${importId}/reimport-diff`);
     panel.dataset.visible = '1';
     panel.innerHTML = _renderReimportDiffPanel(diff);
+    // Wire the undo button (only rendered for editors when there's a snapshot).
+    panel.querySelector('#reimport-undo-btn')?.addEventListener('click', (e) =>
+      undoReimport(importId, diff.snapshot.id, e.currentTarget)
+    );
   } catch (err) {
     if (err.message === 'Auth') return;
     panel.innerHTML = `<p class="error" style="margin-top:8px">${esc(err.message)}</p>`;
   } finally {
+    restore();
+  }
+}
+
+// Undo the last Update Import by restoring the pre-reimport snapshot. The
+// backend captures the current state first, so this is itself reversible.
+async function undoReimport(importId, snapshotId, btnEl) {
+  const ok = window.confirm(
+    'Undo the last Update Import?\n\n' +
+    'This replaces the current data with the snapshot taken just before it — ' +
+    'any changes since (including overrides added afterwards) will be discarded. ' +
+    'A snapshot of the current state is saved first, so this is itself reversible.'
+  );
+  if (!ok) return;
+  const restore = btnLoading(btnEl, 'Undoing');
+  try {
+    const res = await api('POST', `/imports/${importId}/snapshots/${snapshotId}/restore`);
+    showToast(`Restored ${res.works} work${res.works === 1 ? '' : 's'} from the snapshot`, 'success', 5000);
+    await renderDetail(importId);  // rebuilds the page; button is gone afterwards
+  } catch (err) {
+    if (err.message === 'Auth') return;
+    showToast(`Undo failed: ${err.message}`, 'error');
     restore();
   }
 }
@@ -6629,6 +6655,15 @@ function _renderReimportDiffPanel(diff) {
   if (diff.removed.length) badges.push(`<span class="badge badge-removed">${diff.removed.length} removed</span>`);
   if (diff.unchanged_count) badges.push(`<span class="badge badge-unchanged">${diff.unchanged_count} unchanged</span>`);
   parts.push(`<div class="diff-badges">${badges.join(' ')}</div>`);
+
+  // Undo (editors only): restore the pre-update snapshot. Reversible — the
+  // backend snapshots the current state first.
+  if (canEdit() && snap) {
+    parts.push(
+      `<div class="reimport-undo-bar"><button type="button" class="btn btn-secondary" id="reimport-undo-btn">` +
+      `↩ Undo this update — restore the snapshot</button></div>`
+    );
+  }
 
   // Cause legend so the "Why" column reads clearly.
   parts.push(

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1429,6 +1429,7 @@ details.section-block[open] > .section-summary::before {
 /* Sub-label for grouped diff fields (e.g. Price → number / display). inline-block
    so the strikethrough on a changed "before" cell doesn't strike the label. */
 .diff-sub { display: inline-block; color: #888; text-decoration: none; font-size: 11px; margin-right: 4px; }
+.reimport-undo-bar { margin: 2px 0 12px; }
 
 /* Tools panel (collapsed by default to keep the Works list near the top) */
 details.tools-panel[open] > .section-summary::before { transform: rotate(90deg); }

--- a/tests/test_snapshot_restore.py
+++ b/tests/test_snapshot_restore.py
@@ -1,0 +1,147 @@
+"""Tests for snapshot restore / undo.
+
+  POST /imports/{id}/snapshots/{sid}/restore  — replace current data with a snapshot
+
+Restore reinstates the exact prior state (raw + normalised + overrides + flags),
+takes a pre_restore snapshot first (so it's itself reversible), and is audited.
+"""
+
+import io
+import uuid as _uuid
+
+import pytest
+from openpyxl import Workbook
+
+from backend.app.models.audit_log_model import AuditLog
+from backend.app.models.import_snapshot_model import ImportSnapshot
+
+client = pytest.fixture(name="client")(lambda client_lenient: client_lenient)
+
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+HEADERS = ["Cat No", "Gallery", "Title", "Artist", "Price", "Edition", "Artwork", "Medium"]
+ORIG = [
+    [1, "Gallery A", "Sunset", "Jane Doe", "500", None, None, "Oil"],
+    [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+]
+
+
+def _xlsx(rows):
+    wb = Workbook()
+    ws = wb.active
+    ws.append(HEADERS)
+    for r in rows:
+        ws.append(r)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def _upload(client, rows):
+    r = client.post("/import", files={"file": ("orig.xlsx", _xlsx(rows), XLSX_MIME)})
+    assert r.status_code == 200, r.text
+    return r.json()["import_id"]
+
+
+def _reimport(client, import_id, rows, filename="updated.xlsx"):
+    r = client.put(
+        f"/imports/{import_id}/reimport",
+        files={"file": (filename, _xlsx(rows), XLSX_MIME)},
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+def _works(client, import_id):
+    sections = client.get(f"/imports/{import_id}/sections").json()
+    return {w["raw_cat_no"]: w for s in sections for w in s["works"]}
+
+
+def _setup_polished_then_reimported(client):
+    """Upload, add an override + exclusion, then re-import with a price change
+    and an added work. Returns (import_id, pre_reimport_snapshot_id)."""
+    import_id = _upload(client, ORIG)
+    works = _works(client, import_id)
+    client.put(
+        f"/imports/{import_id}/works/{works['2']['id']}/override",
+        json={"title_override": "Custom Dawn"},
+    )
+    client.patch(f"/imports/{import_id}/works/{works['1']['id']}/exclude?exclude=true")
+
+    new_rows = [
+        [1, "Gallery A", "Sunset", "Jane Doe", "600", None, None, "Oil"],  # price changed
+        [2, "Gallery A", "Dawn", "John Smith RA", "1000", None, None, "Acrylic"],
+        [3, "Gallery A", "Noon", "Alice", "NFS", None, None, None],  # added
+    ]
+    _reimport(client, import_id, new_rows)
+
+    snaps = client.get(f"/imports/{import_id}/snapshots").json()
+    assert len(snaps) == 1  # the pre-reimport snapshot
+    return import_id, snaps[0]["id"]
+
+
+def test_restore_reinstates_prior_state(client):
+    import_id, sid = _setup_polished_then_reimported(client)
+
+    # Sanity: the re-import did change things.
+    post = _works(client, import_id)
+    assert post["1"]["price_numeric"] == 600.0
+    assert "3" in post
+
+    r = client.post(f"/imports/{import_id}/snapshots/{sid}/restore")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["restored"] is True
+    assert body["works"] == 2
+
+    w = _works(client, import_id)
+    assert set(w.keys()) == {"1", "2"}  # the added cat 3 is gone
+    assert w["1"]["price_numeric"] == 500.0  # price reverted
+    assert w["1"]["include_in_export"] is False  # exclusion reinstated
+    assert w["2"]["override"]["title_override"] == "Custom Dawn"  # override reinstated
+
+
+def test_restore_takes_pre_restore_snapshot_and_audits(client, db_session):
+    import_id, sid = _setup_polished_then_reimported(client)
+    client.post(f"/imports/{import_id}/snapshots/{sid}/restore")
+
+    iid = _uuid.UUID(import_id)
+    kinds = [
+        s.kind
+        for s in db_session.query(ImportSnapshot).filter(ImportSnapshot.import_id == iid).all()
+    ]
+    assert "pre_restore" in kinds  # current state captured before the restore
+
+    logs = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.import_id == iid, AuditLog.action == "snapshot_restore")
+        .all()
+    )
+    assert len(logs) == 1
+
+
+def test_restore_is_reversible(client):
+    """Restoring the pre_restore snapshot returns to the post-reimport state."""
+    import_id, sid = _setup_polished_then_reimported(client)
+    client.post(f"/imports/{import_id}/snapshots/{sid}/restore")
+    # The restore captured a pre_restore snapshot of the post-reimport state.
+    # Select it by kind (not "newest" — SQLite's second-resolution timestamps
+    # tie when the whole flow runs in milliseconds).
+    snaps = client.get(f"/imports/{import_id}/snapshots").json()
+    pre_restore_id = next(s["id"] for s in snaps if s["kind"] == "pre_restore")
+
+    client.post(f"/imports/{import_id}/snapshots/{pre_restore_id}/restore")
+    w = _works(client, import_id)
+    assert "3" in w  # the added work is back
+    assert w["1"]["price_numeric"] == 600.0  # price change is back
+
+
+def test_restore_unknown_snapshot_is_404(client):
+    import_id = _upload(client, ORIG)
+    r = client.post(f"/imports/{import_id}/snapshots/{_uuid.uuid4()}/restore")
+    assert r.status_code == 404
+
+
+def test_restore_unknown_import_is_404(client):
+    r = client.post(f"/imports/{_uuid.uuid4()}/snapshots/{_uuid.uuid4()}/restore")
+    assert r.status_code == 404


### PR DESCRIPTION
## What

The mutating half of the reimport-snapshot feature (PR A added capture + read-only diff). This lets an editor **undo the last Update Import** by restoring the pre-reimport snapshot, wholesale.

Builds on [#108](https://github.com/hoyla/RA-SummerExhibition-ListOfWorks/pull/108) (merged).

## How

- **`restore_snapshot()`** rebuilds an import's sections / works / overrides / validation warnings verbatim from a snapshot:
  - restores **original row ids** (audit-log references stay valid),
  - restores **normalised values as they were** (no re-normalisation),
  - reconstructs **every column generically**, so a newly-added field can't silently drop out of restore.
- **Itself reversible + audited:** captures a `pre_restore` snapshot of the current state first, then writes a `snapshot_restore` audit entry. Append-only throughout.
- **`POST /imports/{id}/snapshots/{sid}/restore`** — editor-gated; 404 on unknown import/snapshot.
- **UI:** an "↩ Undo this update" button in the "What the last update changed" panel (editors only), behind a confirm; refreshes the page on success.

## Notable fix found along the way
Bulk `delete(synchronize_session=False)` leaves stale instances in the session identity map, so re-inserting rows with their original ids collided. `expunge_all()` after the wipe clears it.

## Tests
5 restore tests (reinstatement, pre_restore + audit, reversibility round-trip, 404s). Full suite green; `ruff check` + `ruff format` clean. **No migration** — reuses the existing `import_snapshots` table.

## Known limitation (deferred, agreed)
Restore reinstates the catalogue data but not the Import record's `filename`/`description` (the snapshot doesn't capture those). Low priority — a small follow-up if wanted.