### PR TITLE
Harden mothball/restore against silent failure modes

### DIFF
--- a/.aws/mothball-prod.sh
+++ b/.aws/mothball-prod.sh
@@ -21,7 +21,11 @@
 set -euo pipefail
 
 REGION="eu-north-1"
-SNAPSHOT_ID="catalogue-prod-mothball-$(date +%Y%m%d)"
+# Timestamp to the second so every run gets a unique snapshot id. A date-only id
+# could collide with a pre-existing (possibly stale) same-day snapshot, which the
+# old reuse-if-exists branch would then have accepted as the "final" backup
+# before deleting the DB with --skip-final-snapshot — silent data loss.
+SNAPSHOT_ID="catalogue-prod-mothball-$(date +%Y%m%d-%H%M%S)"
 export AWS_PAGER=""
 
 echo "============================================"
@@ -43,15 +47,13 @@ echo ">>> 1/4  Snapshotting RDS catalogue-prod -> $SNAPSHOT_ID ..."
 if aws rds describe-db-instances --db-instance-identifier catalogue-prod \
         --region "$REGION" >/dev/null 2>&1; then
 
-    if aws rds describe-db-snapshots --db-snapshot-identifier "$SNAPSHOT_ID" \
-            --region "$REGION" >/dev/null 2>&1; then
-        echo "    (snapshot $SNAPSHOT_ID already exists — reusing)"
-    else
-        aws rds create-db-snapshot \
-            --db-instance-identifier catalogue-prod \
-            --db-snapshot-identifier "$SNAPSHOT_ID" \
-            --region "$REGION" --no-cli-pager >/dev/null
-    fi
+    # The id is unique per run (see above), so always take a fresh snapshot of
+    # the live data. If the id somehow already existed, create fails and set -e
+    # aborts here — before any deletion.
+    aws rds create-db-snapshot \
+        --db-instance-identifier catalogue-prod \
+        --db-snapshot-identifier "$SNAPSHOT_ID" \
+        --region "$REGION" --no-cli-pager >/dev/null
 
     echo "    Waiting for snapshot to complete (5-10 min)..."
     aws rds wait db-snapshot-available \
@@ -118,12 +120,21 @@ echo ""
 # 4. Delete the RDS instance (the snapshot from step 1 is what we keep)
 # --------------------------------------------------------------------------
 echo ">>> 4/4  Deleting RDS instance catalogue-prod ..."
-aws rds delete-db-instance \
-    --db-instance-identifier catalogue-prod \
-    --skip-final-snapshot \
-    --region "$REGION" --no-cli-pager >/dev/null 2>&1 \
-    && echo "    ✓ Deletion initiated (runs in the background, a few minutes)." \
-    || echo "    (instance already gone)"
+if aws rds describe-db-instances --db-instance-identifier catalogue-prod \
+        --region "$REGION" >/dev/null 2>&1; then
+    # Only report "already gone" when it genuinely isn't there. A real failure
+    # (deletion protection, incompatible state) must NOT be masked as success —
+    # otherwise the instance keeps billing while the banner claims it's mothballed.
+    aws rds delete-db-instance \
+        --db-instance-identifier catalogue-prod \
+        --skip-final-snapshot \
+        --region "$REGION" --no-cli-pager >/dev/null \
+        && echo "    ✓ Deletion initiated (runs in the background, a few minutes)." \
+        || { echo "    ERROR: delete-db-instance failed (deletion protection? instance state?)."; \
+             echo "    Snapshot $SNAPSHOT_ID is safe; investigate, then re-run."; exit 1; }
+else
+    echo "    (instance already gone)"
+fi
 echo ""
 
 echo "============================================"

--- a/.aws/restore-prod.sh
+++ b/.aws/restore-prod.sh
@@ -77,7 +77,14 @@ RDS_SG=$(sg catalogue-rds-sg)
 echo ">>> 1/5  Restoring RDS catalogue-prod from $SNAPSHOT_ID ..."
 if aws rds describe-db-instances --db-instance-identifier catalogue-prod \
         --region "$REGION" >/dev/null 2>&1; then
-    echo "    (catalogue-prod already exists — skipping restore)"
+    # Reusing an existing instance — flag it loudly with its create time so a
+    # leftover from an interrupted/earlier restore isn't silently adopted as
+    # though it were the snapshot we were asked to restore.
+    EXISTING_CREATED=$(aws rds describe-db-instances --db-instance-identifier catalogue-prod \
+        --query 'DBInstances[0].InstanceCreateTime' --output text --region "$REGION" 2>/dev/null || echo "unknown")
+    echo "    ⚠  catalogue-prod already exists (created $EXISTING_CREATED) — skipping restore."
+    echo "       If that's a leftover rather than the DB you want, delete it and re-run"
+    echo "       to restore from $SNAPSHOT_ID."
 else
     aws rds restore-db-instance-from-db-snapshot \
         --db-instance-identifier catalogue-prod \
@@ -105,6 +112,16 @@ echo ">>> 2/5  Updating catalogue-prod/DATABASE_URL endpoint ..."
 OLD_URL=$(aws secretsmanager get-secret-value --secret-id catalogue-prod/DATABASE_URL \
     --query SecretString --output text --region "$REGION")
 NEW_URL=$(echo "$OLD_URL" | sed -E "s#@[^/]+/#@${RDS_ENDPOINT}:5432/#")
+# Guard: only write a value that actually points at the new host. If the secret's
+# URL shape didn't match the sed (so the dead endpoint would survive), stop rather
+# than silently persist a broken DATABASE_URL. (Passes idempotent re-runs, where
+# the secret already contains the current endpoint.)
+case "$NEW_URL" in
+    *"@${RDS_ENDPOINT}:5432/"*) : ;;
+    *) echo "    ERROR: DATABASE_URL rewrite did not produce the new endpoint ($RDS_ENDPOINT)."
+       echo "    Refusing to write a possibly-broken secret — fix it manually and re-run."
+       exit 1 ;;
+esac
 aws secretsmanager put-secret-value --secret-id catalogue-prod/DATABASE_URL \
     --secret-string "$NEW_URL" --region "$REGION" --no-cli-pager >/dev/null
 echo "    ✓ Secret repointed."

--- a/docs/mothball-and-restore.md
+++ b/docs/mothball-and-restore.md
@@ -53,7 +53,8 @@ From the project root:
 ```
 
 It will:
-1. Take a snapshot `catalogue-prod-mothball-YYYYMMDD` and **wait until it is
+1. Take a snapshot `catalogue-prod-mothball-YYYYMMDD-HHMMSS` (timestamped per run,
+   so a re-run never reuses a stale earlier snapshot) and **wait until it is
    `available`** — if the snapshot fails, it aborts *before* deleting anything.
 2. Delete the ECS service (cluster + task definitions kept).
 3. Delete the ALB, then its target group.
@@ -75,7 +76,7 @@ From the project root:
 ```bash
 ./.aws/restore-prod.sh                       # uses newest mothball snapshot
 # or pin one explicitly:
-./.aws/restore-prod.sh catalogue-prod-mothball-20260801
+./.aws/restore-prod.sh catalogue-prod-mothball-20260801-031500
 ```
 
 It will:


### PR DESCRIPTION
Follow-up to #121. A pre-dry-run code review of the mothball/restore scripts
surfaced four ways they could fail **silently** against live production. This
PR fixes them. Targets the `mothball-and-restore-procedure` branch so the diff
stays fixes-only and stacks on #121.

## Fixes

**1. 🔴 Data-loss footgun — date-only snapshot id could reuse a stale snapshot**
`mothball-prod.sh` used `catalogue-prod-mothball-$(date +%Y%m%d)` and a
reuse-if-exists branch. Run twice in a day (the plan does: dry run → down-and-up
→ real) and the second run would silently reuse the first snapshot, then delete
the DB with `--skip-final-snapshot` — losing any writes since. Now the id is
timestamped to the second and the script always takes a fresh snapshot.

**2. 🟠 Silent broken restore — DATABASE_URL rewrite unguarded**
`restore-prod.sh` rewrites the secret's host with `sed`. If the URL shape didn't
match, the substitution was a no-op and the **old/dead** endpoint got written
back silently. Added a guard that refuses to write a value that doesn't contain
the new endpoint. (Passes idempotent re-runs.)

**3. 🟡 Restore silently reuses a leftover instance**
If a `catalogue-prod` instance already existed, restore skipped silently. Now it
warns with the instance's create time so a leftover from an interrupted run isn't
mistaken for the intended DB.

**4. 🟡 Masked teardown failure**
`delete-db-instance` failures (e.g. deletion protection) were swallowed and
reported as "(already gone)" while the banner claimed success — the instance
would keep billing. Now existence is checked first and a real failure exits 1.

Plus a docs sync of the runbook's snapshot-id examples.

## Checked and cleared (not changed)
- ALB/TG create-or-describe fallback aborts via `set -e` rather than propagating
  a garbage ARN.
- Subnet AZ selection is nondeterministic but any 2 of 3 default subnets work
  (parity with the original build).
- ECS health-check grace period is omitted in both restore and the original
  setup (parity); the task def's container `healthCheck` has `startPeriod: 120`.

## Verification
`bash -n` passes on both scripts. Not yet run against live AWS — that's the
upcoming dry run.
