### PR TITLE
Reconcile list: cat numbers link through to the work below

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6903,7 +6903,7 @@ function toggleReconCosmetic() {
   }
   if (!cos.length) return;
   const rows = cos.map(f => `<tr>
-    <td class="diff-catno">${esc(f.cat_no ?? '—')}</td>
+    <td class="diff-catno">${_reconCatNoCell(f.cat_no)}</td>
     <td><code>${esc(f.field || '')}</code></td>
     <td><span class="diff-old">${esc(String(f.db_value ?? ''))}</span></td>
     <td><span class="diff-new">${esc(String(f.low_value ?? ''))}</span></td>
@@ -6941,6 +6941,27 @@ function _paintReconGroups() {
       'Text changes — open the work below and set the override. Best done after the re-import is settled.', textual);
 }
 
+// Reconcile findings are keyed by catalogue number; the works table rows are
+// keyed by work id. Map cat no -> work (via _workCache, populated when the
+// sections render) so the cat-no column can click through to the work below,
+// like the Import notes panel does. Returns null when no work matches (e.g. an
+// entry that's in the corrected LOW but not yet in the data) -> plain text.
+function _workByCatNo(catNo) {
+  if (catNo == null || catNo === '') return null;
+  const want = String(catNo);
+  return Object.values(_workCache).find(w => String(w.raw_cat_no ?? '') === want) || null;
+}
+
+// Inner HTML for a reconcile "Cat No" cell: a scroll-to-work link when the work
+// exists in the current data, otherwise the plain (escaped) number.
+function _reconCatNoCell(catNo) {
+  const txt = (catNo != null && catNo !== '') ? String(catNo) : '—';
+  const work = _workByCatNo(catNo);
+  return work
+    ? `<button type="button" class="link-btn" onclick="scrollToWork('${esc(work.id)}')">${esc(txt)}</button>`
+    : esc(txt);
+}
+
 function _reconTaskGroup(num, title, hint, findings) {
   if (!findings.length) return '';
   const rows = findings.map(f => {
@@ -6949,7 +6970,7 @@ function _reconTaskGroup(num, title, hint, findings) {
     const dbv = (f.db_value != null && f.db_value !== '') ? `<span class="diff-old">${esc(String(f.db_value))}</span>` : '<span class="muted">—</span>';
     const lowv = (f.low_value != null && f.low_value !== '') ? `<span class="diff-new">${esc(String(f.low_value))}</span>` : '<span class="muted">—</span>';
     return `<tr>
-      <td class="diff-catno">${esc(f.cat_no ?? '—')}</td>
+      <td class="diff-catno">${_reconCatNoCell(f.cat_no)}</td>
       <td>${what}</td>
       <td>${dbv}</td>
       <td>${lowv}</td>


### PR DESCRIPTION
## What

In the **Reconcile** results, the **Cat No** column is now a click-through link to the matching work in the details below — the same behaviour you already get from the **Import notes** list.

Clicking a cat number opens the work's section, smooth-scrolls and flashes the row highlight, and opens the work's override drawer (via the existing `scrollToWork`).

## How

- `_workByCatNo(catNo)` maps a catalogue number to a work through `_workCache`, reusing the same string match as the existing `?work=` deep-link.
- `_reconCatNoCell(catNo)` renders a `link-btn` to that work when one exists, otherwise plain text.

Applied to both reconcile cat-no render sites: the findings tables (`_reconTaskGroup`) and the suppressed-cosmetic table (`toggleReconCosmetic`). Frontend-only — no backend, API, or snapshot-contract changes.

## Graceful fallback

A cat number only becomes a link when that work exists in the current data — matching the Import notes fallback. So `section_rename` findings (no cat number) and "added" entries (in the corrected LOW but not yet imported) stay as plain text rather than dead links.

## Verification

Ran locally against an import with an existing corrected-LOW snapshot:

- 218/218 finding cat-no cells and 110/110 cosmetic cells link correctly.
- The 9 `section_rename` findings (no cat number) correctly stay as a plain "—".
- Click-through confirmed end-to-end: opens the section, highlights the row, opens the drawer, sets `?work=N`.