### PR TITLE
Prod mothball & restore tooling (off-season teardown)

### DIFF
--- a/.aws/mothball-prod.sh
+++ b/.aws/mothball-prod.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# ==========================================================================
+# Catalogue Tool — Mothball PRODUCTION
+#
+# Takes a final RDS snapshot, then deletes the three resources that cost money
+# year-round: the RDS instance, the ALB (+ target group), and the ECS service.
+#
+# DELIBERATELY LEFT IN PLACE (cheap or free, and they hold all the state):
+#   - S3 bucket  ra-catalogue-prod-028597908565   (uploaded files + versioning)
+#   - The final RDS snapshot                       (= the database, frozen)
+#   - Cognito user pool                            (free <50k MAU; users kept)
+#   - Secrets Manager  catalogue-prod/*            (~$1.20/mo total)
+#   - ECR image, IAM roles, security groups, subnet group, CloudWatch logs
+#
+# Bring it all back with restore-prod.sh.
+#
+# Prerequisites: aws cli configured, account 028597908565, region eu-north-1.
+# Run from the project root.
+# ==========================================================================
+
+set -euo pipefail
+
+REGION="eu-north-1"
+SNAPSHOT_ID="catalogue-prod-mothball-$(date +%Y%m%d)"
+export AWS_PAGER=""
+
+echo "============================================"
+echo "  Catalogue — Mothball PRODUCTION"
+echo "============================================"
+echo ""
+echo "This DELETES the production RDS instance, ALB, and ECS service."
+echo "A snapshot ($SNAPSHOT_ID) is taken and verified FIRST."
+echo "S3 files, Cognito users, secrets, and the container image are untouched."
+echo ""
+read -r -p "Type 'mothball' to continue: " confirm
+[ "$confirm" = "mothball" ] || { echo "Aborted."; exit 1; }
+echo ""
+
+# --------------------------------------------------------------------------
+# 1. Final snapshot (and verify it before deleting anything)
+# --------------------------------------------------------------------------
+echo ">>> 1/4  Snapshotting RDS catalogue-prod -> $SNAPSHOT_ID ..."
+if aws rds describe-db-instances --db-instance-identifier catalogue-prod \
+        --region "$REGION" >/dev/null 2>&1; then
+
+    if aws rds describe-db-snapshots --db-snapshot-identifier "$SNAPSHOT_ID" \
+            --region "$REGION" >/dev/null 2>&1; then
+        echo "    (snapshot $SNAPSHOT_ID already exists — reusing)"
+    else
+        aws rds create-db-snapshot \
+            --db-instance-identifier catalogue-prod \
+            --db-snapshot-identifier "$SNAPSHOT_ID" \
+            --region "$REGION" --no-cli-pager >/dev/null
+    fi
+
+    echo "    Waiting for snapshot to complete (5-10 min)..."
+    aws rds wait db-snapshot-available \
+        --db-snapshot-identifier "$SNAPSHOT_ID" --region "$REGION"
+
+    STATUS=$(aws rds describe-db-snapshots --db-snapshot-identifier "$SNAPSHOT_ID" \
+        --query 'DBSnapshots[0].Status' --output text --region "$REGION")
+    [ "$STATUS" = "available" ] || {
+        echo "    ERROR: snapshot status is '$STATUS', not 'available'."
+        echo "    Aborting BEFORE any deletion — your data is untouched."
+        exit 1
+    }
+    echo "    ✓ Snapshot $SNAPSHOT_ID is available."
+else
+    echo "    (RDS instance catalogue-prod not found — already mothballed?)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# 2. Delete the ECS service (keeps cluster + task definitions)
+# --------------------------------------------------------------------------
+echo ">>> 2/4  Deleting ECS service catalogue-prod ..."
+aws ecs update-service --cluster catalogue --service catalogue-prod \
+    --desired-count 0 --region "$REGION" --no-cli-pager >/dev/null 2>&1 || true
+aws ecs delete-service --cluster catalogue --service catalogue-prod --force \
+    --region "$REGION" --no-cli-pager >/dev/null 2>&1 \
+    && echo "    ✓ Service deleted." \
+    || echo "    (service already gone)"
+echo ""
+
+# --------------------------------------------------------------------------
+# 3. Delete the ALB, then its target group
+# --------------------------------------------------------------------------
+echo ">>> 3/4  Deleting ALB catalogue-alb + target group ..."
+ALB_ARN=$(aws elbv2 describe-load-balancers --names catalogue-alb \
+    --query 'LoadBalancers[0].LoadBalancerArn' --output text \
+    --region "$REGION" 2>/dev/null || echo "None")
+if [ "$ALB_ARN" != "None" ] && [ -n "$ALB_ARN" ]; then
+    aws elbv2 delete-load-balancer --load-balancer-arn "$ALB_ARN" \
+        --region "$REGION" --no-cli-pager
+    aws elbv2 wait load-balancers-deleted --load-balancer-arns "$ALB_ARN" \
+        --region "$REGION"
+    echo "    ✓ ALB deleted."
+else
+    echo "    (ALB already gone)"
+fi
+
+# Target group can only be deleted once no listener references it (i.e. after
+# the ALB is gone).
+TG_ARN=$(aws elbv2 describe-target-groups --names catalogue-prod-tg \
+    --query 'TargetGroups[0].TargetGroupArn' --output text \
+    --region "$REGION" 2>/dev/null || echo "None")
+if [ "$TG_ARN" != "None" ] && [ -n "$TG_ARN" ]; then
+    aws elbv2 delete-target-group --target-group-arn "$TG_ARN" \
+        --region "$REGION" --no-cli-pager \
+        && echo "    ✓ Target group deleted." \
+        || echo "    (target group still referenced or already gone)"
+else
+    echo "    (target group already gone)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# 4. Delete the RDS instance (the snapshot from step 1 is what we keep)
+# --------------------------------------------------------------------------
+echo ">>> 4/4  Deleting RDS instance catalogue-prod ..."
+aws rds delete-db-instance \
+    --db-instance-identifier catalogue-prod \
+    --skip-final-snapshot \
+    --region "$REGION" --no-cli-pager >/dev/null 2>&1 \
+    && echo "    ✓ Deletion initiated (runs in the background, a few minutes)." \
+    || echo "    (instance already gone)"
+echo ""
+
+echo "============================================"
+echo "  ✅  Production mothballed."
+echo "============================================"
+echo ""
+echo "  KEEP THIS — needed to restore:"
+echo "    Snapshot: $SNAPSHOT_ID"
+echo ""
+echo "  Revive with:   ./.aws/restore-prod.sh $SNAPSHOT_ID"
+echo "  (restore-prod.sh also auto-detects the newest mothball snapshot.)"
+echo ""
+echo "  Tip: check for any now-unattached Elastic IPs"
+echo "    aws ec2 describe-addresses --region $REGION \\"
+echo "      --query 'Addresses[?AssociationId==\`null\`].PublicIp'"
+echo "  Unattached EIPs bill ~\$3.60/mo each; release with aws ec2 release-address."

--- a/.aws/restore-prod.sh
+++ b/.aws/restore-prod.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# ==========================================================================
+# Catalogue Tool — Restore PRODUCTION from a mothball snapshot
+#
+# Reverses mothball-prod.sh: restores the RDS instance from a snapshot, repoints
+# the DATABASE_URL secret at the new endpoint, then recreates the ALB, target
+# group, listener, and ECS service. S3 files, Cognito users, secrets, and the
+# ECR image were never deleted, so they come back as they were.
+#
+# Usage:
+#   ./.aws/restore-prod.sh [snapshot-id]
+# If no snapshot id is given, the newest 'catalogue-prod-mothball-*' is used.
+#
+# Prerequisites: aws cli configured, account 028597908565, region eu-north-1.
+# Run from the project root (needs .aws/task-definition-prod.json).
+# ==========================================================================
+
+set -euo pipefail
+
+REGION="eu-north-1"
+ACCOUNT_ID="028597908565"
+ECR_URI="$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/catalogue-app"
+export AWS_PAGER=""
+
+[ -f .aws/task-definition-prod.json ] || {
+    echo "ERROR: run from the project root (.aws/task-definition-prod.json not found)."
+    exit 1
+}
+
+# --------------------------------------------------------------------------
+# Resolve the snapshot
+# --------------------------------------------------------------------------
+SNAPSHOT_ID="${1:-}"
+if [ -z "$SNAPSHOT_ID" ]; then
+    SNAPSHOT_ID=$(aws rds describe-db-snapshots --snapshot-type manual \
+        --query "reverse(sort_by(DBSnapshots[?starts_with(DBSnapshotIdentifier,'catalogue-prod-mothball')],&SnapshotCreateTime))[0].DBSnapshotIdentifier" \
+        --output text --region "$REGION")
+fi
+[ -n "$SNAPSHOT_ID" ] && [ "$SNAPSHOT_ID" != "None" ] || {
+    echo "ERROR: no mothball snapshot found. Pass one explicitly:"
+    echo "  ./.aws/restore-prod.sh <snapshot-id>"
+    exit 1
+}
+
+echo "============================================"
+echo "  Catalogue — Restore PRODUCTION"
+echo "  Snapshot: $SNAPSHOT_ID"
+echo "============================================"
+echo ""
+
+# Warn early if there's no image to run (it normally persists in ECR).
+aws ecr describe-images --repository-name catalogue-app \
+    --image-ids imageTag=latest --region "$REGION" >/dev/null 2>&1 \
+    || echo "  ⚠  No ':latest' image in ECR — deploy one (CI / docker push) before tasks will start."
+
+# --------------------------------------------------------------------------
+# Look up shared networking (created once by setup-infrastructure.sh)
+# --------------------------------------------------------------------------
+VPC_ID=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true \
+    --query 'Vpcs[0].VpcId' --output text --region "$REGION")
+SUBNET_IDS=$(aws ec2 describe-subnets \
+    --filters Name=vpc-id,Values="$VPC_ID" Name=default-for-az,Values=true \
+    --query 'Subnets[*].SubnetId' --output text --region "$REGION")
+SUBNET_1=$(echo "$SUBNET_IDS" | awk '{print $1}')
+SUBNET_2=$(echo "$SUBNET_IDS" | awk '{print $2}')
+
+sg() { aws ec2 describe-security-groups \
+    --filters Name=group-name,Values="$1" Name=vpc-id,Values="$VPC_ID" \
+    --query 'SecurityGroups[0].GroupId' --output text --region "$REGION"; }
+ALB_SG=$(sg catalogue-alb-sg)
+ECS_SG=$(sg catalogue-ecs-sg)
+RDS_SG=$(sg catalogue-rds-sg)
+
+# --------------------------------------------------------------------------
+# 1. Restore RDS from the snapshot
+# --------------------------------------------------------------------------
+echo ">>> 1/5  Restoring RDS catalogue-prod from $SNAPSHOT_ID ..."
+if aws rds describe-db-instances --db-instance-identifier catalogue-prod \
+        --region "$REGION" >/dev/null 2>&1; then
+    echo "    (catalogue-prod already exists — skipping restore)"
+else
+    aws rds restore-db-instance-from-db-snapshot \
+        --db-instance-identifier catalogue-prod \
+        --db-snapshot-identifier "$SNAPSHOT_ID" \
+        --db-instance-class db.t4g.micro \
+        --db-subnet-group-name catalogue-db-subnets \
+        --vpc-security-group-ids "$RDS_SG" \
+        --no-publicly-accessible \
+        --no-multi-az \
+        --region "$REGION" --no-cli-pager >/dev/null
+fi
+echo "    Waiting for RDS to become available (5-10 min)..."
+aws rds wait db-instance-available --db-instance-identifier catalogue-prod \
+    --region "$REGION"
+RDS_ENDPOINT=$(aws rds describe-db-instances --db-instance-identifier catalogue-prod \
+    --query 'DBInstances[0].Endpoint.Address' --output text --region "$REGION")
+echo "    ✓ RDS available: $RDS_ENDPOINT"
+echo ""
+
+# --------------------------------------------------------------------------
+# 2. Repoint DATABASE_URL at the new endpoint (password is unchanged, so it is
+#    still correct in the retained secret — only the host moved)
+# --------------------------------------------------------------------------
+echo ">>> 2/5  Updating catalogue-prod/DATABASE_URL endpoint ..."
+OLD_URL=$(aws secretsmanager get-secret-value --secret-id catalogue-prod/DATABASE_URL \
+    --query SecretString --output text --region "$REGION")
+NEW_URL=$(echo "$OLD_URL" | sed -E "s#@[^/]+/#@${RDS_ENDPOINT}:5432/#")
+aws secretsmanager put-secret-value --secret-id catalogue-prod/DATABASE_URL \
+    --secret-string "$NEW_URL" --region "$REGION" --no-cli-pager >/dev/null
+echo "    ✓ Secret repointed."
+echo ""
+
+# --------------------------------------------------------------------------
+# 3. Ensure cluster + register the task definition
+# --------------------------------------------------------------------------
+echo ">>> 3/5  Registering task definition ..."
+aws ecs create-cluster --cluster-name catalogue --region "$REGION" \
+    --no-cli-pager >/dev/null 2>&1 || true
+sed "s|PLACEHOLDER|$ECR_URI:latest|g" .aws/task-definition-prod.json \
+    > /tmp/task-def-prod-resolved.json
+aws ecs register-task-definition --cli-input-json file:///tmp/task-def-prod-resolved.json \
+    --region "$REGION" --no-cli-pager >/dev/null
+echo "    ✓ Task definition registered."
+echo ""
+
+# --------------------------------------------------------------------------
+# 4. Recreate ALB + target group + listener
+# --------------------------------------------------------------------------
+echo ">>> 4/5  Recreating ALB + target group + listener ..."
+ALB_ARN=$(aws elbv2 create-load-balancer --name catalogue-alb \
+    --subnets "$SUBNET_1" "$SUBNET_2" --security-groups "$ALB_SG" \
+    --scheme internet-facing --type application \
+    --query 'LoadBalancers[0].LoadBalancerArn' --output text \
+    --region "$REGION" --no-cli-pager 2>/dev/null \
+    || aws elbv2 describe-load-balancers --names catalogue-alb \
+        --query 'LoadBalancers[0].LoadBalancerArn' --output text --region "$REGION")
+
+TG_ARN=$(aws elbv2 create-target-group --name catalogue-prod-tg \
+    --protocol HTTP --port 8000 --vpc-id "$VPC_ID" --target-type ip \
+    --health-check-path /health --health-check-interval-seconds 30 \
+    --healthy-threshold-count 2 --unhealthy-threshold-count 3 \
+    --query 'TargetGroups[0].TargetGroupArn' --output text \
+    --region "$REGION" --no-cli-pager 2>/dev/null \
+    || aws elbv2 describe-target-groups --names catalogue-prod-tg \
+        --query 'TargetGroups[0].TargetGroupArn' --output text --region "$REGION")
+
+LISTENER_ARN=$(aws elbv2 describe-listeners --load-balancer-arn "$ALB_ARN" \
+    --query 'Listeners[0].ListenerArn' --output text --region "$REGION" 2>/dev/null || echo "None")
+if [ "$LISTENER_ARN" = "None" ] || [ -z "$LISTENER_ARN" ]; then
+    aws elbv2 create-listener --load-balancer-arn "$ALB_ARN" \
+        --protocol HTTP --port 80 \
+        --default-actions Type=forward,TargetGroupArn="$TG_ARN" \
+        --region "$REGION" --no-cli-pager >/dev/null
+fi
+ALB_DNS=$(aws elbv2 describe-load-balancers --load-balancer-arns "$ALB_ARN" \
+    --query 'LoadBalancers[0].DNSName' --output text --region "$REGION")
+echo "    ✓ ALB ready."
+echo ""
+
+# --------------------------------------------------------------------------
+# 5. Create the ECS service
+# --------------------------------------------------------------------------
+echo ">>> 5/5  Creating ECS service catalogue-prod ..."
+aws ecs create-service \
+    --cluster catalogue \
+    --service-name catalogue-prod \
+    --task-definition catalogue-prod \
+    --desired-count 1 \
+    --launch-type FARGATE \
+    --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_1,$SUBNET_2],securityGroups=[$ECS_SG],assignPublicIp=ENABLED}" \
+    --load-balancers "targetGroupArn=$TG_ARN,containerName=app,containerPort=8000" \
+    --region "$REGION" --no-cli-pager >/dev/null 2>&1 \
+    || aws ecs update-service --cluster catalogue --service catalogue-prod \
+        --task-definition catalogue-prod --desired-count 1 \
+        --region "$REGION" --no-cli-pager >/dev/null
+echo "    ✓ Service starting."
+echo ""
+
+echo "============================================"
+echo "  ✅  Production restored."
+echo "============================================"
+echo ""
+echo "  App URL:  http://$ALB_DNS"
+echo ""
+echo "  Give it a few minutes for the task to start and pass health checks."
+echo "  The app runs Alembic migrations on boot — a no-op against restored data."
+echo "  Watch rollout:"
+echo "    aws ecs describe-services --cluster catalogue --services catalogue-prod \\"
+echo "      --query 'services[0].deployments' --region $REGION"

--- a/.aws/setup-infrastructure.sh
+++ b/.aws/setup-infrastructure.sh
@@ -16,6 +16,10 @@
 #   8. GitHub OIDC provider
 #   9. Secrets Manager entries (per-environment)
 #  10. Application Load Balancer (host-based routing)
+#
+# Seasonal teardown/rebuild of production (between exhibitions) is handled
+# separately by mothball-prod.sh / restore-prod.sh — see
+# docs/mothball-and-restore.md.
 # ==========================================================================
 
 set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -170,11 +170,17 @@ tests/            # pytest suite (~975 tests across 40 test files)
 .github/workflows/
   ci.yml          # GitHub Actions CI/CD pipeline
 .aws/
-  task-definition-staging.json  # ECS task definition (staging)
-  task-definition-prod.json     # ECS task definition (production)
+  setup-infrastructure.sh        # One-time AWS build (ECR, S3, RDS, ECS, ALB, IAM)
+  mothball-prod.sh               # Tear prod down to near-zero cost between seasons
+  restore-prod.sh                # Rebuild prod from a mothball snapshot
+  migrate-to-per-env-secrets.sh  # One-off secrets migration
+  task-definition-prod.json      # ECS task definition (production)
 docs/
   architecture_v1.md
-  dev-guide.md      # Developer guide (local setup, migrations, environments)
+  dev-guide.md                  # Developer guide (local setup, migrations, environments)
+  mothball-and-restore.md       # Seasonal prod teardown/rebuild runbook
+  staging-rebuild-checklist.md  # How to recreate the decommissioned staging env
+  reconcile.md
   export_spec_v1.md
   roadmap.md
 ```

--- a/docs/architecture_v1.md
+++ b/docs/architecture_v1.md
@@ -48,6 +48,13 @@ Excel Upload
 | Storage    | Local disk / Amazon S3                  |
 | Testing    | pytest (~975 tests across 40 test files) |
 
+**Infrastructure & operations.** The AWS stack (ECR, S3, RDS, ECS Fargate,
+ALB, IAM, Cognito) is built by [`.aws/setup-infrastructure.sh`](../.aws/setup-infrastructure.sh).
+The tool runs for only a few weeks each year, so production is mothballed to
+near-zero cost between exhibitions and rebuilt intact — see
+[`mothball-and-restore.md`](mothball-and-restore.md). Database backups are
+covered in [`dev-guide.md`](dev-guide.md#database-backup-production).
+
 ---
 
 ## 3. Data model

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -439,3 +439,137 @@ If an endpoint returns 500 with no log output:
 | LoW warning type not showing in UI               | Check the label map `_LOW_WARNING_LABELS` and the `_LOW_CHANGED_TYPES` set in `app.js`                                                    |
 | Index warning type not showing in UI             | Check the label map `_IDX_WARNING_LABELS` and the `_IDX_CHANGED_TYPES` set in `app.js`                                                    |
 | LoW Flags column badge not appearing             | Check `workRowHTML()` flags array — badges come from client-side detection (Trimmed, Norm, RA) and server-side warnings                    |
+
+---
+
+## Database backup (production)
+
+The production RDS instance (`catalogue-prod`, Postgres 16) is private
+(`PubliclyAccessible: false`) and there's no bastion or VPN into its VPC, so it
+can't be reached directly from a laptop. `pg_dump` also isn't installed in the
+app image, so dumping via ECS Exec isn't an option (and even if it were, the
+SSM session channel that backs `execute-command` is an interactive PTY, not a
+binary-safe pipe — it would corrupt a custom-format dump).
+
+The reliable, fully-managed route is to **restore a snapshot to a temporary,
+publicly-accessible instance**, `pg_dump` from it locally, then delete it. RDS
+takes automatic daily snapshots (7-day retention); use the latest, or take a
+fresh manual one first if you need up-to-the-minute data.
+
+This account makes that easy: the prod VPC is the **default VPC**, and the
+existing `catalogue-db-subnets` group sits in public subnets (IGW route,
+public-IP-on-launch). So the temp instance can reuse that subnet group and
+still be reachable — the only new resource is a throwaway security group locked
+to your IP.
+
+**Prerequisites:** AWS CLI configured for account `028597908565` / region
+`eu-north-1`, and a local `pg_dump`/`pg_restore` **≥ 16** (the prod engine is
+16.10; older clients refuse the dump). On macOS: `brew install libpq` and put
+its `bin` on your `PATH`.
+
+```bash
+export AWS_REGION=eu-north-1 AWS_PAGER=""
+VPC=vpc-0b17f45cadb2c54aa
+SUBNET_GROUP=catalogue-db-subnets
+TEMP_ID=catalogue-restore-$(date +%Y%m%d)
+```
+
+**1. Pick a snapshot.** Use the latest automated snapshot:
+
+```bash
+SNAPSHOT=$(aws rds describe-db-snapshots \
+  --db-instance-identifier catalogue-prod \
+  --query 'reverse(sort_by(DBSnapshots,&SnapshotCreateTime))[0].DBSnapshotIdentifier' \
+  --output text)
+echo "Using snapshot: $SNAPSHOT"
+```
+
+For up-to-the-minute data, take a fresh one first instead:
+
+```bash
+aws rds create-db-snapshot --db-instance-identifier catalogue-prod \
+  --db-snapshot-identifier "$TEMP_ID"
+aws rds wait db-snapshot-available --db-snapshot-identifier "$TEMP_ID"
+SNAPSHOT=$TEMP_ID
+```
+
+**2. Create a throwaway security group open to your IP only:**
+
+```bash
+MYIP=$(curl -s https://checkip.amazonaws.com)
+SG=$(aws ec2 create-security-group \
+  --group-name "$TEMP_ID-sg" \
+  --description "Temp RDS restore access" \
+  --vpc-id "$VPC" --query GroupId --output text)
+aws ec2 authorize-security-group-ingress \
+  --group-id "$SG" --protocol tcp --port 5432 --cidr "${MYIP}/32"
+```
+
+**3. Restore the snapshot to a temporary public instance:**
+
+```bash
+aws rds restore-db-instance-from-db-snapshot \
+  --db-instance-identifier "$TEMP_ID" \
+  --db-snapshot-identifier "$SNAPSHOT" \
+  --db-subnet-group-name "$SUBNET_GROUP" \
+  --vpc-security-group-ids "$SG" \
+  --db-instance-class db.t4g.micro \
+  --publicly-accessible --no-multi-az
+
+aws rds wait db-instance-available --db-instance-identifier "$TEMP_ID"
+ENDPOINT=$(aws rds describe-db-instances --db-instance-identifier "$TEMP_ID" \
+  --query 'DBInstances[0].Endpoint.Address' --output text)
+```
+
+The restored instance keeps prod's master credentials. Reuse them from Secrets
+Manager, swapping the host for the temp endpoint:
+
+```bash
+PROD_URL=$(aws secretsmanager get-secret-value \
+  --secret-id catalogue-prod/DATABASE_URL \
+  --query SecretString --output text)
+# Replace the host:port between '@' and '/dbname' with the temp endpoint.
+# (If the secret is JSON rather than a bare URL, extract the field first.)
+TEMP_URL=$(echo "$PROD_URL" | sed -E "s#@[^/]+/#@${ENDPOINT}:5432/#")
+```
+
+**4. Dump locally:**
+
+```bash
+pg_dump "$TEMP_URL" \
+  --no-owner --no-privileges \
+  --format=custom \
+  --file=prod_$(date +%Y%m%d).dump
+```
+
+`--format=custom` produces a compressed dump for `pg_restore`; `--no-owner
+--no-privileges` strips prod's roles, which don't exist elsewhere.
+
+**5. Restore into local Docker (optional):**
+
+```bash
+pg_restore \
+  --no-owner --no-privileges \
+  --clean --if-exists \
+  --single-transaction \
+  -d postgresql://catalogue:catalogue@localhost:5432/catalogue \
+  prod_$(date +%Y%m%d).dump
+```
+
+`--clean --if-exists` drops and recreates objects so you can re-run over an
+existing local DB; `--single-transaction` makes the restore all-or-nothing.
+
+**6. Tear down the temp resources** — don't skip this; it's a publicly-reachable
+copy of prod data:
+
+```bash
+aws rds delete-db-instance --db-instance-identifier "$TEMP_ID" --skip-final-snapshot
+aws rds wait db-instance-deleted --db-instance-identifier "$TEMP_ID"
+aws ec2 delete-security-group --group-id "$SG"
+# If you took a manual snapshot in step 1, delete it too:
+# aws rds delete-db-snapshot --db-snapshot-identifier "$TEMP_ID"
+```
+
+> Automatic snapshots are also visible in the AWS console under RDS →
+> Snapshots and can be restored to a new instance there without the CLI — the
+> same approach, just click-driven.

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -573,3 +573,6 @@ aws ec2 delete-security-group --group-id "$SG"
 > Automatic snapshots are also visible in the AWS console under RDS →
 > Snapshots and can be restored to a new instance there without the CLI — the
 > same approach, just click-driven.
+
+> To tear the **whole** production stack down between exhibitions (not just
+> dump the database), see [`mothball-and-restore.md`](mothball-and-restore.md).

--- a/docs/mothball-and-restore.md
+++ b/docs/mothball-and-restore.md
@@ -1,0 +1,125 @@
+# Mothball & Restore — Production
+
+This tool is used for a couple of weeks a year. The rest of the time the
+production stack can be torn down to near-zero cost and rebuilt intact when the
+next exhibition comes round. This is the runbook; the two scripts
+(`.aws/mothball-prod.sh`, `.aws/restore-prod.sh`) automate it.
+
+- **Region / account:** `eu-north-1` / `028597908565`
+- **Related:** [`staging-rebuild-checklist.md`](staging-rebuild-checklist.md) (staging
+  was torn down in April 2026 the same way), [`.aws/setup-infrastructure.sh`](../.aws/setup-infrastructure.sh)
+  (the original full build).
+
+## What costs money, and what doesn't
+
+No NAT gateways, so the only year-round costs are three resources:
+
+| Resource | ~Monthly | Mothball action |
+|---|---|---|
+| ALB `catalogue-alb` | ~£15–18 | Delete → recreate on restore |
+| Fargate task (256/512, desired=1) | ~£8–10 | Delete service |
+| RDS `catalogue-prod` (t4g.micro, 20 GB) | ~£13 | Final snapshot → delete |
+| **Running total** | **~£40/mo (~£480/yr)** | |
+
+Everything that holds **state** is cheap or free and is **left in place**, which
+is what makes the restore lossless:
+
+- **S3** `ra-catalogue-prod-028597908565` — uploaded files + versioning (pennies)
+- **The final RDS snapshot** — this *is* the database, frozen (cents/mo)
+- **Cognito user pool** — free under 50k monthly users, so every account survives
+- **Secrets Manager** `catalogue-prod/{DATABASE_URL,API_KEY,S3_BUCKET}` (~£1/mo)
+- **ECR image, IAM roles, security groups, subnet group, CloudWatch log group** — free
+
+**Mothballed cost: ~£1.50–2/mo (~£20/yr).** Saving ≈ **£460/yr**.
+
+## The two wrinkles (already handled by the scripts)
+
+1. **RDS comes back from a snapshot, not a fresh create.** `setup-infrastructure.sh`
+   would create an *empty* DB with a *new* password. `restore-prod.sh` instead
+   restores the snapshot (data + original password intact) and then repoints the
+   retained `DATABASE_URL` secret at the new endpoint hostname (the
+   `…cjc8si80mtkh…` token is per-instance and changes each rebuild).
+2. **The ALB URL changes** on each rebuild (new `catalogue-alb-NNN….elb.amazonaws.com`).
+   There's no Route53 zone, so just note the new URL printed at the end of
+   `restore-prod.sh` and re-share it. (If you ever want a stable URL, add a
+   ~£0.40/mo hosted zone with an alias to the ALB and re-point it on restore.)
+
+## Mothball (end of season)
+
+From the project root:
+
+```bash
+./.aws/mothball-prod.sh
+```
+
+It will:
+1. Take a snapshot `catalogue-prod-mothball-YYYYMMDD` and **wait until it is
+   `available`** — if the snapshot fails, it aborts *before* deleting anything.
+2. Delete the ECS service (cluster + task definitions kept).
+3. Delete the ALB, then its target group.
+4. Delete the RDS instance (`--skip-final-snapshot`, because step 1 already made one).
+
+**Record the snapshot id** it prints — that's all `restore-prod.sh` needs (it can
+also auto-detect the newest one). Then optionally check for orphaned Elastic IPs
+(unattached ones bill ~£3/mo each):
+
+```bash
+aws ec2 describe-addresses --region eu-north-1 \
+  --query 'Addresses[?AssociationId==`null`].PublicIp'
+```
+
+## Restore (a day before the next exhibition)
+
+From the project root:
+
+```bash
+./.aws/restore-prod.sh                       # uses newest mothball snapshot
+# or pin one explicitly:
+./.aws/restore-prod.sh catalogue-prod-mothball-20260801
+```
+
+It will:
+1. Restore RDS from the snapshot and wait until available.
+2. Repoint `catalogue-prod/DATABASE_URL` at the new endpoint.
+3. Re-register the prod task definition (image `…/catalogue-app:latest` from ECR).
+4. Recreate the ALB, target group, and HTTP:80 listener.
+5. Create the ECS service (desired=1) wired to the target group.
+
+It prints the new app URL. Give it a few minutes to pass health checks. The app
+runs Alembic migrations on boot, which is a no-op against the restored data.
+
+**Before restoring, confirm an image exists in ECR** (it normally persists):
+
+```bash
+aws ecr describe-images --repository-name catalogue-app \
+  --image-ids imageTag=latest --region eu-north-1 >/dev/null && echo "image OK"
+```
+
+If it's gone, push one first via the normal CI/deploy path.
+
+## Verify after restore
+
+```bash
+# Task healthy and stable?
+aws ecs describe-services --cluster catalogue --services catalogue-prod \
+  --query 'services[0].{running:runningCount,desired:desiredCount}' --region eu-north-1
+# Target healthy in the ALB?
+aws elbv2 describe-target-health \
+  --target-group-arn "$(aws elbv2 describe-target-groups --names catalogue-prod-tg \
+     --query 'TargetGroups[0].TargetGroupArn' --output text --region eu-north-1)" \
+  --region eu-north-1 --query 'TargetHealthDescriptions[].TargetHealth.State'
+```
+
+Then open the printed URL and log in — Cognito accounts and all data should be
+exactly as they were.
+
+## Safety notes
+
+- The mothball script is **snapshot-first, verify, then delete** — it will not
+  delete the database without a confirmed-available snapshot.
+- S3 data and Cognito users are never touched by either script.
+- Both scripts are re-runnable: existing resources are detected and skipped.
+- Manual snapshots persist until explicitly deleted (unlike the 7-day automated
+  ones), so a mothball snapshot is safe to leave for the full off-season. Delete
+  old ones once a season is successfully restored:
+  `aws rds delete-db-snapshot --db-snapshot-identifier <id>`.

--- a/docs/staging-rebuild-checklist.md
+++ b/docs/staging-rebuild-checklist.md
@@ -2,6 +2,11 @@
 
 If staging needs to be recreated, here's what existed and how to rebuild it.
 
+> **See also:** [`mothball-and-restore.md`](mothball-and-restore.md) — production
+> uses the same teardown/rebuild pattern (snapshot the DB, delete the
+> cost-incurring resources, rebuild from the snapshot), but scripted end-to-end
+> for the seasonal mothball cycle.
+
 ## Region / Account
 - **Region**: eu-north-1
 - **Account**: 028597908565


### PR DESCRIPTION
## What & why

The catalogue tool is used for only a couple of weeks a year (RA Summer
Exhibition *List of Works* production). The rest of the year the production AWS
stack can be torn down to near-zero cost and rebuilt intact for the next
exhibition. This branch adds the tooling to do that safely.

## What's here

- **`.aws/mothball-prod.sh`** — snapshot-first, *verify*, then delete. Takes a
  final RDS snapshot and waits until it is `available` (aborts before deleting
  anything if the snapshot fails), then deletes the ECS service, the ALB + target
  group, and the RDS instance.
- **`.aws/restore-prod.sh`** — restores RDS from the snapshot, repoints the
  `DATABASE_URL` secret at the new endpoint, re-registers the prod task
  definition (`catalogue-app:latest`), recreates the ALB / target group / HTTP
  listener, and creates the ECS service.
- **`docs/mothball-and-restore.md`** — the runbook.
- Also rewrites the broken "Database backup (production)" section in
  `docs/dev-guide.md` (the old version piped `pg_dump` through
  `aws ecs execute-command`, which can't work — no `pg_dump` in the image and the
  PTY corrupts binary dumps) and adds doc cross-references.

## Economics

| State | Cost |
|---|---|
| Running | ≈ £40/mo (~£480/yr) — ALB ~£15–18, Fargate ~£8–10, RDS t4g.micro ~£13 |
| Mothballed | ≈ £20/yr |

State that persists untouched, making the restore lossless: S3 uploads, the
final RDS snapshot, Cognito users, Secrets Manager entries, the ECR image,
IAM roles / security groups / subnet group / log group.

## Status & caveats

- **Untested against live AWS.** Scripts are `bash -n` syntax-checked and built
  from verified resource names, but have not been run for real yet. Planned
  sequence: dry run → full down-and-up test → real mothball.
- Two baked-in assumptions: (a) the retained `DATABASE_URL` secret password
  matches the snapshot — holds unless the DB password is rotated between snapshot
  and teardown; (b) a `:latest` image persists in ECR at restore time
  (`restore-prod.sh` warns if it is missing).
